### PR TITLE
Fix: info button not appearing in property grid when selecting multiple elements 

### DIFF
--- a/common/changes/@bentley/property-grid-react/fix-property-grid-multiselect_2021-12-09-17-48.json
+++ b/common/changes/@bentley/property-grid-react/fix-property-grid-multiselect_2021-12-09-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/property-grid-react",
+      "comment": "Fix for info button not appearing when multiple elements are selected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/property-grid-react"
+}

--- a/packages/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -110,6 +110,7 @@ export const MultiElementPropertyGrid = (props: Partial<PropertyGridProps>) => {
     };
 
     Presentation.selection.selectionChange.addListener(onSelectionChange);
+    onSelectionChange();
     return () => {
       Presentation.selection.selectionChange.removeListener(onSelectionChange);
     };


### PR DESCRIPTION
Problem was that the function that figures out if there's multiple elements selected is registered as a listen event, but that event isn't triggered during the initial opening of the widget (i.e. if you select multiple elements which opens the property grid widget, vs having the widget already opened and selecting multiple elements as a new selection). 

Adding a direct call to the onSelectionChange function after registering the event listener ensures it's still called when the widget is first opened.