### PR TITLE
Persist the show/hide null values toggle per user instead of per iModel or iTwin.

### DIFF
--- a/common/changes/@itwin/property-grid-react/persist-show-hide-null-per-user_2022-07-22-16-49.json
+++ b/common/changes/@itwin/property-grid-react/persist-show-hide-null-per-user_2022-07-22-16-49.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/property-grid-react",
       "comment": "Persist show/hide null value toggle per user and not per iTwin/iModel",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@itwin/property-grid-react"

--- a/common/changes/@itwin/property-grid-react/persist-show-hide-null-per-user_2022-07-22-16-49.json
+++ b/common/changes/@itwin/property-grid-react/persist-show-hide-null-per-user_2022-07-22-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Persist show/hide null value toggle per user and not per iTwin/iModel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/api/ShowNullValuesPreferenceClient.ts
+++ b/packages/itwin/property-grid/src/api/ShowNullValuesPreferenceClient.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import { IModelApp } from "@itwin/core-frontend";
 import { Logger } from "@itwin/core-bentley";
-import { UiFramework } from "@itwin/appui-react";
 
 const PROPERTY_GRID_NAMESPACE = "PropertyGridPreferences";
 const PROPERTY_GRID_SHOWNULL_KEY = "showNullValues";
@@ -13,18 +12,13 @@ const LOGGER_CATEGORY = "PropertyGrid";
 // Get showNullValues toggle from UserPreferences (corresponds to hide / show empty fields)
 export const getShowNullValuesPreference = async () => {
   const userPrefs = IModelApp.userPreferences;
-  if(userPrefs) {
+  if (userPrefs) {
     const accessToken = await IModelApp.getAccessToken();
-    const iModel = UiFramework.getIModelConnection();
-    const iTwinId = iModel?.iTwinId;
-    const iModelId = iModel?.iModelId;
     try {
       const showNullValuesRes = await userPrefs.get({
         accessToken,
         namespace: PROPERTY_GRID_NAMESPACE,
         key: PROPERTY_GRID_SHOWNULL_KEY,
-        iTwinId,
-        iModelId,
       });
       if (showNullValuesRes !== undefined) {
         return showNullValuesRes === "true";
@@ -42,19 +36,14 @@ export const getShowNullValuesPreference = async () => {
 // Save showNullValues toggle to UserPreferences (corresponds to hide / show empty fields)
 export const saveShowNullValuesPreference = async (value: boolean) => {
   const userPrefs = IModelApp.userPreferences;
-  if(userPrefs) {
+  if (userPrefs) {
     const accessToken = await IModelApp.getAccessToken();
-    const iModel = UiFramework.getIModelConnection();
-    const iTwinId = iModel?.iTwinId;
-    const iModelId = iModel?.iModelId;
     try {
       await userPrefs.save({
         accessToken,
         content: String(value),
         namespace: PROPERTY_GRID_NAMESPACE,
         key: PROPERTY_GRID_SHOWNULL_KEY,
-        iTwinId,
-        iModelId,
       });
     } catch (error) {
       Logger.logError(


### PR DESCRIPTION
Removed iTwinId and iModelId from calls to save/get null value toggle so that it is persisted for the user and not as a shared setting.