### PR TITLE
[One Click LCA] Update error message of job creation for unauthorized users

### DIFF
--- a/common/changes/@itwin/one-click-lca-react/oclca-rbac-error-message_2022-05-26-22-32.json
+++ b/common/changes/@itwin/one-click-lca-react/oclca-rbac-error-message_2022-05-26-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/one-click-lca-react",
+      "comment": "Update error message notification on unauthorized user triggering carbon calculation jobs. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/one-click-lca-react"
+}

--- a/common/changes/@itwin/one-click-lca-react/oclca-rbac-error-message_2022-06-03-00-47.json
+++ b/common/changes/@itwin/one-click-lca-react/oclca-rbac-error-message_2022-06-03-00-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/one-click-lca-react",
+      "comment": "Fix name typo in description",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/one-click-lca-react"
+}

--- a/packages/itwin/one-click-lca-widget/README.md
+++ b/packages/itwin/one-click-lca-widget/README.md
@@ -2,7 +2,7 @@
 
 Copyright © Bentley Systems, Incorporated. All rights reserved.
 
-The One Click CLA widget is a UI component for iTwin Viewer applications that simplifies how users (and developers) interface with the [Carbon Calculation One Click LCA APIs](https://developer.bentley.com/apis/carbon-calculation/overview/).
+The One Click LCA widget is a UI component for iTwin Viewer applications that simplifies how users (and developers) interface with the [Carbon Calculation One Click LCA APIs](https://developer.bentley.com/apis/carbon-calculation/overview/).
 The one-click-lca-react package provides a UiProvider class, `OneClickLCAProvider`, which can be passed into the `uiProviders` prop of the iTwin Viewer's `<Viewer />` component.
 
 ## Getting Started

--- a/packages/itwin/one-click-lca-widget/src/components/ExportModal.tsx
+++ b/packages/itwin/one-click-lca-widget/src/components/ExportModal.tsx
@@ -125,16 +125,17 @@ const ExportModal = (props: ExportProps) => {
             pinStatus(jobCreated?.job);
           } else {
             setJobStatus(JobStatus.StatusEnum.Failed);
-            toaster.negative("Failed to create one click lca job. 😔")
+            toaster.negative("Failed to create one click lca job. 😔");
           }
         } catch (e) {
           setJobStatus(JobStatus.StatusEnum.Failed);
-          toaster.negative("You are not authorized to create carbon calculation jobs. Please contact project administrator.")
+          toaster.negative("You are not authorized to create carbon calculation jobs. Please contact project administrator.");
+          /* eslint-disable no-console */
           console.error(e);
         }
       } else {
         setJobStatus(JobStatus.StatusEnum.Failed);
-        toaster.negative("Failed to get retrieve reportId or token. 😔")
+        toaster.negative("Failed to get retrieve reportId or token. 😔");
       }
     },
     [props, pinStatus, oneClickLCAClientApi]
@@ -161,6 +162,7 @@ const ExportModal = (props: ExportProps) => {
         }
       } catch (err) {
         toaster.negative("Failed to sign in One Click LCA.");
+        /* eslint-disable no-console */
         console.error(err);
       }
       startSigningIn(false);
@@ -234,9 +236,9 @@ const ExportModal = (props: ExportProps) => {
         default:
           return (
             <div className="oclca-progress-radial-container">
-              <Text>Invalid Job Status 😔</Text>
+              <Text>Invalid Job Status <span role="img" aria-label="sad">😔</span></Text>
             </div>
-          )
+          );
       }
     },
     []
@@ -246,7 +248,8 @@ const ExportModal = (props: ExportProps) => {
     if (props.isOpen && isSignedIn && cache?.token) {
       runJob(cache.token).catch((err) => {
         setJobStatus(JobStatus.StatusEnum.Failed);
-        toaster.negative("Error occurs while running the job. 😔")
+        toaster.negative("Error occurs while running the job. 😔");
+        /* eslint-disable no-console */
         console.error(err);
       });
     }

--- a/packages/itwin/one-click-lca-widget/src/components/ExportModal.tsx
+++ b/packages/itwin/one-click-lca-widget/src/components/ExportModal.tsx
@@ -19,6 +19,7 @@ import {
   ProgressLinear,
   ProgressRadial,
   Text,
+  toaster,
 } from "@itwin/itwinui-react";
 import {
   SvgVisibilityHide,
@@ -97,7 +98,8 @@ const ExportModal = (props: ExportProps) => {
             }
             setJobStatus(currentJobStatus.job?.status);
           } else {
-            throw new Error("failed to get job status");
+            setJobStatus(JobStatus.StatusEnum.Failed);
+            toaster.negative("Failed to get job status. 😔");
           }
         }
       }, PIN_INTERVAL);
@@ -122,13 +124,17 @@ const ExportModal = (props: ExportProps) => {
           if (jobCreated?.job?.id) {
             pinStatus(jobCreated?.job);
           } else {
-            throw new Error("Failed to create job");
+            setJobStatus(JobStatus.StatusEnum.Failed);
+            toaster.negative("Failed to create one click lca job. 😔")
           }
         } catch (e) {
-          throw new Error(`Failed to create one click lca job.${e}`);
+          setJobStatus(JobStatus.StatusEnum.Failed);
+          toaster.negative("You are not authorized to create carbon calculation jobs. Please contact project administrator.")
+          console.error(e);
         }
       } else {
-        throw new Error("No reportId or accessToken");
+        setJobStatus(JobStatus.StatusEnum.Failed);
+        toaster.negative("Failed to get retrieve reportId or token. 😔")
       }
     },
     [props, pinStatus, oneClickLCAClientApi]
@@ -138,19 +144,24 @@ const ExportModal = (props: ExportProps) => {
     async (e) => {
       e.preventDefault();
       startSigningIn(true);
-      const result = await oneClickLCAClientApi.getOneclicklcaAccessToken(
-        email,
-        password
-      );
-      if (result && result.access_token && result.expires_in) {
-        cacheToken({
-          token: result.access_token,
-          exp: Date.now() + result.expires_in * MILI_SECONDS,
-        });
-        resetSignin();
-        setIsSignedIn(true);
-      } else {
-        showSigninError(true);
+      try {
+        const result = await oneClickLCAClientApi.getOneclicklcaAccessToken(
+          email,
+          password
+        );
+        if (result && result.access_token && result.expires_in) {
+          cacheToken({
+            token: result.access_token,
+            exp: Date.now() + result.expires_in * MILI_SECONDS,
+          });
+          resetSignin();
+          setIsSignedIn(true);
+        } else {
+          showSigninError(true);
+        }
+      } catch (err) {
+        toaster.negative("Failed to sign in One Click LCA.");
+        console.error(err);
       }
       startSigningIn(false);
     },
@@ -221,7 +232,11 @@ const ExportModal = (props: ExportProps) => {
             </div>
           );
         default:
-          throw new Error(`Job status is invalid ${status}`);
+          return (
+            <div className="oclca-progress-radial-container">
+              <Text>Invalid Job Status 😔</Text>
+            </div>
+          )
       }
     },
     []
@@ -230,7 +245,9 @@ const ExportModal = (props: ExportProps) => {
   useEffect(() => {
     if (props.isOpen && isSignedIn && cache?.token) {
       runJob(cache.token).catch((err) => {
-        throw new Error(err);
+        setJobStatus(JobStatus.StatusEnum.Failed);
+        toaster.negative("Error occurs while running the job. 😔")
+        console.error(err);
       });
     }
   }, [props.isOpen, isSignedIn, cache, runJob]);

--- a/packages/itwin/one-click-lca-widget/src/components/Reports.tsx
+++ b/packages/itwin/one-click-lca-widget/src/components/Reports.tsx
@@ -6,8 +6,8 @@ import React, { useEffect, useMemo, useState } from "react";
 import { SearchBox } from "@itwin/core-react";
 import { IModelApp } from "@itwin/core-frontend";
 import { useActiveIModelConnection } from "@itwin/appui-react";
-import { Button, Table } from "@itwin/itwinui-react";
-import type { Report} from "@itwin/insights-client";
+import { Button, Table, toaster } from "@itwin/itwinui-react";
+import type { Report } from "@itwin/insights-client";
 import { ReportingClient } from "@itwin/insights-client";
 import { WidgetHeader } from "./utils";
 import ExportModal from "./ExportModal";
@@ -106,11 +106,14 @@ const Reports = () => {
             }
           })
           .catch((err) => {
-            throw new Error(err);
+            setIsLoading(false);
+            toaster.negative("You are not authorized to get reports for this projects. Please contact project administrator.")
+            console.error(err);
           });
       })
       .catch((err) => {
-        throw new Error(err);
+        toaster.negative("You are not authorized to use this system.")
+        console.error(err);
       });
   }, [projectId, reportingClientApi]);
 

--- a/packages/itwin/one-click-lca-widget/src/components/Reports.tsx
+++ b/packages/itwin/one-click-lca-widget/src/components/Reports.tsx
@@ -107,12 +107,14 @@ const Reports = () => {
           })
           .catch((err) => {
             setIsLoading(false);
-            toaster.negative("You are not authorized to get reports for this projects. Please contact project administrator.")
+            toaster.negative("You are not authorized to get reports for this projects. Please contact project administrator.");
+            /* eslint-disable no-console */
             console.error(err);
           });
       })
       .catch((err) => {
-        toaster.negative("You are not authorized to use this system.")
+        toaster.negative("You are not authorized to use this system.");
+        /* eslint-disable no-console */
         console.error(err);
       });
   }, [projectId, reportingClientApi]);


### PR DESCRIPTION
Before, if an unauthorized user tries to trigger a carbon calculation job, the export modal will show a spinner hanging forever and the error message is showed in console. To make it more user friendly, we provide a toaster notification with detailed information and show the job failed in the modal.

Also updated error message and notification for other types of failures like signing in, getting job status etc.

![image](https://user-images.githubusercontent.com/88792140/170589762-0e1c2d38-7dcc-4b14-aedc-b57ca681a04e.png)
