### PR TITLE
Replace removed variable $uicore-button-focus-boxshadow in MapLayer's scss files

### DIFF
--- a/common/changes/@itwin/map-layers/fix-map-layers-scss_2023-04-18-21-52.json
+++ b/common/changes/@itwin/map-layers/fix-map-layers-scss_2023-04-18-21-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "remove refs of $uicore-button-focus-boxshadow in maplayers scss files",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
@@ -268,7 +268,7 @@ $default-font-size: --iui-font-size-1;
 
     &:focus {
       outline: none;
-      box-shadow: $uicore-button-focus-boxshadow;
+      box-shadow: rgba(var(--iui-color-border-accent), var(--iui-opacity-4)) 0px 0px 0px 2px;
     }
   }
 }

--- a/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.scss
@@ -93,7 +93,7 @@ $default-font-size: --iui-font-size-1;
 
     &:focus {
       outline: none;
-      box-shadow: $uicore-button-focus-boxshadow;
+      box-shadow: rgba(var(--iui-color-border-accent), var(--iui-opacity-4)) 0px 0px 0px 2px;
     }
   }
 

--- a/packages/itwin/map-layers/src/ui/widget/SubLayersTree.scss
+++ b/packages/itwin/map-layers/src/ui/widget/SubLayersTree.scss
@@ -13,6 +13,7 @@
   .core-tree-node {
     >.contents {
       padding-left: 31px;
+
       >.core-image-checkbox {
         top: 5px;
       }
@@ -49,7 +50,7 @@
       }
 
       &:focus {
-        box-shadow: $uicore-button-focus-boxshadow;
+        box-shadow: rgba(var(--iui-color-border-accent), var(--iui-opacity-4)) 0px 0px 0px 2px;
         outline: none;
       }
     }


### PR DESCRIPTION
Webpack is throwing errors compiling @itwin/map-layers due to the usage of $uicore-button-focus-boxshadow which no longer exists.

I've swapped those references with `rgba(var(--iui-color-border-accent), var(--iui-opacity-4)) 0px 0px 0px 2px;`, which seems to be the easiest replacement given the following:
- In 3.7.x version of appui I found: `$uicore-button-focus-boxshadow: $buic-focus-boxshadow 0px 0px 0px 2px;` and also from there I found `--buic-focus-boxshadow: rgba(var(--iui-color-foreground-primary-rgb), var(--iui-opacity-4));` 
- From the iTwinUI migration [doc](https://github.com/iTwin/iTwinUI/wiki/iTwinUI-variables-v1-migration-guide) I found `--iui-color-foreground-primary-rgb` is now equivalent to `--iui-color-border-accent`

I'm sure there is a simpler replacement, but this appears to be close to 1 to 1 with now non existent original variable. I'm thinking we can get this in so the build is viable then perhaps someone can determine if a better alternative can be used