### PR TITLE
[property-grid-react] Added optional forcePosition property to ContextMenuItemInfo

### DIFF
--- a/common/changes/@itwin/property-grid-react/fix-propgrid-specify-position-context-menu_2022-05-25-18-39.json
+++ b/common/changes/@itwin/property-grid-react/fix-propgrid-specify-position-context-menu_2022-05-25-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Added option forcePosition property to ContextMenuItemInfo",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -295,8 +295,7 @@ export const PropertyGrid = ({
             // If option needs to go in a specific position in the list, put it there. otherwise just push.
             if(option.forcePosition !== undefined) {
               items.splice(option.forcePosition, 0, newItem);
-            }
-            else {
+            } else {
               items.push(newItem);
             }
           }

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -278,7 +278,7 @@ export const PropertyGrid = ({
 
         if (additionalContextMenuOptions?.length) {
           for (const option of additionalContextMenuOptions) {
-            items.push({
+            const newItem = {
               ...option,
               key: `additionalContextMenuOption_${option.label}`,
               onSelect: () => {
@@ -291,7 +291,14 @@ export const PropertyGrid = ({
                 }
                 setContextMenu(undefined);
               },
-            });
+            };
+            // If option needs to go in a specific position in the list, put it there. otherwise just push.
+            if(option.forcePosition !== undefined) {
+              items.splice(option.forcePosition, 0, newItem);
+            }
+            else {
+              items.push(newItem);
+            }
           }
         }
 

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -24,6 +24,7 @@ import type {
 export type ContextMenuItemInfo = ContextMenuItemProps & React.Attributes & {
   label: string;
   isValid?: (record: PropertyRecord, field?: Field) => boolean;
+  forcePosition?: number;
 };
 
 export interface OnSelectEventArgs {


### PR DESCRIPTION
Unified Viewer needs the ability to show the additional context menu item for "Share this Favorite" at the top of the dropdown. I added an optional forcePosition property. If set, the item will be added at that position in the list, otherwise it will be added to the end like before.