### PR TITLE
Add PR trigger to CI pipeline

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -3,6 +3,12 @@
 trigger:
   - master
 
+pr:
+  drafts: false
+  branches:
+    include:
+      - master
+
 schedules:
   - cron: "0 9 * * Mon-Fri"
     displayName: Weekday 4 AM (UTC -5) daily build


### PR DESCRIPTION
If no PR trigger is present in an azure devops pipeline hosted in github, pull request validation is enabled for all branches. By defining the PR trigger ourselves we can override the default behavior. For more info, see [PR triggers in GitHub](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers).