### PR TITLE
Taking ownership of `tree-widget-react`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,8 @@
 /packages/itwin/property-grid  @itwin/viewer-components-reviewers @JoeZman @aruniverse @diegopinate
 /common/changes/@itwin/property-grid-react  @itwin/viewer-components-reviewers @JoeZman @aruniverse @diegopinate
 
-/packages/itwin/tree-widget  @itwin/viewer-components-reviewers @JoeZman @diegopinate @aruniverse
-/common/changes/@itwin/tree-widget-react  @itwin/viewer-components-reviewers @JoeZman @diegopinate @aruniverse
+/packages/itwin/tree-widget  @itwin/viewer-components-reviewers @itwin/itwinjs-core-presentation
+/common/changes/@itwin/tree-widget-react  @itwin/viewer-components-reviewers @itwin/itwinjs-core-presentation
 
 /packages/itwin/measure-tools  @itwin/viewer-components-reviewers @simnorm @a-gagnon @bsy-nicholasw
 /common/changes/@itwin/measure-tools-react  @itwin/viewer-components-reviewers @simnorm @a-gagnon @bsy-nicholasw


### PR DESCRIPTION
@iTwin/itwinjs-core-presentation is taking development ownership of the `tree-widget-react` package.