### PR TITLE
restore transient state of tree widget if remounted (such as when a tab)

### DIFF
--- a/common/changes/@itwin/tree-widget-react/fix-tree-widget-restore-state_2022-05-05-18-37.json
+++ b/common/changes/@itwin/tree-widget-react/fix-tree-widget-restore-state_2022-05-05-18-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "set restore transient state in tree widget ui items provider to restore state when remounted",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
@@ -46,7 +46,7 @@ export class TreeWidgetUiItemsProvider implements UiItemsProvider {
       // eslint-disable-next-line deprecation/deprecation
       (!section && stageUsage === StageUsage.General && zoneLocation === AbstractZoneLocation.CenterRight) ||
       (stageUsage === StageUsage.General && location === preferredLocation && section === preferredPanelSection
-         && UiFramework.uiVersion !== "1")
+        && UiFramework.uiVersion !== "1")
     ) {
       const trees: SelectableContentDefinition[] = [];
 
@@ -103,6 +103,7 @@ export class TreeWidgetUiItemsProvider implements UiItemsProvider {
         label: TreeWidget.translate("treeview"),
         getWidgetContent: () => <TreeWidgetComponent trees={trees} />,
         icon: "icon-hierarchy-tree",
+        restoreTransientState: () => true,
       });
     }
 


### PR DESCRIPTION
add `restoreTransientState` to the TreeWidgetUiItemsProvider to ensure that the widget's state is restored if remounted such as is the case when used in a tab