### PR TITLE
[property-grid-react] don't open property grid tab when only transient elements selected

### DIFF
--- a/common/changes/@itwin/property-grid-react/fix-property-grid-transient_2022-05-09-17-15.json
+++ b/common/changes/@itwin/property-grid-react/fix-property-grid-transient_2022-05-09-17-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "dont open property grid tab when only transient elements (such as view sections) are selected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -14,7 +14,7 @@ import {
 } from "@itwin/appui-abstract";
 import { FrontstageManager, UiFramework } from "@itwin/appui-react";
 import { Id64 } from "@itwin/core-bentley";
-import { InstanceKey } from "@itwin/presentation-common";
+import type { InstanceKey } from "@itwin/presentation-common";
 import type { ISelectionProvider, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
 import { Presentation } from "@itwin/presentation-frontend";
 import * as React from "react";

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -13,6 +13,8 @@ import {
   WidgetState,
 } from "@itwin/appui-abstract";
 import { FrontstageManager, UiFramework } from "@itwin/appui-react";
+import { Id64 } from "@itwin/core-bentley";
+import { InstanceKey } from "@itwin/presentation-common";
 import type { ISelectionProvider, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
 import { Presentation } from "@itwin/presentation-frontend";
 import * as React from "react";
@@ -26,12 +28,21 @@ const onPresentationSelectionChanged = async (evt: SelectionChangeEventArgs, sel
   const widgetDef = FrontstageManager.activeFrontstageDef?.findWidgetDef(MultiElementPropertyGridId);
   if (widgetDef) {
     const selection = selectionProvider.getSelection(evt.imodel, evt.level);
-    if (selection.isEmpty) {
-      widgetDef?.setWidgetState(WidgetState.Hidden);
-    } else {
-      if (selection.instanceKeys.size !== 0) {
-        widgetDef?.setWidgetState(WidgetState.Open);
+    const instanceKeys: InstanceKey[] = [];
+    selection.instanceKeys.forEach(
+      (ids: Set<string>, className: string) => {
+        ids.forEach((id: string) => {
+          instanceKeys.push({
+            id,
+            className,
+          });
+        });
       }
+    );
+    if (instanceKeys.some((key) => !Id64.isTransient(key.id))) {
+      widgetDef.setWidgetState(WidgetState.Open);
+    } else {
+      widgetDef.setWidgetState(WidgetState.Hidden);
     }
   }
 };


### PR DESCRIPTION
updates the logic of the onPresentationSelectionChanged handler in the PropertyGridUiItemsProvider, which is meant to handle showing/hiding the property grid when it is set in a tab such as in app ui v1.0, to reflect the logic used in the useEffect in the MultiElementPropertyGrid, which handles showing/hiding the property grid in an app ui v2.0 panel, to prevent showing the property grid when only transient elements (such as view section panes) are selected