### PR TITLE
[Grouping&Mapping] query keywords no longer listens to selection and env fix

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/query-keywords_2022-07-01-23-01.json
+++ b/common/changes/@itwin/grouping-mapping-widget/query-keywords_2022-07-01-23-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Query Keywords by default no longer takes selection when no keywords are applied",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/common/changes/@itwin/grouping-mapping-widget/query-keywords_2022-07-01-23-02.json
+++ b/common/changes/@itwin/grouping-mapping-widget/query-keywords_2022-07-01-23-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Fixed incorrect prefix being applied on first render",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMapping.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMapping.tsx
@@ -9,7 +9,7 @@ import { IModelApp } from "@itwin/core-frontend";
 import type { IMappingClient } from "../IMappingClient";
 import type { ClientPrefix, GetAccessTokenFn, GroupingMappingApiConfig } from "./context/GroupingApiConfigContext";
 import { GroupingMappingApiConfigContext } from "./context/GroupingApiConfigContext";
-import { createDefaultMappingClient, createMappingClient, MappingClientContext } from "./context/MappingClientContext";
+import { createMappingClient, MappingClientContext } from "./context/MappingClientContext";
 
 export interface GroupingMappingProps {
   /**
@@ -41,9 +41,8 @@ const GroupingMapping = ({ getAccessToken, prefix, client }: GroupingMappingProp
     setApiConfig(() => ({ prefix, getAccessToken: getAccessToken ?? authorizationClientGetAccessToken }));
   }, [getAccessToken, prefix]);
 
-
   useEffect(() => {
-    setMappingClient(createMappingClient(clientProp))
+    setMappingClient(createMappingClient(clientProp));
   }, [clientProp]);
 
   return (

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMapping.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMapping.tsx
@@ -30,7 +30,7 @@ export interface GroupingMappingProps {
 const authorizationClientGetAccessToken = (async () => (await IModelApp.authorizationClient?.getAccessToken() ?? ""));
 
 const GroupingMapping = ({ getAccessToken, prefix, client }: GroupingMappingProps) => {
-  const [mappingClient, setMappingClient] = useState<IMappingClient>(createDefaultMappingClient());
+  const [mappingClient, setMappingClient] = useState<IMappingClient | undefined>();
   const [apiConfig, setApiConfig] = useState<GroupingMappingApiConfig>({
     getAccessToken: getAccessToken ?? authorizationClientGetAccessToken,
     prefix,
@@ -53,11 +53,11 @@ const GroupingMapping = ({ getAccessToken, prefix, client }: GroupingMappingProp
     <GroupingMappingApiConfigContext.Provider
       value={apiConfig}
     >
-      <MappingClientContext.Provider value={mappingClient}>
+      {mappingClient ? <MappingClientContext.Provider value={mappingClient}>
         <div className='group-mapping-container'>
           <Mappings />
         </div>
-      </MappingClientContext.Provider>
+      </MappingClientContext.Provider> : undefined}
     </GroupingMappingApiConfigContext.Provider>
   );
 };

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/context/MappingClientContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/context/MappingClientContext.ts
@@ -19,6 +19,12 @@ export const createDefaultMappingClient = (prefix?: ClientPrefix): IMappingClien
   return new ReportingClient(url);
 };
 
+export const createMappingClient = (clientProp: IMappingClient | ClientPrefix) => {
+  if (undefined === clientProp || typeof clientProp === "string") {
+    return createDefaultMappingClient(clientProp as ClientPrefix);
+  }
+  return clientProp;
+}
 export const MappingClientContext = createContext<IMappingClient>(createDefaultMappingClient());
 
 export const useMappingClient = () => {

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/context/MappingClientContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/context/MappingClientContext.ts
@@ -24,7 +24,7 @@ export const createMappingClient = (clientProp: IMappingClient | ClientPrefix) =
     return createDefaultMappingClient(clientProp as ClientPrefix);
   }
   return clientProp;
-}
+};
 export const MappingClientContext = createContext<IMappingClient>(createDefaultMappingClient());
 
 export const useMappingClient = () => {


### PR DESCRIPTION
Originally, by default, if no query was being generated by either query generation methods it would take the selected element class and generate a simple query off of that. This made it confusing when generating a query using Query Keywords since it wasn't obvious sometimes which method it was using. The other method was also called Selection, so it'd be better to keep any selection event to that method. 

Also fixed a bug, where no matter the prefix, it would always hit prod first.