### PR TITLE
Bugfix/measure tools UI 2.0

### DIFF
--- a/common/changes/@itwin/measure-tools-react/bugfix-measure-tools-ui-2.0_2022-05-12-18-47.json
+++ b/common/changes/@itwin/measure-tools-react/bugfix-measure-tools-ui-2.0_2022-05-12-18-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Modify MeasurementPropertyWidget such that adding or removing measurements one by one does not collapse them. This was working in the MeasurementWidget.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}


### PR DESCRIPTION
Fix the MeasurementPropertyWidget (aka MeasurementWidget for ui-2.0) that would not properly expand the measurements while selecting/deselecting them one by one. This is a regression from the older version and is required whenever we use Measurement tools to place multiple measurements. The user should always see the properties of the last created measurement without ever having to expand it manually.