### PR TITLE
[measure-tools] Bugfix/default tool localization

### DIFF
--- a/common/changes/@itwin/measure-tools-react/bugfix-defaultToolLocalization_2022-05-26-12-22.json
+++ b/common/changes/@itwin/measure-tools-react/bugfix-defaultToolLocalization_2022-05-26-12-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Fix obtaining localized strings for the various tools.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/packages/itwin/measure-tools/src/tools/ClearMeasurementsTool.ts
+++ b/packages/itwin/measure-tools/src/tools/ClearMeasurementsTool.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 
 import type { Viewport } from "@itwin/core-frontend";
 import { MeasurementManager } from "../api/MeasurementManager";
@@ -10,10 +10,27 @@ import type { Measurement } from "../api/Measurement";
 import { PrimitiveToolBase } from "../api/MeasurementTool";
 import type { Feature } from "../api/FeatureTracking";
 import { MeasureToolsFeatures } from "../api/FeatureTracking";
+import { MeasureTools } from "../MeasureTools";
 
 export class ClearMeasurementsTool extends PrimitiveToolBase {
   public static override toolId = "MeasureTools.ClearMeasurements";
   public static override iconSpec = "icon-measure-clear";
+
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.ClearMeasurements.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.ClearMeasurements.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.ClearMeasurements.keyin",
+    );
+  }
 
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_ClearMeasurements;

--- a/packages/itwin/measure-tools/src/tools/MeasureAngleTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureAngleTool.ts
@@ -34,14 +34,20 @@ MeasureAngleToolModel
   public static override toolId = "MeasureTools.MeasureAngle";
   // TODO: Change icon once UX team provides icon
   public static override iconSpec = "icon-angle-measure";
-  public static get label() {
+
+  public static override get flyover() {
     return MeasureTools.localization.getLocalizedString(
       "MeasureTools:tools.MeasureAngle.flyover"
     );
   }
-  public static override get flyover() {
+  public static override get description(): string {
     return MeasureTools.localization.getLocalizedString(
-      "MeasureTools:tools.MeasureAngle.flyover"
+      "MeasureTools:tools.MeasureAngle.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureAngle.keyin",
     );
   }
 

--- a/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
@@ -32,6 +32,22 @@ MeasureAreaToolModel
   public static override toolId = "MeasureTools.MeasureArea";
   public static override iconSpec = "icon-measure-2d";
 
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureArea.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureArea.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureArea.keyin",
+    );
+  }
+
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_MeasureArea;
   }

--- a/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -31,6 +31,22 @@ MeasureDistanceToolModel
   public static override toolId = "MeasureTools.MeasureDistance";
   public static override iconSpec = "icon-measure-distance";
 
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureDistance.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureDistance.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureDistance.keyin",
+    );
+  }
+
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_MeasureDistance;
   }

--- a/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
@@ -42,6 +42,22 @@ MeasureLocationToolModel
   public static override toolId = "MeasureTools.MeasureLocation";
   public static override iconSpec = "icon-measure-location";
 
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureLocation.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureLocation.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureLocation.keyin",
+    );
+  }
+
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_MeasureLocation;
   }

--- a/packages/itwin/measure-tools/src/tools/MeasurePerpendicularTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasurePerpendicularTool.ts
@@ -39,6 +39,23 @@ MeasureDistanceToolModel
   public static override iconSpec = "icon-measure-perpendicular";
 
   protected _firstSurface?: Plane3dByOriginAndUnitNormal;
+
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasurePerpendicular.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasurePerpendicular.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasurePerpendicular.keyin",
+    );
+  }
+
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_MeasurePerpendicular;
   }

--- a/packages/itwin/measure-tools/src/tools/MeasureRadiusTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureRadiusTool.ts
@@ -35,6 +35,22 @@ MeasureRadiusToolModel
   // TODO: Change icon once UX team provides icon
   public static override iconSpec = "icon-three-points-circular-arc";
 
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureRadius.flyover"
+    );
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureRadius.description",
+    );
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString(
+      "MeasureTools:tools.MeasureRadius.keyin",
+    );
+  }
+
   protected override get feature(): Feature | undefined {
     return MeasureToolsFeatures.Tools_MeasureRadius;
   }


### PR DESCRIPTION
Override the default behavior of obtaining localized strings.
Default implementation resolves to `${toolNamespace}:tools.${toolId}.${localizedStringKey}` which doesn't match the structure of the localized string file of this package.