### PR TITLE
Tree widget: restore hide all button behavior

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree-widget-restore_hide_all_behavior_2023-03-23-14-30.json
+++ b/common/changes/@itwin/tree-widget-react/tree-widget-restore_hide_all_behavior_2023-03-23-14-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "'ModelsTree': Restored 'HideAll' button behavior to hide only models",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -151,16 +151,6 @@ function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
 function HideAllButton(props: ModelsTreeHeaderButtonProps) {
   const hideAll = async () => {
     props.viewport.changeModelDisplay(props.models.map((model) => model.id), false);
-    props.viewport.clearAlwaysDrawn();
-    if (props.viewport.iModel) {
-      await toggleAllCategories(
-        IModelApp.viewManager,
-        props.viewport.iModel,
-        false,
-        props.viewport,
-        false
-      );
-    }
     props.viewport.invalidateScene();
   };
 


### PR DESCRIPTION
https://github.com/iTwin/viewer-components-react/commit/0c77c4b965ff9b1211ba636d95ae273f26158b5a changed ShowAll and HideAll buttons behavior to toggle categories visibility alongside models. This works great for ShowAll button but in case of HideAll button it breaks this workflow:

* Open ModelsTree and hide all
* Toggle in the tree Models that you wan to be visible

Previous behavior would enable model and categories would be visible. After https://github.com/iTwin/viewer-components-react/commit/0c77c4b965ff9b1211ba636d95ae273f26158b5a categories are not visible and need to be enabled one by one.

This PR restores HideAll button to previous behavior to only hide models.