### PR TITLE
Bugfix/distance measurement ray3d

### DIFF
--- a/common/changes/@itwin/measure-tools-react/bugfix-distanceMeasurementRay3d_2022-08-03-03-43.json
+++ b/common/changes/@itwin/measure-tools-react/bugfix-distanceMeasurementRay3d_2022-08-03-03-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Temporarily fix a problem in core-geometry where Ray3d.createStartEnd captures the origin point instead of copying it. This solves an issue where the DistanceMeasurement's start point was being modified when it shouldn't have. (This will be fixed with PR #4012 on itwinjs-core.)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -307,7 +307,7 @@ export class DistanceMeasurement extends Measurement {
       return Point3d.createAdd2Scaled(this._startPoint, 0.5, this._endPoint, 0.5);
 
     const range = Range1d.createNull();
-    let ray = Ray3d.createStartEnd(this._startPoint, this._endPoint);
+    let ray = Ray3d.createStartEnd(this._startPoint.clone(), this._endPoint);
 
     // Either start/end or BOTH are outside the clip planes. If nothing intersects, don't bother displaying anything.
     if (!clipPlanes.hasIntersectionWithRay(ray, range))
@@ -322,7 +322,7 @@ export class DistanceMeasurement extends Measurement {
     }
 
     if (!endIn) {
-      ray = Ray3d.createStartEnd(this._endPoint, this._startPoint, ray);
+      ray = Ray3d.createStartEnd(this._endPoint.clone(), this._startPoint);
       if (clipPlanes.hasIntersectionWithRay(ray, range))
         clampedEndPoint = ray.fractionToPoint(range.high);
     }


### PR DESCRIPTION
Temporarily fix a problem in core-geometry where Ray3d.createStartEnd captures the origin point instead of copying it. This solves an issue where the DistanceMeasurement's start point was being modified when it shouldn't have.
(This will eventually be fixed with [PR #4012 on itwinjs-core.](https://github.com/iTwin/itwinjs-core/pull/4012))