### PR TITLE
Tree Widget: Make changelogs consistent

### DIFF
--- a/common/changes/@itwin/tree-widget-react/Fix_invert_button_2023-04-18-16-20.json
+++ b/common/changes/@itwin/tree-widget-react/Fix_invert_button_2023-04-18-16-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "Categories tree: fix invert button behavior. Previously, only categories were affected, now sub-categories will be affected as well.",
+      "comment": "Categories tree: Fix behavior of the Invert button. Previously, only categories were affected, now sub-categories are affected as well.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/conditional_trees_2023-04-24-10-24.json
+++ b/common/changes/@itwin/tree-widget-react/conditional_trees_2023-04-24-10-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "Added ability to conditionally show trees inside widget.",
+      "comment": "Widget: Added ability to conditionally show trees.",
       "type": "minor"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/jake-breakdown-trees_2023-04-20-20-09.json
+++ b/common/changes/@itwin/tree-widget-react/jake-breakdown-trees_2023-04-20-20-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "updating to core@3.7.0 and appui@4.0.0",
+      "comment": "Dependencies' update: `core@3.7.0`, `appui@4.0.0`",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
+++ b/common/changes/@itwin/tree-widget-react/rework_additional_trees_handling_2023-04-14-14-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING:** Reworked how trees are provided to the widget. Instead of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
+      "comment": "**BREAKING** Widget: Reworked the way trees are provided to the widget. Instead of having separate configuration properties for hiding default trees and adding additional trees now there is only one property for supplying a list of trees to show.",
       "type": "minor"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/tree-widget-models-tree-hierarchy-configuration_2023-05-11-08-05.json
+++ b/common/changes/@itwin/tree-widget-react/tree-widget-models-tree-hierarchy-configuration_2023-05-11-08-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING:** `ModelsTreeProps.enableElementsClassGrouping` has been moved to `ModelsTreeProps.hierarchyConfig.enableElementsClassGrouping`.",
+      "comment": "**BREAKING** Models tree: `ModelsTreeProps.enableElementsClassGrouping` has been moved to `ModelsTreeProps.hierarchyConfig.enableElementsClassGrouping`.",
       "type": "none"
     },
     {

--- a/common/changes/@itwin/tree-widget-react/tree_widget_update_deps_2023-04-21-11-58.json
+++ b/common/changes/@itwin/tree-widget-react/tree_widget_update_deps_2023-04-21-11-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "Removed usage of deprecated `@itwin/presentation-components` APIs",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/update_tree_checkboxes_2023-04-17-16-44.json
+++ b/common/changes/@itwin/tree-widget-react/update_tree_checkboxes_2023-04-17-16-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "Updated trees to use visibility checkbox from `@itwin/itwinui-react`.",
+      "comment": "Trees: Updated trees to use visibility checkbox from `@itwin/itwinui-react`.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Trying to add some consistency for our changelogs... I think the structure to be as follows:
```
{BREAKING CHANGE PREFIX} {Affected  component name}: {Change description}.
```

- `{BREAKING CHANGE PREFIX}` is `**BREAKING**`. Add when the commit contains a breaking change.
- `{Affected  component name}` is one of the harder pieces to come up with. Guidelines:
  - It has to be something that consumers understand - it can't be a name of some internal component. In case of a change to internal component, the name should be set to a higher level component that uses the internal one.
  - Sometimes the change affects multiple components. In that case:
    - When the components are at the same level, consider using a unified name (e.g. "Models tree" + "Categories tree" = "Trees").
    - When they're at different levels, consider using multiple changelog messages.
  - When it's a dependencies change, use "Dependencies' update"

