### PR TITLE
[property-grid-react] ensure the multiselect option appears when component first mounts

### DIFF
--- a/common/changes/@itwin/property-grid-react/fix-property-grid-multi-select-icon_2022-05-06-20-09.json
+++ b/common/changes/@itwin/property-grid-react/fix-property-grid-multi-select-icon_2022-05-06-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "ensure the multi select property grid option appears if applicable when component first mounts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -68,6 +68,9 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
       }
     };
 
+    // ensure this selection handling runs if component mounts after the selection event fires:
+    onSelectionChange();
+
     const removeListener = Presentation.selection.selectionChange.addListener(onSelectionChange);
     return () => removeListener();
   }, [iModelConnection]);


### PR DESCRIPTION
if you select many elements while the property grid is not mounted, it will mount and not show the option to open the multi element property grid because the logic to do so only runs in a selection event handler which will only have been setup after the selection event has fired. The solution is to ensure when the component mounts that logic automatically runs.