### PR TITLE
Keep component's state when viewport is undefined [ModelsTree]

### DIFF
--- a/common/changes/@bentley/tree-widget-react/master_2021-11-15-14-50.json
+++ b/common/changes/@bentley/tree-widget-react/master_2021-11-15-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Fix an issue where ModelsTree Component could lose its state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react"
+}

--- a/packages/tree-widget/src/components/trees/ModelsTree.tsx
+++ b/packages/tree-widget/src/components/trees/ModelsTree.tsx
@@ -49,7 +49,7 @@ export const ModelsTreeComponent = (props: ModelTreeProps) => {
   const [available3dModels, setAvailable3dModels] = useState([] as string[]);
   const [availableModels, setAvailableModels] = useState([] as string[]);
   const [viewport, setViewport] = useState<ScreenViewport | undefined>(
-    undefined
+    IModelApp.viewManager.selectedView
   );
 
   const {
@@ -84,7 +84,6 @@ export const ModelsTreeComponent = (props: ModelTreeProps) => {
   };
 
   useEffect(() => {
-    setViewport(IModelApp.viewManager.selectedView);
     IModelApp.viewManager.onSelectedViewportChanged.addListener(
       _handleSelectedViewportChanged
     );
@@ -93,7 +92,7 @@ export const ModelsTreeComponent = (props: ModelTreeProps) => {
         _handleSelectedViewportChanged
       );
     };
-  }, [IModelApp.viewManager.selectedView]);
+  }, []);
 
   useEffect(() => {
     queryModels(viewport)


### PR DESCRIPTION
Fix for an issue where ModelsTree component can lose its state when `selectedView` property spuriously changes to undefined (Happens with `ContentLayoutManager` from `@bentley/ui-framework` and `CivilReviewTools` from `@bentley/civil-reviewtools-frontend`). By "losing the state", I mean, tree nodes in `ControlledTree` reset (for example, expanded/not expanded property).