### PR TITLE
Fix "Hide All" button blocked by search bar

### DIFF
--- a/common/changes/@bentley/tree-widget-react/fixhideallbuttonblocked_2022-01-07-11-55.json
+++ b/common/changes/@bentley/tree-widget-react/fixhideallbuttonblocked_2022-01-07-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Fix hide all button blocked by search bar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react"
+}

--- a/packages/tree-widget/src/components/search-bar/SearchBar.scss
+++ b/packages/tree-widget/src/components/search-bar/SearchBar.scss
@@ -69,7 +69,7 @@
       float: right;
       margin-right: 0;
       box-sizing: border-box;
-      width: 20px;
+      width: 0px;
       visibility: hidden;
       opacity: 0;
       overflow: hidden;


### PR DESCRIPTION
The search bar was blocking the "Hide All" button when the search bar was closed and you could not click on about 70% of the "Hide All" button from the left side.