### PR TITLE
Hide property grid by default

### DIFF
--- a/common/changes/@itwin/measure-tools-react/hide-property-grid_2022-03-25-15-27.json
+++ b/common/changes/@itwin/measure-tools-react/hide-property-grid_2022-03-25-15-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "remove setTimeout from useEffect",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/common/changes/@itwin/property-grid-react/hide-property-grid_2022-03-25-14-51.json
+++ b/common/changes/@itwin/property-grid-react/hide-property-grid_2022-03-25-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "hide property-grid by default",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/common/changes/@itwin/property-grid-react/hide-property-grid_2022-03-25-15-41.json
+++ b/common/changes/@itwin/property-grid-react/hide-property-grid_2022-03-25-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "PropertyGridProps expanded to allow default location",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasurementPropertyWidget.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasurementPropertyWidget.tsx
@@ -141,9 +141,9 @@ export const MeasurementPropertyWidget = () => {
 
   React.useEffect(() => {
     if (lastSelectedCount) {
-      setTimeout(() => widgetDef?.setWidgetState(WidgetState.Open));
+      widgetDef?.setWidgetState(WidgetState.Open);
     } else {
-      setTimeout(() => widgetDef?.setWidgetState(WidgetState.Hidden));
+      widgetDef?.setWidgetState(WidgetState.Hidden);
     }
   }, [widgetDef, lastSelectedCount]);
 

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -15,7 +15,7 @@ import {
 import { UiFramework } from "@itwin/appui-react";
 import * as React from "react";
 
-import { MultiElementPropertyGrid } from "./components/MultiElementPropertyGrid";
+import { MultiElementPropertyGrid, MultiElementPropertyGridId } from "./components/MultiElementPropertyGrid";
 import { PropertyGridManager } from "./PropertyGridManager";
 import type { PropertyGridProps } from "./types";
 
@@ -53,10 +53,10 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
       )
     ) {
       widgets.push({
-        id: "vcr:PropertyGrid",
+        id: MultiElementPropertyGridId,
         label: PropertyGridManager.translate("widget-label"),
         getWidgetContent: () => <MultiElementPropertyGrid {...this._props} />,
-        defaultState: WidgetState.Closed,
+        defaultState: WidgetState.Hidden,
         icon: "icon-info",
       });
     }

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -38,11 +38,13 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
     zoneLocation?: AbstractZoneLocation
   ): ReadonlyArray<AbstractWidgetProps> {
     const widgets: AbstractWidgetProps[] = [];
+    const preferredLocation = this._props?.defaultPanelLocation ?? StagePanelLocation.Right;
+    const preferredPanelSection = this._props?.defaultPanelSection ?? StagePanelSection.End;
     if (
       (
         stageUsage === StageUsage.General &&
-        location === StagePanelLocation.Right &&
-        section === StagePanelSection.End &&
+        location === preferredLocation &&
+        section === preferredPanelSection &&
         UiFramework.uiVersion !== "1"
       ) ||
       (

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -124,7 +124,7 @@ export const FilteringPropertyGridWithUnifiedSelection = (
     ),
   }), []);
 
-  const { isOverLimit, numSelectedElements } = usePropertyDataProviderWithUnifiedSelection({ dataProvider: props.dataProvider as IPresentationPropertyDataProvider });
+  const { isOverLimit } = usePropertyDataProviderWithUnifiedSelection({ dataProvider: props.dataProvider as IPresentationPropertyDataProvider });
 
   const filteringDataProvider = useDisposable(useCallback(
     () => new FilteringPropertyDataProvider(
@@ -141,11 +141,10 @@ export const FilteringPropertyGridWithUnifiedSelection = (
 
   return (
     <>
-      {(isOverLimit || !numSelectedElements) ? (
+      {isOverLimit ? (
         <FillCentered style={{ flexDirection: "column" }}>
-          {!numSelectedElements && <i className="property-grid-react-filtering-pg-icon icon icon-info" />}
           <div className="property-grid-react-filtering-pg-label">
-            {isOverLimit ? localizations.tooManySelected : localizations.noneSelected}
+            { localizations.tooManySelected }
           </div>
         </FillCentered>
       ) : (

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import './MultiElementPropertyGrid.scss';
+import "./MultiElementPropertyGrid.scss";
 
 import type { InstanceKey } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
@@ -17,8 +17,8 @@ import { ElementList } from "./ElementList";
 import { PropertyGrid } from "./PropertyGrid";
 import React, { useEffect, useMemo, useState } from "react";
 import classnames from "classnames";
-import { WidgetState } from '@itwin/appui-abstract';
-import { Id64 } from '@itwin/core-bentley';
+import { WidgetState } from "@itwin/appui-abstract";
+import { Id64 } from "@itwin/core-bentley";
 
 enum MultiElementPropertyContent {
   PropertyGrid = 0,
@@ -121,10 +121,10 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
   );
 
   useEffect(() => {
-    if (instanceKeys.some(key => !Id64.isTransient(key.id))) {
-      widgetDef?.setWidgetState(WidgetState.Open)
+    if (instanceKeys.some((key) => !Id64.isTransient(key.id))) {
+      widgetDef?.setWidgetState(WidgetState.Open);
     } else {
-      widgetDef?.setWidgetState(WidgetState.Hidden)
+      widgetDef?.setWidgetState(WidgetState.Hidden);
     }
   }, [widgetDef, instanceKeys]);
 

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -31,7 +31,7 @@ function useSpecificWidgetDef(id: string) {
   return frontstageDef?.findWidgetDef(id);
 }
 
-export const MultiElementPropertyGridId = "vcr:PropertyGrid";
+export const MultiElementPropertyGridId = "vcr:MultiElementPropertyGrid";
 
 export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
   const iModelConnection = useActiveIModelConnection();

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -3,11 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import "./MultiElementPropertyGrid.scss";
+import './MultiElementPropertyGrid.scss';
 
 import type { InstanceKey } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import {
+  useActiveFrontstageDef,
   useActiveIModelConnection,
 } from "@itwin/appui-react";
 
@@ -16,12 +17,21 @@ import { ElementList } from "./ElementList";
 import { PropertyGrid } from "./PropertyGrid";
 import React, { useEffect, useMemo, useState } from "react";
 import classnames from "classnames";
+import { WidgetState } from '@itwin/appui-abstract';
+import { Id64 } from '@itwin/core-bentley';
 
 enum MultiElementPropertyContent {
   PropertyGrid = 0,
   ElementList = 1,
   SingleElementPropertyGrid = 2,
 }
+
+function useSpecificWidgetDef(id: string) {
+  const frontstageDef = useActiveFrontstageDef();
+  return frontstageDef?.findWidgetDef(id);
+}
+
+export const MultiElementPropertyGridId = "vcr:PropertyGrid";
 
 export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
   const iModelConnection = useActiveIModelConnection();
@@ -32,6 +42,7 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
   const [moreThanOneElement, setMoreThanOneElement] = useState(false);
   const [selectedInstanceKey, setSelectedInstanceKey] =
     useState<InstanceKey>();
+  const widgetDef = useSpecificWidgetDef(MultiElementPropertyGridId);
 
   useEffect(() => {
     const onSelectionChange = () => {
@@ -108,6 +119,14 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
       key={"SingleElementPropertyGrid"}
     />
   );
+
+  useEffect(() => {
+    if (instanceKeys.some(key => !Id64.isTransient(key.id))) {
+      widgetDef?.setWidgetState(WidgetState.Open)
+    } else {
+      widgetDef?.setWidgetState(WidgetState.Hidden)
+    }
+  }, [widgetDef, instanceKeys]);
 
   return (
     <div className="property-grid-react-transition-container">

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -11,6 +11,10 @@ import type {
 import type { PropertyGridContextMenuArgs } from "@itwin/components-react";
 import type { ContextMenuItemProps, Orientation } from "@itwin/core-react";
 import type { FavoritePropertiesScope } from "@itwin/presentation-frontend";
+import type {
+  StagePanelLocation,
+  StagePanelSection
+} from "@itwin/appui-abstract";
 
 export type ContextMenuItemInfo = ContextMenuItemProps &
 React.Attributes & { label: string };
@@ -28,6 +32,8 @@ export interface PropertyGridProps {
   favoritePropertiesScope?: FavoritePropertiesScope;
   enableCopyingPropertyText?: boolean;
   enableNullValueToggle?: boolean;
+  defaultPanelLocation?: StagePanelLocation;
+  defaultPanelSection?: StagePanelSection;
   /** If true, enables property category group nesting  */
   enablePropertyGroupNesting?: boolean;
   additionalContextMenuOptions?: ContextMenuItemInfo[];

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -13,7 +13,7 @@ import type { ContextMenuItemProps, Orientation } from "@itwin/core-react";
 import type { FavoritePropertiesScope } from "@itwin/presentation-frontend";
 import type {
   StagePanelLocation,
-  StagePanelSection
+  StagePanelSection,
 } from "@itwin/appui-abstract";
 
 export type ContextMenuItemInfo = ContextMenuItemProps &


### PR DESCRIPTION
Hides property grid by default unless at least one non-transient element is in selection set.