### PR TITLE
Property grid navigation

### DIFF
--- a/common/changes/@itwin/property-grid-react/Property-grid-navigation_2022-07-07-20-19.json
+++ b/common/changes/@itwin/property-grid-react/Property-grid-navigation_2022-07-07-20-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Instead of hiding the down navigation button, show it disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -222,26 +222,28 @@ export const MultiElementPropertyGrid = (props: PropertyGridProps) => {
               enableAncestorNavigation
                 ?
                 <>
-                  {hasParent &&
-                    <IconButton
-                      size="small"
-                      styleType="borderless"
-                      title={PropertyGridManager.translate("tools.navigateUpTooltip")}
-                      onClick={onNavigateUp}
-                      tabIndex={0}
-                    >
-                      <SvgArrowUp />
-                    </IconButton>
-                  }
-                  {ancestorKeys.length > 1 &&
-                    <IconButton
-                      size="small"
-                      styleType="borderless"
-                      title={PropertyGridManager.translate("tools.navigateDownTooltip")}
-                      onClick={onNavigateDown}
-                    >
-                      <SvgArrowDown />
-                    </IconButton>
+                  {(hasParent || ancestorKeys.length > 1) &&
+                    <>
+                      <IconButton
+                        size="small"
+                        styleType="borderless"
+                        title={PropertyGridManager.translate("tools.navigateUpTooltip")}
+                        onClick={onNavigateUp}
+                        tabIndex={0}
+                        disabled={!hasParent}
+                      >
+                        <SvgArrowUp />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        styleType="borderless"
+                        title={PropertyGridManager.translate("tools.navigateDownTooltip")}
+                        onClick={onNavigateDown}
+                        disabled={ancestorKeys.length < 2}
+                      >
+                        <SvgArrowDown />
+                      </IconButton>
+                    </>
                   }
                 </>
                 : undefined


### PR DESCRIPTION
Instead of hiding the down navigation button when not available, it was decided to disable the button instead.

Work Item:
https://bentleycs.visualstudio.com/beconnect/_workitems/edit/936785

![image](https://user-images.githubusercontent.com/17307464/177865136-7ccfd08b-9d24-43ef-8f74-9cd52bb2fd96.png)
