### PR TITLE
[property-grid-react] fix ui items provider so the property grid appears when loaded into appui v1.0

### DIFF
--- a/common/changes/@itwin/property-grid-react/fix-property-gruid-provider-ui-1.0_2022-05-05-15-05.json
+++ b/common/changes/@itwin/property-grid-react/fix-property-gruid-provider-ui-1.0_2022-05-05-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "fix property grid ui items provider when loading into appui v1.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -13,7 +13,8 @@ import {
   WidgetState,
 } from "@itwin/appui-abstract";
 import { FrontstageManager, UiFramework } from "@itwin/appui-react";
-import { ISelectionProvider, Presentation, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
+import type { ISelectionProvider, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
+import { Presentation } from "@itwin/presentation-frontend";
 import * as React from "react";
 
 import { MultiElementPropertyGrid, MultiElementPropertyGridId } from "./components/MultiElementPropertyGrid";

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -12,22 +12,47 @@ import {
   StageUsage,
   WidgetState,
 } from "@itwin/appui-abstract";
-import { UiFramework } from "@itwin/appui-react";
+import { FrontstageManager, UiFramework } from "@itwin/appui-react";
+import { ISelectionProvider, Presentation, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
 import * as React from "react";
 
 import { MultiElementPropertyGrid, MultiElementPropertyGridId } from "./components/MultiElementPropertyGrid";
 import { PropertyGridManager } from "./PropertyGridManager";
 import type { PropertyGridProps } from "./types";
 
+/** Listen for selection changes and when nothing is selection hide the Widget by calling widgetDef.setWidgetState  */
+const onPresentationSelectionChanged = async (evt: SelectionChangeEventArgs, selectionProvider: ISelectionProvider) => {
+  const widgetDef = FrontstageManager.activeFrontstageDef?.findWidgetDef(MultiElementPropertyGridId);
+  if (widgetDef) {
+    const selection = selectionProvider.getSelection(evt.imodel, evt.level);
+    if (selection.isEmpty) {
+      widgetDef?.setWidgetState(WidgetState.Hidden);
+    } else {
+      if (selection.instanceKeys.size !== 0) {
+        widgetDef?.setWidgetState(WidgetState.Open);
+      }
+    }
+  }
+};
+
 /** Provides the property grid widget to zone 9 */
 export class PropertyGridUiItemsProvider implements UiItemsProvider {
   public readonly id = "PropertyGridUiItemsProvider";
+  private _removeListenerFunc?: () => void;
 
   private _props?: PropertyGridProps;
 
   constructor(props?: PropertyGridProps) {
     this._props = props;
+    if (UiFramework.uiVersion === "1") {
+      this._removeListenerFunc = Presentation.selection.selectionChange.addListener(onPresentationSelectionChanged);
+    }
   }
+
+  // When the provider is unloaded also remove the handler
+  public onUnregister = () => {
+    this._removeListenerFunc && this._removeListenerFunc();
+  };
 
   public provideWidgets(
     _stageId: string,

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -8,6 +8,7 @@ import "./MultiElementPropertyGrid.scss";
 import type { InstanceKey } from "@itwin/presentation-common";
 import { Presentation } from "@itwin/presentation-frontend";
 import {
+  UiFramework,
   useActiveFrontstageDef,
   useActiveIModelConnection,
 } from "@itwin/appui-react";
@@ -121,10 +122,12 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
   );
 
   useEffect(() => {
-    if (instanceKeys.some((key) => !Id64.isTransient(key.id))) {
-      widgetDef?.setWidgetState(WidgetState.Open);
-    } else {
-      widgetDef?.setWidgetState(WidgetState.Hidden);
+    if (UiFramework.uiVersion !== "1") {
+      if (instanceKeys.some((key) => !Id64.isTransient(key.id))) {
+        widgetDef?.setWidgetState(WidgetState.Open);
+      } else {
+        widgetDef?.setWidgetState(WidgetState.Hidden);
+      }
     }
   }, [widgetDef, instanceKeys]);
 
@@ -137,7 +140,7 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
             "property-grid-react-animated-tab-animate-right": idx > content,
             "property-grid-react-animated-tab-animate-left": idx < content,
           })} >
-            { component }
+            {component}
           </div>
         ))}
       </div>


### PR DESCRIPTION
The current implementation of the property grid when using a ui items provider is to rely on the useEffect in the MultiElementGrid to handle hiding / showing the property grid on selection events. This won't work in appui v1.0 because the component will be unmounted and cannot have its state changed from that useEffect. 

The workaround is to implement a mechanism similar to what Bill did here: https://github.com/iTwin/itwinjs-core/blob/ce886ecde5caec43972f7b6a4dd4cf3cd13eba06/test-apps/ui-items-providers-test/src/ui/providers/NetworkTracingUiProvider.tsx#L69

If the PropertyGridUiItemsProvider is created in appui v1.0, then a listener will be added (that is cleaned up during the onUnregister callback) that will handle the toggling of the property grid's widget state in place of the useEffect, which will not run if in appui v1.0