### PR TITLE
Tree widget: remove tree filtering when search is closed

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree_widget-search_fix_2023-03-24-07-50.json
+++ b/common/changes/@itwin/tree-widget-react/tree_widget-search_fix_2023-03-24-07-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Fixed tree filtering not being removed when search box is closed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/search-bar/SearchBar.tsx
+++ b/packages/itwin/tree-widget/src/components/search-bar/SearchBar.tsx
@@ -40,8 +40,6 @@ export interface SearchBarProps extends CommonProps {
   /** Filtering is cleared after everything's loaded */
   onFilterStart: (newFilter: string) => void;
   /** Filtering is cleared after everything's loaded */
-  onFilterCancel?: () => void;
-  /** Filtering is cleared after everything's loaded */
   onFilterClear?: () => void;
   /** Total number of results/entries */
   resultCount: number;
@@ -145,8 +143,7 @@ SearchBarState
               searchText={value}
               valueChangedDelay={valueChangedDelay}
               placeholder={placeholder}
-              onFilterCancel={this.props.onFilterCancel}
-              onFilterClear={this.props.onFilterClear}
+              onClear={this.props.onFilterClear}
               onFilterStart={this.props.onFilterStart}
               resultCount={this.props.resultCount}
               onIconClick={this._onToggleSearch}

--- a/packages/itwin/tree-widget/src/components/search-bar/SearchBox.tsx
+++ b/packages/itwin/tree-widget/src/components/search-bar/SearchBox.tsx
@@ -28,10 +28,6 @@ export interface SearchBoxProps extends CommonProps {
   onIconClick?: () => void;
   /** Filtering is cleared after everything's loaded */
   onFilterStart: (newFilter: string) => void;
-  /** Filtering is cleared after everything's loaded */
-  onFilterClear?: () => void;
-  /** Filtering is cleared after everything's loaded */
-  onFilterCancel?: () => void;
   /** Tells the component if parent component is still handling the filtering */
   filteringInProgress?: boolean;
   /** Total number of results/entries */

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
@@ -62,7 +62,6 @@ function CategoriesTreeComponentImpl(props: CategoriesTreeProps & { iModel: IMod
         placeholder={TreeWidget.translate("search")}
         title={TreeWidget.translate("searchForSomething")}
         filteringInProgress={searchOptions.isFiltering}
-        onFilterCancel={searchOptions.onFilterCancel}
         onFilterClear={searchOptions.onFilterCancel}
         onFilterStart={searchOptions.onFilterStart}
         onSelectedChanged={searchOptions.onResultSelectedChanged}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -81,7 +81,6 @@ function ModelsTreeComponentImpl(props: ModelTreeProps & { iModel: IModelConnect
         placeholder={TreeWidget.translate("search")}
         title={TreeWidget.translate("searchForSomething")}
         filteringInProgress={searchOptions.isFiltering}
-        onFilterCancel={searchOptions.onFilterCancel}
         onFilterClear={searchOptions.onFilterCancel}
         onFilterStart={searchOptions.onFilterStart}
         onSelectedChanged={searchOptions.onResultSelectedChanged}


### PR DESCRIPTION
`onFilterCancel` and `onFilterClear` callbacks were not used in `SearchBox` component. Removed them and switched to using  `onClear` callback.