### PR TITLE
[Grouping&Mapping] Add an extraction enabled toggle

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/extractionenabletoggle_2022-05-16-07-13.json
+++ b/common/changes/@itwin/grouping-mapping-widget/extractionenabletoggle_2022-05-16-07-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Adds a toggle for enabling extraction in the add/edit mapping view and the three dot menu in the mappings table",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/BlockingOverlay.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/BlockingOverlay.scss
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+@import '~@itwin/itwinui-css/scss/variables';
+
+.group-mapping-blocking-overlay {
+  background-color: black;
+  position: absolute;
+  height: inherit;
+  right: 6px;
+  left: 6px;
+  opacity: 60%;
+  z-index: 9999;
+  visibility: hidden;
+
+  &.visible {
+    visibility: visible;
+  }
+}
+
+.group-mapping-blocking-overlay-spinner {
+  display: flex;
+  justify-content: center;
+  height: inherit;
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/BlockingOverlay.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/BlockingOverlay.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import classnames from "classnames";
+import React from "react";
+import { LoadingSpinner } from "./utils";
+import "./BlockingOverlay.scss";
+
+export interface BlockingOverlayProps {
+  isVisible: boolean;
+}
+
+export const BlockingOverlay = ({ isVisible }: BlockingOverlayProps) => {
+  return (
+    <div className={classnames("group-mapping-blocking-overlay", isVisible && "visible")}>
+      <div className="group-mapping-blocking-overlay-spinner">
+        <LoadingSpinner />
+      </div>
+    </div>
+  );
+};

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/MappingAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/MappingAction.tsx
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Fieldset, LabeledInput, Small } from "@itwin/itwinui-react";
+import { Fieldset, LabeledInput, Small, ToggleSwitch } from "@itwin/itwinui-react";
 import React, { useContext, useState } from "react";
 import ActionPanel from "./ActionPanel";
 import useValidator, { NAME_REQUIREMENTS } from "../hooks/useValidator";
@@ -23,6 +23,7 @@ const MappingAction = ({ iModelId, mapping, returnFn }: MappingActionProps) => {
   const [values, setValues] = useState({
     name: mapping?.mappingName ?? "",
     description: mapping?.description ?? "",
+    extractionEnabled: mapping?.extractionEnabled ?? true,
   });
   const [validator, showValidationMessage] = useValidator();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -40,10 +41,12 @@ const MappingAction = ({ iModelId, mapping, returnFn }: MappingActionProps) => {
         ? await reportingClientApi.updateMapping(apiContext.accessToken, iModelId, mapping.id ?? "", {
           mappingName: values.name,
           description: values.description,
+          extractionEnabled: values.extractionEnabled,
         })
         : await reportingClientApi.createMapping(apiContext.accessToken, iModelId, {
           mappingName: values.name,
           description: values.description,
+          extractionEnabled: values.extractionEnabled,
         });
       await returnFn();
     } catch (error: any) {
@@ -113,6 +116,16 @@ const MappingAction = ({ iModelId, mapping, returnFn }: MappingActionProps) => {
             onBlurCapture={(event) => {
               handleInputChange(event, values, setValues);
               validator.showMessageFor("description");
+            }}
+          />
+          <ToggleSwitch
+            id='extractionEnabled'
+            name='extractionEnabled'
+            label='Extraction enabled'
+            labelPosition="left"
+            checked={values.extractionEnabled}
+            onChange={(event) => {
+              setValues({ ...values, extractionEnabled: event.currentTarget.checked });
             }}
           />
         </Fieldset>


### PR DESCRIPTION
This PR adds an extraction toggle in the mapping add/modify view and also in the three dot menu in the mappings table.

When the extraction is toggled from the three dot menu then an overlay with a loading circle is displayed to block user clicks

Toggle in the add/modify view:
![add_modify](https://user-images.githubusercontent.com/15067512/168545490-de1dd086-110b-4533-aeb4-494396b2cf91.png)

Toggle in the three dot menu:
![threedotmenu](https://user-images.githubusercontent.com/15067512/168545480-dbd2f3bd-777e-4640-adc6-f87f0fd64691.png)

The blocking overlay:
![overlay](https://user-images.githubusercontent.com/15067512/168545488-70905b82-0e6c-40a6-929c-fbbf3f4ee3bb.png)