### PR TITLE
Make property grid column resizer more movable

### DIFF
--- a/common/changes/@itwin/property-grid-react/Make_property_grid_column_resizer_more_movable_2023-04-17-07-15.json
+++ b/common/changes/@itwin/property-grid-react/Make_property_grid_column_resizer_more_movable_2023-04-17-07-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Make property grid column resizer more movable",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/README.md
+++ b/packages/itwin/property-grid/README.md
@@ -37,16 +37,28 @@ interface PropertyGridProps {
   isOrientationFixed?: boolean;
   enableFavoriteProperties?: boolean;
   favoritePropertiesScope?: FavoritePropertiesScope;
+  customOnDataChanged?: (
+    dataProvider: IPresentationPropertyDataProvider
+  ) => Promise<void>;
+  actionButtonRenderers?: ActionButtonRenderer[];
+  actionButtonsWidth?: number;
   enableCopyingPropertyText?: boolean;
   enableNullValueToggle?: boolean;
+  enableAncestorNavigation?: boolean;
+  persistNullValueToggle?: boolean;
+  defaultPanelLocation?: StagePanelLocation;
+  defaultPanelSection?: StagePanelSection;
+  defaultPanelWidgetPriority?: number;
   enablePropertyGroupNesting?: boolean;
   additionalContextMenuOptions?: ContextMenuItemInfo[];
+  defaultContextMenuOptions?: Map<PropertyGridDefaultContextMenuKey, Partial<ContextMenuItemInfo>>;
   rulesetId?: string;
   rootClassName?: string;
   dataProvider?: PresentationPropertyDataProvider;
-  onInfoButton?: () => void;
   onBackButton?: () => void;
   disableUnifiedSelection?: boolean;
+  autoExpandChildCategories?: boolean;
+  headerContent?: JSX.Element;
 }
 ```
 

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -179,7 +179,7 @@ export const FilteringPropertyGrid = (
         {...props}
         minLabelWidth={10}
         minValueWidth={10}
-        actionButtonWidth={props.actionButtonWidth ?? props.actionButtonRenderers ? 90 : 0}
+        actionButtonWidth={props.actionButtonWidth ?? props.actionButtonRenderers ? undefined : 0}
         dataProvider={autoExpandingFilteringDataProvider}
       />
     </>

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -177,6 +177,9 @@ export const FilteringPropertyGrid = (
     <>
       <VirtualizedPropertyGridWithDataProvider
         {...props}
+        minLabelWidth={10}
+        minValueWidth={10}
+        actionButtonWidth={props.actionButtonWidth ?? props.actionButtonRenderers ? 90 : 0}
         dataProvider={autoExpandingFilteringDataProvider}
       />
     </>

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -47,6 +47,7 @@ export const PropertyGrid = ({
   favoritePropertiesScope,
   customOnDataChanged,
   actionButtonRenderers,
+  actionButtonsWidth,
   enableCopyingPropertyText,
   enableNullValueToggle,
   persistNullValueToggle,
@@ -424,6 +425,7 @@ export const PropertyGrid = ({
             isPropertySelectionEnabled={true}
             onPropertyContextMenu={onPropertyContextMenu}
             actionButtonRenderers={actionButtonRenderers}
+            actionButtonWidth={actionButtonsWidth}
             width={width}
             height={height}
             autoExpandChildCategories={autoExpandChildCategories}
@@ -438,6 +440,7 @@ export const PropertyGrid = ({
             isPropertySelectionEnabled={true}
             onPropertyContextMenu={onPropertyContextMenu}
             actionButtonRenderers={actionButtonRenderers}
+            actionButtonWidth={actionButtonsWidth}
             width={width}
             height={height}
             autoExpandChildCategories={autoExpandChildCategories}

--- a/packages/itwin/property-grid/src/types.ts
+++ b/packages/itwin/property-grid/src/types.ts
@@ -41,6 +41,7 @@ export interface PropertyGridProps {
     dataProvider: IPresentationPropertyDataProvider
   ) => Promise<void>;
   actionButtonRenderers?: ActionButtonRenderer[];
+  actionButtonsWidth?: number;
   enableCopyingPropertyText?: boolean;
   enableNullValueToggle?: boolean;
   enableAncestorNavigation?: boolean;


### PR DESCRIPTION
closes iTwin/presentation#116