### PR TITLE
Fix for GroupingMatchingWidget when used in UI 1.0 applications

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/Fix-for-grouping-mapping-Ui-1.0_2022-02-04-22-07.json
+++ b/common/changes/@itwin/grouping-mapping-widget/Fix-for-grouping-mapping-Ui-1.0_2022-02-04-22-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/grouping-mapping-widget",
-      "comment": "This PR adds a check for AbstractZoneLocation.CenterLeft (4) so that the widget will be returned when called by UiItemsProviders in UI 1.0 contexts. This does not affect UI 2.0 usAdds es.",
+      "comment": "This adds a check for AbstractZoneLocation.CenterLeft (4) in GroupinngMappingWidget so that the widget will be returned when called by UiItemsProviders in UI 1.0 contexts. This does not affect UI 2.0 uses.",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/grouping-mapping-widget/Fix-for-grouping-mapping-Ui-1.0_2022-02-04-22-07.json
+++ b/common/changes/@itwin/grouping-mapping-widget/Fix-for-grouping-mapping-Ui-1.0_2022-02-04-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "This PR adds a check for AbstractZoneLocation.CenterLeft (4) so that the widget will be returned when called by UiItemsProviders in UI 1.0 contexts. This does not affect UI 2.0 usAdds es.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
@@ -6,7 +6,7 @@ import type {
   AbstractWidgetProps,
   UiItemsProvider} from "@itwin/appui-abstract";
 import {
-  AbstractZoneLocation
+  AbstractZoneLocation,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,

--- a/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/GroupingMappingWidget.tsx
@@ -6,6 +6,7 @@ import type {
   AbstractWidgetProps,
   UiItemsProvider} from "@itwin/appui-abstract";
 import {
+  AbstractZoneLocation
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
@@ -21,13 +22,15 @@ export class GroupingMappingProvider implements UiItemsProvider {
     _stageId: string,
     stageUsage: string,
     location: StagePanelLocation,
-    section?: StagePanelSection
+    section?: StagePanelSection,
+    zonelocation?: AbstractZoneLocation
   ): ReadonlyArray<AbstractWidgetProps> {
     const widgets: AbstractWidgetProps[] = [];
     if (
-      location === StagePanelLocation.Left &&
+      (location === StagePanelLocation.Left &&
       section === StagePanelSection.Start &&
-      stageUsage === StageUsage.General
+      stageUsage === StageUsage.General) ||
+      zonelocation === AbstractZoneLocation.CenterLeft
     ) {
       const GroupingMappingWidget: AbstractWidgetProps = {
         id: "GroupingMappingWidget",


### PR DESCRIPTION
The Grouping Mapping Widget is not working in UI 1.0 contexts because of a defect where it is not checking for the zoneLocation and so does not return the widget to UI 1.0 when provideWidgets is called.

This PR adds a check for AbstractZoneLocation.CenterLeft (4) so that the widget will be returned when called by UiItemsProviders in UI 1.0 contexts.  This does not affect UI 2.0 uses.