### PR TITLE
Tree-Widget: Rework how trees are added to widget

### DIFF
--- a/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
+++ b/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "Reworked how trees are provided to the widget. Instaed of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
+      "comment": "**BREAKING:** Reworked how trees are provided to the widget. Instaed of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
+++ b/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING:** Reworked how trees are provided to the widget. Instaed of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
+      "comment": "**BREAKING:** Reworked how trees are provided to the widget. Instead of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
+++ b/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Reworked how trees are provided to the widget. Instaed of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1136,6 +1136,7 @@ importers:
       '@itwin/presentation-frontend': 3.7.0
       '@itwin/presentation-testing': 4.0.0-dev.31
       '@itwin/webgl-compatibility': 3.7.0
+      '@rushstack/eslint-patch': 1.2.0
       '@testing-library/react': ^12.0.0
       '@testing-library/react-hooks': ^7.0.2
       '@types/chai': 4.3.1
@@ -1206,6 +1207,7 @@ importers:
       '@itwin/presentation-frontend': 3.7.0_3df2ddb6f779a099b187706b89336d9d
       '@itwin/presentation-testing': 4.0.0-dev.31_9563cb0765733f42f97f9cf59bde3c37
       '@itwin/webgl-compatibility': 3.7.0
+      '@rushstack/eslint-patch': 1.2.0
       '@testing-library/react': 12.1.5_react-dom@17.0.2+react@17.0.2
       '@testing-library/react-hooks': 7.0.2_react-dom@17.0.2+react@17.0.2
       '@types/chai': 4.3.1
@@ -8602,7 +8604,6 @@ packages:
 
   /@rushstack/eslint-patch/1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
-    dev: false
 
   /@rushstack/node-core-library/3.45.5:
     resolution: {integrity: sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==}

--- a/packages/itwin/tree-widget/.eslintrc.js
+++ b/packages/itwin/tree-widget/.eslintrc.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+require("@rushstack/eslint-patch/modern-module-resolution");
+
+module.exports = {
+  plugins: ["@itwin"],
+  extends: "plugin:@itwin/ui",
+  rules: {
+    "@itwin/no-internal": ["error"],
+    "@typescript-eslint/no-floating-promises": [
+      "error",
+      { "ignoreIIFE": true }
+    ]
+  },
+};

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -71,6 +71,7 @@
     "@itwin/presentation-frontend": "3.7.0",
     "@itwin/presentation-testing": "4.0.0-dev.31",
     "@itwin/webgl-compatibility": "3.7.0",
+    "@rushstack/eslint-patch": "1.2.0",
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/chai": "4.3.1",
@@ -114,14 +115,6 @@
     "react-dom": "^17.0.2"
   },
   "eslintConfig": {
-    "plugins": ["@itwin"],
-    "extends": ["plugin:@itwin/ui"],
-    "rules": {
-      "@itwin/no-internal": ["error"],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-        { "ignoreIIFE": true }
-      ]
-    }
+    "extends": [".eslintrc.js"]
   }
 }

--- a/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
@@ -7,18 +7,22 @@ import "./TreeWidgetComponent.scss";
 import * as React from "react";
 import { SelectableContent, SelectableContentDefinition } from "@itwin/components-react";
 
+export interface TreeDefinition {
+  id: string;
+  getLabel: () => string;
+  render: () => React.ReactNode;
+}
+
 interface TreeWidgetComponentProps {
-  trees?: SelectableContentDefinition[];
+  trees: TreeDefinition[];
 }
 
 export function TreeWidgetComponent(props: TreeWidgetComponentProps) {
-  const trees: SelectableContentDefinition[] = [];
-
-  if (props.trees && props.trees.length !== 0) {
-    for (const entry of props.trees) {
-      trees.push(entry);
-    }
-  }
+  const trees: SelectableContentDefinition[] = props.trees.map((tree) => ({
+    id: tree.id,
+    label: tree.getLabel(),
+    render: tree.render,
+  }));
 
   return (
     <div className="tree-widget-visibility-widget">

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
@@ -52,7 +52,8 @@ export function CategoriesTreeComponent(props: CategoriesTreeComponentProps) {
 CategoriesTreeComponent.ShowAllButton = ShowAllButton;
 CategoriesTreeComponent.HideAllButton = HideAllButton;
 CategoriesTreeComponent.InvertButton = InvertButton;
-CategoriesTreeComponent.Id = "categories-tree";
+CategoriesTreeComponent.id = "categories-tree";
+CategoriesTreeComponent.getLabel = () => TreeWidget.translate("categories");
 
 function CategoriesTreeComponentImpl(props: CategoriesTreeComponentProps & { iModel: IModelConnection, viewport: ScreenViewport }) {
   const categories = useCategories(IModelApp.viewManager, props.iModel, props.viewport);

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -54,7 +54,8 @@ ModelsTreeComponent.HideAllButton = HideAllButton;
 ModelsTreeComponent.InvertButton = InvertButton;
 ModelsTreeComponent.View2DButton = View2DButton;
 ModelsTreeComponent.View3DButton = View3DButton;
-ModelsTreeComponent.Id = "models-tree";
+ModelsTreeComponent.id = "models-tree";
+ModelsTreeComponent.getLabel = () => TreeWidget.translate("models");
 
 function ModelsTreeComponentImpl(props: ModelTreeComponentProps & { iModel: IModelConnection, viewport: ScreenViewport }) {
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/377

Refactored `TreeWidgetUiItemsProvider` to have single config property for controlling trees shown in widget instead of having multiple properties hiding/adding trees.

Fixed eslint.