### PR TITLE
[property-grid-react] support overriding the auto child category expansion behavior

### DIFF
--- a/common/changes/@itwin/property-grid-react/property-grid-auot-expand-child-categories_2022-05-17-20-55.json
+++ b/common/changes/@itwin/property-grid-react/property-grid-auot-expand-child-categories_2022-05-17-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "support overriding property grid auto child category expansion behavior",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/api/AutoExpandingPropertyDataProvider.ts
+++ b/packages/itwin/property-grid/src/api/AutoExpandingPropertyDataProvider.ts
@@ -2,11 +2,23 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
 import { PresentationPropertyDataProvider } from "@itwin/presentation-components";
+import type { PresentationPropertyDataProviderProps } from "@itwin/presentation-components";
 import type { PropertyCategory, PropertyData } from "@itwin/components-react";
 
+export interface AutoExpandingPropertyDataProviderProps extends PresentationPropertyDataProviderProps {
+  autoExpandChildCategories?: boolean;
+}
+
 export class AutoExpandingPropertyDataProvider extends PresentationPropertyDataProvider {
+  private _autoExpandChildCategories = true;
+  constructor(props: AutoExpandingPropertyDataProviderProps) {
+    super(props);
+    if (undefined !== props.autoExpandChildCategories) {
+      this._autoExpandChildCategories = props.autoExpandChildCategories;
+    }
+  }
+
   public override async getData(): Promise<PropertyData> {
     const result = await super.getData();
     this.expandCategories(result.categories);
@@ -16,7 +28,7 @@ export class AutoExpandingPropertyDataProvider extends PresentationPropertyDataP
   private expandCategories(categories: PropertyCategory[]) {
     categories.forEach((category: PropertyCategory) => {
       category.expand = true;
-      if (category.childCategories) {
+      if (category.childCategories && this._autoExpandChildCategories) {
         this.expandCategories(category.childCategories);
       }
     });

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -71,9 +71,9 @@ export const PropertyGrid = ({
   onBackButton,
   disableUnifiedSelection,
   instanceKey,
+  autoExpandChildCategories,
 }: PropertyGridPropsWithSingleElement) => {
   const iModelConnection = useActiveIModelConnection();
-
   const createDataProvider = useCallback(() => {
     let dp;
     if (propDataProvider) {
@@ -83,6 +83,7 @@ export const PropertyGrid = ({
         imodel: iModelConnection,
         ruleset: rulesetId,
         disableFavoritesCategory: !enableFavoriteProperties,
+        autoExpandChildCategories,
       });
     }
     if (dp) {
@@ -96,7 +97,7 @@ export const PropertyGrid = ({
       }
     }
     return dp;
-  }, [propDataProvider, iModelConnection, rulesetId, enableFavoriteProperties, enablePropertyGroupNesting, instanceKey]);
+  }, [autoExpandChildCategories, propDataProvider, iModelConnection, rulesetId, enableFavoriteProperties, enablePropertyGroupNesting, instanceKey]);
 
   const dataProvider = useOptionalDisposable(createDataProvider);
 
@@ -452,6 +453,7 @@ export const PropertyGrid = ({
             actionButtonRenderers={actionButtonRenderers}
             width={width}
             height={height}
+            autoExpandChildCategories={autoExpandChildCategories}
           />
         )}
       </div>

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -58,6 +58,8 @@ export interface PropertyGridProps {
   disableUnifiedSelection?: boolean;
   // eslint-disable-next-line deprecation/deprecation
   defaultZoneLocation?: AbstractZoneLocation;
+  /** If true, expands child categories (true by default)  */
+  autoExpandChildCategories?: boolean;
 }
 
 export enum PropertyGridDefaultContextMenuKey {


### PR DESCRIPTION
allow for overriding the child category expansion
default behavior:
![image](https://user-images.githubusercontent.com/25822334/168909385-674ecef4-38f4-4fbd-94ae-56069ae1ddcd.png)

if `autoEpandChildCategories` is set to false this will be the result:
![image](https://user-images.githubusercontent.com/25822334/168908910-7d4533ed-e31b-4f6a-b19b-639b3f2b3be1.png)
