### PR TITLE
[Grouping & Mapping] Extraction toggle changes

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/extractionenabletogglelabel_2022-06-06-11-48.json
+++ b/common/changes/@itwin/grouping-mapping-widget/extractionenabletogglelabel_2022-06-06-11-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Changed the extraction enable toggle label",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/MappingAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/MappingAction.tsx
@@ -102,8 +102,8 @@ const MappingAction = ({ iModelId, mapping, returnFn }: MappingActionProps) => {
           <ToggleSwitch
             id='extractionEnabled'
             name='extractionEnabled'
-            label='Extraction enabled'
-            labelPosition="left"
+            label='Extract data from iModel'
+            labelPosition="right"
             checked={values.extractionEnabled}
             onChange={(event) => {
               setValues({ ...values, extractionEnabled: event.currentTarget.checked });


### PR DESCRIPTION
Changed the label and it's position for the extraction toggle.

![extractiontoggle](https://user-images.githubusercontent.com/15067512/172155141-975aa007-db57-42c5-8fb1-432cfc6fd87b.png)
