### PR TITLE
[Grouping&Mapping] More styling fixes and loading spinners enhancements

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/group-by-styling-fixes_2022-03-10-01-48.json
+++ b/common/changes/@itwin/grouping-mapping-widget/group-by-styling-fixes_2022-03-10-01-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/grouping-mapping-widget",
-      "comment": "Fixed overlapping seperator in group by selection pane",
+      "comment": "Fixed overlapping seperator in group by selection pane and polished loading spinners",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/grouping-mapping-widget/group-by-styling-fixes_2022-03-10-01-48.json
+++ b/common/changes/@itwin/grouping-mapping-widget/group-by-styling-fixes_2022-03-10-01-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Fixed overlapping seperator in group by selection pane",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/ActionPanel.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/ActionPanel.tsx
@@ -5,6 +5,7 @@
 import { Button } from "@itwin/itwinui-react";
 import * as React from "react";
 import "./ActionPanel.scss";
+import { LoadingSpinner } from "./utils";
 
 export interface ActionPanelProps {
   onSave: () => void;
@@ -22,6 +23,9 @@ const ActionPanel = ({
   return (
     <div id='action' className='action-panel-container'>
       <div className='action-panel'>
+        {isLoading &&
+          <LoadingSpinner />
+        }
         <Button
           disabled={disabled || isLoading}
           styleType='high-visibility'
@@ -35,7 +39,7 @@ const ActionPanel = ({
           type='button'
           id='cancel'
           onClick={onCancel}
-          disabled={isLoading}
+          disabled={disabled || isLoading}
         >
           Cancel
         </Button>

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.scss
@@ -2,6 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@import '~@itwin/itwinui-css/scss/variables';
+
 .delete-modal-body-text {
   display: flex;
   gap: 4px;
@@ -9,4 +11,8 @@
   > strong {
     min-width: 0px;
   }
+}
+
+.loading-delete {
+  margin-right: $iui-s;
 }

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
@@ -4,12 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 import {
   Button,
-  IconButton,
   Leading,
   MiddleTextTruncation,
   Modal,
-  ModalButtonBar,
-  ProgressRadial,
+  ModalButtonBar
 } from "@itwin/itwinui-react";
 import React, { useState } from "react";
 import "./DeleteModal.scss";

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
@@ -13,7 +13,7 @@ import {
 } from "@itwin/itwinui-react";
 import React, { useState } from "react";
 import "./DeleteModal.scss";
-import { handleError } from "./utils";
+import { handleError, LoadingSpinner } from "./utils";
 
 export interface DeleteModalProps {
   entityName: string;
@@ -65,15 +65,13 @@ export const DeleteModal = ({
           </strong>
         </div>
         <ModalButtonBar>
-          {isLoading ? (
-            <IconButton styleType='high-visibility'>
-              <ProgressRadial size="small" indeterminate />
-            </IconButton>
-          ) : (
-            <Button styleType='high-visibility' onClick={deleteCallback}>
-              Delete
-            </Button>
-          )}
+          {isLoading &&
+            <div className="loading-delete">
+              <LoadingSpinner />
+            </div>}
+          <Button styleType='high-visibility' onClick={deleteCallback} disabled={isLoading}>
+            Delete
+          </Button>
           <Button
             styleType='default'
             onClick={() => {

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/DeleteModal.tsx
@@ -7,7 +7,7 @@ import {
   Leading,
   MiddleTextTruncation,
   Modal,
-  ModalButtonBar
+  ModalButtonBar,
 } from "@itwin/itwinui-react";
 import React, { useState } from "react";
 import "./DeleteModal.scss";

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupAction.tsx
@@ -52,6 +52,7 @@ const GroupAction = ({
   const [simpleQuery, setSimpleQuery] = useState<string>("");
   const [validator, showValidationMessage] = useValidator();
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isRendering, setIsRendering] = useState<boolean>(false);
   const [currentPropertyList, setCurrentPropertyList] = React.useState<
   PropertyRecord[]
   >([]);
@@ -98,7 +99,7 @@ const GroupAction = ({
           return;
         }
 
-        setIsLoading(true);
+        setIsRendering(true);
         const ids = await fetchIdsFromQuery(query ?? "", iModelConnection);
         const resolvedHiliteIds = await visualizeElementsById(
           ids,
@@ -109,7 +110,7 @@ const GroupAction = ({
       } catch {
         toaster.negative("Sorry, we have failed to generate a valid query. 😔");
       } finally {
-        setIsLoading(false);
+        setIsRendering(false);
       }
     };
 
@@ -304,6 +305,7 @@ const GroupAction = ({
               defaultChecked
               value={"Selection"}
               label={"Selection"}
+              disabled={isLoading || isRendering}
             />
             <RadioTile
               icon={<SvgSearch />}
@@ -311,6 +313,7 @@ const GroupAction = ({
               onChange={changeGroupByType}
               value={"Query Keywords"}
               label={"Query Keywords"}
+              disabled={isLoading || isRendering}
             />
           </RadioTileGroup>
           {groupByType === "Selection" ?
@@ -322,6 +325,8 @@ const GroupAction = ({
                 setQuery,
                 queryBuilder,
                 setQueryBuilder,
+                isLoading,
+                isRendering,
               }}
             >
               <GroupQueryBuilderContainer />
@@ -333,14 +338,14 @@ const GroupAction = ({
                 required
                 value={searchInput}
                 onChange={(event) => setSearchInput(event.target.value)}
-                disabled={isLoading}
+                disabled={isLoading || isRendering}
                 placeholder={`ex: wall curtain "panel" facade`} />
               <div className="search-actions">
-                {isLoading &&
+                {isRendering &&
                   <LoadingSpinner />
                 }
-                <Button disabled={isLoading} onClick={() => generateSearchQuery(searchInput ? searchInput.split(" ") : [])}>Apply</Button>
-                <Button disabled={isLoading} onClick={() => {
+                <Button disabled={isLoading || isRendering} onClick={() => generateSearchQuery(searchInput ? searchInput.split(" ") : [])}>Apply</Button>
+                <Button disabled={isLoading || isRendering} onClick={() => {
                   setQuery("");
                   setSearchInput("");
                 }}>Clear</Button>
@@ -361,7 +366,7 @@ const GroupAction = ({
           await goBack();
         }}
         disabled={
-          !(details.groupName && details.description && (query || simpleQuery))
+          !(details.groupName && details.description && (query || simpleQuery) && !isRendering && !isLoading)
         }
         isLoading={isLoading}
       />

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupQueryBuilderContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupQueryBuilderContext.ts
@@ -15,6 +15,8 @@ export interface PropertySelection {
   setQuery: React.Dispatch<React.SetStateAction<string>>;
   queryBuilder: QueryBuilder;
   setQueryBuilder: React.Dispatch<React.SetStateAction<QueryBuilder>>;
+  isLoading: boolean;
+  isRendering: boolean;
 }
 export const GroupQueryBuilderContext = React.createContext<PropertySelection>({
   currentPropertyList: [],
@@ -23,4 +25,6 @@ export const GroupQueryBuilderContext = React.createContext<PropertySelection>({
   setQuery: () => "",
   queryBuilder: new QueryBuilder(undefined),
   setQueryBuilder: () => new QueryBuilder(undefined),
+  isLoading: false,
+  isRendering: false,
 });

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -36,14 +36,6 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
   public override render() {
     const { indentation, highlight, ...props } = this.props;
     const displayLabel = this.props.propertyRecord.property.displayLabel;
-    const offset = CommonPropertyRenderer.getLabelOffset(
-      indentation,
-      props.orientation,
-      props.width,
-      props.columnRatio,
-      props.columnInfo?.minLabelWidth,
-    );
-
     const activeMatchIndex =
       this.props.propertyRecord.property.name ===
         highlight?.activeHighlight?.highlightedItemIdentifier
@@ -63,7 +55,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
         labelElement={
           <PrimitivePropertyLabelRenderer
             // Added label offset to account for checkbox
-            offset={offset + 24}
+            offset={24}
             renderColon={this.props.orientation === Orientation.Horizontal}
             tooltip={displayLabel}
           >

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -6,7 +6,6 @@ import * as React from "react";
 import { Orientation } from "@itwin/core-react";
 import { PrimitivePropertyLabelRenderer } from "@itwin/components-react";
 import type { HighlightingComponentProps } from "@itwin/components-react/lib/cjs/components-react/common/HighlightingComponentProps";
-import { CommonPropertyRenderer } from "@itwin/components-react/lib/cjs/components-react/properties/renderers/CommonPropertyRenderer";
 import { HighlightedText } from "@itwin/components-react/lib/cjs/components-react/common/HighlightedText";
 
 import { PropertyView } from "./PropertyView";

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -62,6 +62,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
         {...props}
         labelElement={
           <PrimitivePropertyLabelRenderer
+            // Added label offset to account for checkbox
             offset={offset + 24}
             renderColon={this.props.orientation === Orientation.Horizontal}
             tooltip={displayLabel}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -46,7 +46,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
 
     const activeMatchIndex =
       this.props.propertyRecord.property.name ===
-      highlight?.activeHighlight?.highlightedItemIdentifier
+        highlight?.activeHighlight?.highlightedItemIdentifier
         ? highlight.activeHighlight.highlightIndex
         : undefined;
     const label = highlight
@@ -62,7 +62,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
         {...props}
         labelElement={
           <PrimitivePropertyLabelRenderer
-            offset={offset}
+            offset={offset + 24}
             renderColon={this.props.orientation === Orientation.Horizontal}
             tooltip={displayLabel}
           >

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -33,7 +33,7 @@ export interface PrimitiveRendererProps extends SharedRendererProps {
 export class PrimitivePropertyRenderer extends React.Component<PrimitiveRendererProps> {
   /** @internal */
   public override render() {
-    const { indentation, highlight, ...props } = this.props;
+    const { highlight, ...props } = this.props;
     const displayLabel = this.props.propertyRecord.property.displayLabel;
     // TODO Refactor this to consider checkbox.
     // const offset = CommonPropertyRenderer.getLabelOffset(

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -63,7 +63,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
         {...props}
         labelElement={
           <PrimitivePropertyLabelRenderer
-            //Added offset to account for checkbox
+            // Added offset to account for checkbox
             offset={24}
             renderColon={this.props.orientation === Orientation.Horizontal}
             tooltip={displayLabel}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PrimitivePropertyRenderer.tsx
@@ -36,6 +36,15 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
   public override render() {
     const { indentation, highlight, ...props } = this.props;
     const displayLabel = this.props.propertyRecord.property.displayLabel;
+    // TODO Refactor this to consider checkbox.
+    // const offset = CommonPropertyRenderer.getLabelOffset(
+    //   indentation,
+    //   props.orientation,
+    //   props.width,
+    //   props.columnRatio,
+    //   props.columnInfo?.minLabelWidth,
+    // );
+
     const activeMatchIndex =
       this.props.propertyRecord.property.name ===
         highlight?.activeHighlight?.highlightedItemIdentifier
@@ -54,7 +63,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
         {...props}
         labelElement={
           <PrimitivePropertyLabelRenderer
-            // Added label offset to account for checkbox
+            //Added offset to account for checkbox
             offset={24}
             renderColon={this.props.orientation === Orientation.Horizontal}
             tooltip={displayLabel}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyGrid.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyGrid.scss
@@ -2,8 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/expandable/list";
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@import '~@itwin/core-react/lib/cjs/core-react/expandable/list';
+@import '~@itwin/core-react/lib/cjs/core-react/scrollbar';
 
 .gm-components-property-grid-loader {
   display: flex;
@@ -61,7 +61,7 @@
   @include components-property-list;
 
   display: grid;
-  grid-row-gap: 1px; // A gap of 10px is too wasteful
+  grid-row-gap: 0px;
   overflow: hidden;
 }
 

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.scss
@@ -58,6 +58,18 @@ $text-font-color: $buic-text-color;
     position: absolute;
     z-index: 1;
   }
+  // Radial does not respect checkbox positioning, have to force it.
+  > .iui-progress-indicator-radial {
+    position: absolute;
+  }
+  .components-property-selection-loading {
+    display: flex;
+    width: $iui-m;
+    height: $iui-m;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
 }
 
 .components-property-record-value {

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.scss
@@ -52,9 +52,11 @@ $text-font-color: $buic-text-color;
 
 .components-property-record-label {
   @include record-cell;
+  position: relative;
   .components-property-selection-checkbox {
-    margin-right: $iui-s;
     flex-shrink: 0;
+    position: absolute;
+    z-index: 1;
   }
 }
 

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import type { PropertyRecord} from "@itwin/appui-abstract";
+import type { PropertyRecord } from "@itwin/appui-abstract";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
 import { ElementSeparator, Orientation } from "@itwin/core-react";
 import { ActionButtonList } from "@itwin/components-react";

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
@@ -13,7 +13,7 @@ import type { SharedRendererProps } from "./PropertyRender";
 import { GroupQueryBuilderContext } from "../GroupQueryBuilderContext";
 import { useCallback } from "react";
 import { PropertyGridColumnStyleProvider } from "@itwin/components-react/lib/cjs/components-react/properties/renderers/PropertyGridColumns";
-import { Checkbox } from "@itwin/itwinui-react";
+import { Checkbox, ProgressRadial } from "@itwin/itwinui-react";
 
 /** Properties of [[PropertyView]] React component
  * @public
@@ -33,6 +33,7 @@ export interface PropertyViewProps extends SharedRendererProps {
  */
 export const PropertyView = (props: PropertyViewProps) => {
   const context = React.useContext(GroupQueryBuilderContext);
+  const [isCheckboxLoading, setIsCheckboxLoading] = React.useState(false);
 
   const _validatePropertySelection = () => {
     if (context.currentPropertyList.includes(props.propertyRecord)) {
@@ -87,6 +88,7 @@ export const PropertyView = (props: PropertyViewProps) => {
 
   const _addSelectedProperty = useCallback(
     async (prop: PropertyRecord) => {
+      setIsCheckboxLoading(true);
       // TODO: roof selected item/category value is an object but format is primitive(needs further exploration)
       if (
         !context.currentPropertyList.includes(prop) &&
@@ -194,6 +196,11 @@ export const PropertyView = (props: PropertyViewProps) => {
     }
   }, [context.currentPropertyList, props.propertyRecord]);
 
+  React.useEffect(() => {
+    if (!context.isRendering)
+      setIsCheckboxLoading(false);
+  }, [context.isRendering]);
+
   const _onPropertySelectionChanged = () => {
     setIsPropertySelected(!isPropertySelected);
   };
@@ -275,6 +282,8 @@ export const PropertyView = (props: PropertyViewProps) => {
             className='components-property-selection-checkbox'
             checked={isPropertySelected}
             onChange={_onPropertySelectionChanged}
+            disabled={context.isLoading || context.isRendering}
+            isLoading={isCheckboxLoading}
           />
         )}
         {props.labelElement}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
@@ -13,7 +13,7 @@ import type { SharedRendererProps } from "./PropertyRender";
 import { GroupQueryBuilderContext } from "../GroupQueryBuilderContext";
 import { useCallback } from "react";
 import { PropertyGridColumnStyleProvider } from "@itwin/components-react/lib/cjs/components-react/properties/renderers/PropertyGridColumns";
-import { Checkbox, ProgressRadial } from "@itwin/itwinui-react";
+import { Checkbox } from "@itwin/itwinui-react";
 
 /** Properties of [[PropertyView]] React component
  * @public
@@ -278,14 +278,14 @@ export const PropertyView = (props: PropertyViewProps) => {
       <div className='components-property-record-label'>
         {props.propertyRecord.value.valueFormat ===
           PropertyValueFormat.Primitive && (
-          <Checkbox
-            className='components-property-selection-checkbox'
-            checked={isPropertySelected}
-            onChange={_onPropertySelectionChanged}
-            disabled={context.isLoading || context.isRendering}
-            isLoading={isCheckboxLoading}
-          />
-        )}
+            <Checkbox
+              className='components-property-selection-checkbox'
+              checked={isPropertySelected}
+              onChange={_onPropertySelectionChanged}
+              disabled={context.isLoading || context.isRendering}
+              isLoading={isCheckboxLoading}
+            />
+          )}
         {props.labelElement}
       </div>
       {needElementSeparator ? (
@@ -302,14 +302,14 @@ export const PropertyView = (props: PropertyViewProps) => {
       ) : undefined}
       {props.propertyRecord.value.valueFormat ===
         PropertyValueFormat.Primitive ? (
-          <div className='components-property-record-value'>
-            <span>
-              {props.valueElementRenderer
-                ? props.valueElementRenderer()
-                : props.valueElement}
-            </span>
-          </div>
-        ) : undefined}
+        <div className='components-property-record-value'>
+          <span>
+            {props.valueElementRenderer
+              ? props.valueElementRenderer()
+              : props.valueElement}
+          </span>
+        </div>
+      ) : undefined}
       {props.actionButtonRenderers ? (
         <ActionButtonList
           orientation={props.orientation}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/property-grid/PropertyView.tsx
@@ -88,12 +88,14 @@ export const PropertyView = (props: PropertyViewProps) => {
 
   const _addSelectedProperty = useCallback(
     async (prop: PropertyRecord) => {
-      setIsCheckboxLoading(true);
       // TODO: roof selected item/category value is an object but format is primitive(needs further exploration)
       if (
         !context.currentPropertyList.includes(prop) &&
         prop.value.valueFormat === PropertyValueFormat.Primitive
       ) {
+        if (prop.value.displayValue) {
+          setIsCheckboxLoading(true);
+        }
         context.setCurrentPropertyList(
           context.currentPropertyList.concat(prop)
         );
@@ -278,14 +280,14 @@ export const PropertyView = (props: PropertyViewProps) => {
       <div className='components-property-record-label'>
         {props.propertyRecord.value.valueFormat ===
           PropertyValueFormat.Primitive && (
-            <Checkbox
-              className='components-property-selection-checkbox'
-              checked={isPropertySelected}
-              onChange={_onPropertySelectionChanged}
-              disabled={context.isLoading || context.isRendering}
-              isLoading={isCheckboxLoading}
-            />
-          )}
+          <Checkbox
+            className='components-property-selection-checkbox'
+            checked={isPropertySelected}
+            onChange={_onPropertySelectionChanged}
+            disabled={context.isLoading || context.isRendering}
+            isLoading={isCheckboxLoading}
+          />
+        )}
         {props.labelElement}
       </div>
       {needElementSeparator ? (
@@ -302,14 +304,14 @@ export const PropertyView = (props: PropertyViewProps) => {
       ) : undefined}
       {props.propertyRecord.value.valueFormat ===
         PropertyValueFormat.Primitive ? (
-        <div className='components-property-record-value'>
-          <span>
-            {props.valueElementRenderer
-              ? props.valueElementRenderer()
-              : props.valueElement}
-          </span>
-        </div>
-      ) : undefined}
+          <div className='components-property-record-value'>
+            <span>
+              {props.valueElementRenderer
+                ? props.valueElementRenderer()
+                : props.valueElement}
+            </span>
+          </div>
+        ) : undefined}
       {props.actionButtonRenderers ? (
         <ActionButtonList
           orientation={props.orientation}


### PR DESCRIPTION
The property grid had overlapping separator with the labels due to the unexpected checkbox we put in. Fixed it. Too many inline scripted styles made it difficult to do it nicely. Also polished a lot of the loading spinners positioning and added more.