### PR TITLE
Bugfix/measure location dynamic flag

### DIFF
--- a/common/changes/@itwin/measure-tools-react/bugfix-measureLocationDynamicFlag_2022-07-19-23-51.json
+++ b/common/changes/@itwin/measure-tools-react/bugfix-measureLocationDynamicFlag_2022-07-19-23-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Fix obtaining the initial tool settings value. onPostInstall is called after the tool settings is created. Ensure we only notify user once if the iModel is not geolocated. Found a problem where we would output a message on each mouse motion (using dynamic measurement) which would clutter the whole screen.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}


### PR DESCRIPTION
### Fixes in MeasureLocationTool:
- Retrieve the initial tool setting value in onInstall rather than onPostInstall since the latter is called after the tool settings ui is created.
- Add a flag to notify the user once that the current iModel is not geolocated. Currently, using the dynamic measurement with an iModel without geolocation will generate a large number of messages that would clutter the whole screen.