### PR TITLE
Removed redundant callback

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/group-cleanup_2023-02-24-13-47.json
+++ b/common/changes/@itwin/grouping-mapping-widget/group-cleanup_2023-02-24-13-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.tsx
@@ -207,7 +207,6 @@ export const Groupings = ({
       await showGroup(group);
       setHiddenGroupsIds(hiddenGroupsIds.filter((id) => id !== group.id));
     }
-
   };
 
   const refresh = useCallback(async () => {
@@ -242,19 +241,6 @@ export const Groupings = ({
     const allIds = await getHiliteIdsFromGroupsWrapper(groups);
     await zoomToElements(allIds);
   }, [setHiddenGroupsIds, groups, hideGroupsWrapper, getHiliteIdsFromGroupsWrapper]);
-
-  const toggleGroupColor = useCallback(
-    async (e: any) => {
-      if (e.target.checked) {
-        await visualizeGroupColorsWrapper(groups);
-        setShowGroupColor(true);
-      } else {
-        clearEmphasizedOverriddenElements();
-        setShowGroupColor(false);
-      }
-    },
-    [groups, visualizeGroupColorsWrapper, setShowGroupColor],
-  );
 
   return (
     <>
@@ -302,7 +288,7 @@ export const Groupings = ({
                 className='gmw-toggle'
                 disabled={isLoadingQuery}
                 checked={showGroupColor}
-                onChange={toggleGroupColor}
+                onChange={() => setShowGroupColor((b) => !b)}
               ></ToggleSwitch>
               <IconButton
                 title='Show All'

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
@@ -13,7 +13,7 @@ export interface GroupHilitedElements {
   groups: Group[];
   setGroups: (groups: Group[]) => void;
   setHiddenGroupsIds: (hiddenGroupIds: string[]) => void;
-  setShowGroupColor: (showGroupColor: boolean) => void;
+  setShowGroupColor: (showGroupColor: boolean | ((showGroupColor: boolean) => boolean)) => void;
 }
 
 export const GroupHilitedElementsContext = React.createContext<GroupHilitedElements>({


### PR DESCRIPTION
Removing a redundant callback that was not necessary. useEffect was already making a call to visualizeGroupColorsWrapper.