### PR TITLE
Fix so that the ZoneLocation is checked for UI 1.0

### DIFF
--- a/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
@@ -6,6 +6,7 @@ import type {
   AbstractWidgetProps,
   UiItemsProvider} from "@itwin/appui-abstract";
 import {
+  AbstractZoneLocation,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
@@ -21,13 +22,15 @@ export class GroupingMappingProvider implements UiItemsProvider {
     _stageId: string,
     stageUsage: string,
     location: StagePanelLocation,
-    section?: StagePanelSection
+    section?: StagePanelSection,
+    zonelocation?: AbstractZoneLocation,
   ): ReadonlyArray<AbstractWidgetProps> {
     const widgets: AbstractWidgetProps[] = [];
     if (
-      location === StagePanelLocation.Left &&
+      ( location === StagePanelLocation.Left &&
       section === StagePanelSection.Start &&
-      stageUsage === StageUsage.General
+      stageUsage === StageUsage.General ) ||
+      zoneLocation === AbstractZoneLocation.CenterLeft 
     ) {
       const GroupingMappingWidget: AbstractWidgetProps = {
         id: "GroupingMappingWidget",


### PR DESCRIPTION
Currently there is an issue for this component in UI 1.0 where the Widgets won't show up.  This is because the ZoneLocation is not being checked by provideWidgets.