### PR TITLE
Exposed contexts, hooks, and types

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/Mindaugas-expose-mapping-hooks-ctx_2023-01-13-08-15.json
+++ b/common/changes/@itwin/grouping-mapping-widget/Mindaugas-expose-mapping-hooks-ctx_2023-01-13-08-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Exposed MappingClient context, related hooks and types.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/common/changes/@itwin/grouping-mapping-widget/Mindaugas-expose-mapping-hooks-ctx_2023-01-13-08-16.json
+++ b/common/changes/@itwin/grouping-mapping-widget/Mindaugas-expose-mapping-hooks-ctx_2023-01-13-08-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Exposed GroupingMappingApiConfig context, related hooks and types.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/grouping-mapping-widget.ts
+++ b/packages/itwin/grouping-mapping-widget/src/grouping-mapping-widget.ts
@@ -6,8 +6,8 @@
 export * from "./widget/GroupingMappingWidget";
 
 /** Interfaces for providing custom MappingClient and API configuration */
-export { createDefaultMappingClient } from "./widget/components/context/MappingClientContext";
-export { ClientPrefix, GetAccessTokenFn } from "./widget/components/context/GroupingApiConfigContext";
+export { createDefaultMappingClient, createMappingClient, MappingClientContext, useMappingClient } from "./widget/components/context/MappingClientContext";
+export { ClientPrefix, GetAccessTokenFn, GroupingMappingApiConfig, GroupingMappingApiConfigContext, useGroupingMappingApiConfig } from "./widget/components/context/GroupingApiConfigContext";
 export * from "@itwin/insights-client";
 
 /** Internal components for custom UIs */


### PR DESCRIPTION
Everything related to `MappingClient` and `GroupingMappingApiConfig` contexts were exposed for better extensibility.