### PR TITLE
[property-grid-react] if the property grid tab is minimized do not force it open

### DIFF
--- a/common/changes/@itwin/property-grid-react/property-grid-force-open-fix_2022-05-18-17-41.json
+++ b/common/changes/@itwin/property-grid-react/property-grid-force-open-fix_2022-05-18-17-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "if the property grid is minimized do not force it open",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -40,7 +40,10 @@ const onPresentationSelectionChanged = async (evt: SelectionChangeEventArgs, sel
       }
     );
     if (instanceKeys.some((key) => !Id64.isTransient(key.id))) {
-      widgetDef.setWidgetState(WidgetState.Open);
+      // if the widget is minimized, do not force it open
+      if (widgetDef.activeState === WidgetState.Hidden) {
+        widgetDef.setWidgetState(WidgetState.Open);
+      }
     } else {
       widgetDef.setWidgetState(WidgetState.Hidden);
     }


### PR DESCRIPTION
when the property grid is a minimized tab like so:
![image](https://user-images.githubusercontent.com/25822334/169107858-72e9d85e-7e0f-411b-9924-a6a4f43854d6.png)
or merged into a zone with another active like so:
![image](https://user-images.githubusercontent.com/25822334/169107960-fb739fdf-f711-4b7e-8983-fbcb7be98025.png)
in those cases we do not want to force the property grid to open when a selection event occurs, instead we only want to do this when the property grid is hidden

Note: since this affects only tab behavior it only affects the property grid behavior in app ui v1