### PR TITLE
[property-grid-react] support overriding the default zone location used in the ui items provider

### DIFF
--- a/common/changes/@itwin/property-grid-react/fix-property-grid-default-zone-location_2022-05-10-16-24.json
+++ b/common/changes/@itwin/property-grid-react/fix-property-grid-default-zone-location_2022-05-10-16-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "allow default zone location to be overridden",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -77,6 +77,8 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
     const widgets: AbstractWidgetProps[] = [];
     const preferredLocation = this._props?.defaultPanelLocation ?? StagePanelLocation.Right;
     const preferredPanelSection = this._props?.defaultPanelSection ?? StagePanelSection.End;
+    // eslint-disable-next-line deprecation/deprecation
+    const preferredZoneLocation = this._props?.defaultZoneLocation ?? AbstractZoneLocation.CenterRight
     if (
       (
         stageUsage === StageUsage.General &&
@@ -87,8 +89,7 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
       (
         !section &&
         stageUsage === StageUsage.General &&
-        // eslint-disable-next-line deprecation/deprecation
-        zoneLocation === AbstractZoneLocation.CenterRight
+        zoneLocation === preferredZoneLocation
       )
     ) {
       widgets.push({

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -78,7 +78,7 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
     const preferredLocation = this._props?.defaultPanelLocation ?? StagePanelLocation.Right;
     const preferredPanelSection = this._props?.defaultPanelSection ?? StagePanelSection.End;
     // eslint-disable-next-line deprecation/deprecation
-    const preferredZoneLocation = this._props?.defaultZoneLocation ?? AbstractZoneLocation.CenterRight
+    const preferredZoneLocation = this._props?.defaultZoneLocation ?? AbstractZoneLocation.CenterRight;
     if (
       (
         stageUsage === StageUsage.General &&

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -17,8 +17,7 @@ import type {
   StagePanelSection,
 } from "@itwin/appui-abstract";
 
-export type ContextMenuItemInfo = ContextMenuItemProps &
-  React.Attributes & { label: string };
+export type ContextMenuItemInfo = ContextMenuItemProps & React.Attributes & { label: string };
 
 export interface OnSelectEventArgs {
   dataProvider: IPresentationPropertyDataProvider;

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -12,12 +12,13 @@ import type { PropertyGridContextMenuArgs } from "@itwin/components-react";
 import type { ContextMenuItemProps, Orientation } from "@itwin/core-react";
 import type { FavoritePropertiesScope } from "@itwin/presentation-frontend";
 import type {
+  AbstractZoneLocation,
   StagePanelLocation,
   StagePanelSection,
 } from "@itwin/appui-abstract";
 
 export type ContextMenuItemInfo = ContextMenuItemProps &
-React.Attributes & { label: string };
+  React.Attributes & { label: string };
 
 export interface OnSelectEventArgs {
   dataProvider: IPresentationPropertyDataProvider;
@@ -43,5 +44,7 @@ export interface PropertyGridProps {
   onInfoButton?: () => void;
   onBackButton?: () => void;
   disableUnifiedSelection?: boolean;
+  // eslint-disable-next-line deprecation/deprecation
+  defaultZoneLocation?: AbstractZoneLocation;
 }
 


### PR DESCRIPTION
Allow the default zone location (Center.Right) to be overridden by a property grid prop the same way we already support for the panel / section locations (which are used in app ui v2.0 whereas zone location is used only by app ui v1.0)