### PR TITLE
[ReportsConfig] Fixed flaky tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@
 /packages/itwin/reports-config-widget  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
 /common/changes/@itwin/reports-config-widget-react  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
 
-/packages/itwin/breakdown-trees  @itwin/viewer-components-reviewers @JValiunas @MeghaCBorty @DanishMehmood-bit
-/common/changes/@itwin/breakdown-trees-react  @itwin/viewer-components-reviewers @JValiunas @MeghaCBorty @DanishMehmood-bit
+/packages/itwin/breakdown-trees  @itwin/viewer-components-reviewers @JValiunas @DanishMehmood-bit
+/common/changes/@itwin/breakdown-trees-react  @itwin/viewer-components-reviewers @JValiunas @DanishMehmood-bit
 
 /packages/itwin/geo-tools  @itwin/viewer-components-reviewers @mdastous-bentley
 /common/changes/@itwin/geo-tools-react  @itwin/viewer-components-reviewers @mdastous-bentley

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /common/changes/@itwin/one-click-lca-react  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
 
 /packages/itwin/reports-config-widget  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
-/common/changes/@itwin/reports-config-widget  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
+/common/changes/@itwin/reports-config-widget-react  @itwin/viewer-components-reviewers @arnobmallickbsw @bingjiez @Guillar1
 
 /packages/itwin/breakdown-trees  @itwin/viewer-components-reviewers @JValiunas @MeghaCBorty @DanishMehmood-bit
 /common/changes/@itwin/breakdown-trees-react  @itwin/viewer-components-reviewers @JValiunas @MeghaCBorty @DanishMehmood-bit

--- a/common/changes/@itwin/reports-config-widget-react/rcw-flaky-tests-fix_2022-06-15-17-48.json
+++ b/common/changes/@itwin/reports-config-widget-react/rcw-flaky-tests-fix_2022-06-15-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/reports-config-widget-react",
+      "comment": "Fixed some flaky unit tests",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/reports-config-widget-react"
+}

--- a/packages/itwin/reports-config-widget/src/test/ReportMappings.test.tsx
+++ b/packages/itwin/reports-config-widget/src/test/ReportMappings.test.tsx
@@ -60,9 +60,9 @@ const mockIModelsResponse = [
   {
     iModel: {
       id: mockIModelId1,
-      displayName: faker.random.alpha(10),
-      name: faker.random.alpha(10),
-      description: faker.random.words(10),
+      displayName: "rAnDoMdIsPlAynAmE1",
+      name: "rAnDomName1",
+      description: "rAnDoMDeScRiPtIoN1",
       createdDateTime: "2021-10-04T22:13:50.397Z",
       state: IModelState.Initialized,
       projectId: mockITwinId,
@@ -83,9 +83,9 @@ const mockIModelsResponse = [
   {
     iModel: {
       id: mockIModelId2,
-      displayName: faker.random.alpha(10),
-      name: faker.random.alpha(10),
-      description: faker.random.words(10),
+      displayName: "rAnDoMdIsPlAynAmE2",
+      name: "rAnDomName2",
+      description: "rAnDoMDeScRiPtIoN2",
       createdDateTime: "2021-10-04T22:13:50.397Z",
       state: IModelState.Initialized,
       projectId: mockITwinId,
@@ -121,8 +121,8 @@ const mockProjectIModels = {
 
 const mockReport: Report = {
   id: mockReportId,
-  displayName: faker.random.alpha(10),
-  description: faker.random.words(10),
+  displayName: "mOcKRePoRt1",
+  description: "mOcKRePoRtDeScRiPtIoN1",
   deleted: false,
   _links: {
     project: {
@@ -180,11 +180,11 @@ const mockMappingsFactory = (
   mockReportMappings: ReportMappingCollection
 ): [MappingSingle[], RequestHandler[]] => {
   const mockMappings: MappingSingle[] = mockReportMappings.mappings!.map(
-    (mapping) => ({
+    (mapping, index) => ({
       mapping: {
         id: mapping.mappingId,
-        mappingName: faker.random.alpha(10),
-        description: faker.random.words(10),
+        mappingName: `mOcKMaPpIngNaMe${index}`,
+        description: `mOcKmApPInGDeScRiPtIoN${index}`,
         extractionEnabled: false,
         createdOn: "",
         createdBy: "",
@@ -509,13 +509,14 @@ describe("Report Mappings View", () => {
 
     // Adding an extra unmapped mapping.
     const extraMappingId = faker.datatype.uuid();
-    const extraMappingName = faker.random.alpha(10);
+    const extraMappingName = "mOcKNaMeExTrA";
+    const extraMappingDescription = "mOcKDeScRiPtIoNeXtRa";
 
     mockMappings.push({
       mapping: {
         id: extraMappingId,
         mappingName: extraMappingName,
-        description: faker.random.words(10),
+        description: extraMappingDescription,
         extractionEnabled: false,
         createdOn: "",
         createdBy: "",

--- a/packages/itwin/reports-config-widget/src/test/Reports.test.tsx
+++ b/packages/itwin/reports-config-widget/src/test/Reports.test.tsx
@@ -42,10 +42,10 @@ const mockIModelId = faker.datatype.uuid();
 const reportsFactory = (): ReportCollection => ({
   reports: Array.from(
     { length: faker.datatype.number({ min: 3, max: 5 }) },
-    () => ({
+    (_, index) => ({
       id: `${faker.datatype.uuid()}`,
-      displayName: faker.random.alpha(10),
-      description: faker.random.words(10),
+      displayName: `mOcKRePoRT${index}`,
+      description: `mOcKRePoRTDeScRiPtIoN${index}`,
     })
   ),
   _links: {


### PR DESCRIPTION
faker.random.words(), in rare situations, was using words that the tests would query for. Making them fail.