### PR TITLE
[Tree-Widget] Fix AutoSizer to render children even if width or height is 0

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree-widget-auto-sizer-fix_2022-04-21-11-58.json
+++ b/common/changes/@itwin/tree-widget-react/tree-widget-auto-sizer-fix_2022-04-21-11-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Do not unmount children in AutoSizer when height or width is 0 to avoid losing children state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
+++ b/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 import React, { useCallback, useState } from "react";
 import { useResizeObserver } from "@itwin/core-react";
 
@@ -21,7 +25,7 @@ export const AutoSizer = (props: AutoSizerProps) => {
 
   return (
     <div ref={ref} style={{ width: "100%", height: "100%" }}>
-      {width && height && (props.children({ width, height }))}
+      {props.children({ width, height })}
     </div>
   );
 };


### PR DESCRIPTION
Changed AutoSizer behavior to avoid unmounting children when width or height is 0. This was causing trees from `@itwin/appui-react` to lose their state.