### PR TITLE
Tree Widget: Remove unused feature of filtering the tree by element ids

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree-widget-models-tree-remove-unused-filtering-by-element-ids_2023-03-09-13-02.json
+++ b/common/changes/@itwin/tree-widget-react/tree-widget-models-tree-remove-unused-filtering-by-element-ids_2023-03-09-13-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Models Tree: Remove unused feature of filtering the tree by element ids",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/Hierarchy.GroupedByClass.json
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/Hierarchy.GroupedByClass.json
@@ -266,7 +266,7 @@
               }
             }
           ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL ANDALSO (NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId))",
+          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
           "groupByClass": true,
           "groupByLabel": false
         }
@@ -300,7 +300,6 @@
               }
             }
           ],
-          "instanceFilter": "NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId)",
           "groupByClass": true,
           "groupByLabel": false
         }

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/Hierarchy.json
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/Hierarchy.json
@@ -266,7 +266,7 @@
               }
             }
           ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL ANDALSO (NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId))",
+          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -300,7 +300,6 @@
               }
             }
           ],
-          "instanceFilter": "NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId)",
           "groupByClass": false,
           "groupByLabel": false
         }

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -56,7 +56,6 @@ describe("ModelsTree", () => {
     const imodelMock = moq.Mock.ofType<IModelConnection>();
     const selectionManagerMock = moq.Mock.ofType<SelectionManager>();
     let presentationManagerMock: moq.IMock<PresentationManager>;
-    let rulesetVariablesManagerMock: moq.IMock<RulesetVariablesManager>;
 
     after(() => {
       Presentation.terminate();
@@ -81,7 +80,6 @@ describe("ModelsTree", () => {
 
       const mocks = mockPresentationManager();
       presentationManagerMock = mocks.presentationManager;
-      rulesetVariablesManagerMock = mocks.rulesetVariablesManager;
       Presentation.setPresentationManager(presentationManagerMock.object);
     });
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -28,7 +28,7 @@ import { createCategoryNode, createElementClassGroupingNode, createElementNode, 
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
-import type { PresentationManager, RulesetVariablesManager, SelectionManager } from "@itwin/presentation-frontend";
+import type { PresentationManager, SelectionManager } from "@itwin/presentation-frontend";
 import type { TestIModelBuilder } from "@itwin/presentation-testing";
 import type { CategoryProps, ElementProps, ModelProps, PhysicalElementProps, RelatedElementProps } from "@itwin/core-common";
 import type { ModelsVisibilityHandler } from "../../../components/trees/models-tree/ModelsVisibilityHandler";

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -24,6 +24,7 @@ import { ModelsTree, RULESET_MODELS, RULESET_MODELS_GROUPED_BY_CLASS } from "../
 import { ModelsTreeNodeType } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
 import { deepEquals, mockPresentationManager, TestUtils } from "../../TestUtils";
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createKey, createModelNode, createSubjectNode } from "../Common";
+
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
@@ -346,12 +347,6 @@ describe("ModelsTree", () => {
           await result.findByText("filtered-node");
 
           expect(spy).to.be.calledOnce;
-        });
-
-        it("filters nodes by element IDs", async () => {
-          const elementIds = ["0x123", "0x456"];
-          render(<ModelsTree {...sizeProps} iModel={imodelMock.object} modelsVisibilityHandler={visibilityHandlerMock.object} filteredElementIds={elementIds} />);
-          rulesetVariablesManagerMock.verify(async (x) => x.setId64s("filtered-element-ids", elementIds), moq.Times.once());
         });
       });
     });


### PR DESCRIPTION
The feature was `@alpha`, was unused and was causing issues with the hierarchy (the underlying issues will be fixed separately)