### PR TITLE
Tree Widget: Use type imports

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree_type_imports_2023-05-11-12-03.json
+++ b/common/changes/@itwin/tree-widget-react/tree_type_imports_2023-05-11-12-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Enforce consistent usage of type imports.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -585,7 +585,7 @@ importers:
       cpx2: 3.0.2
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
-      eslint-plugin-react: 7.29.4_eslint@7.32.0
+      eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.4.0_eslint@7.32.0
       jest: 27.5.1
       jest-cli: 27.5.1
@@ -1041,7 +1041,7 @@ importers:
       cpx2: 3.0.2
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
-      eslint-plugin-react: 7.29.4_eslint@7.32.0
+      eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.4.0_eslint@7.32.0
       jest: 27.5.1
       jest-cli: 27.5.1
@@ -1246,7 +1246,7 @@ importers:
       cpx2: 3.0.2
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
-      eslint-plugin-react: 7.29.4_eslint@7.32.0
+      eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.4.0_eslint@7.32.0
       jest: 27.5.1
       jest-cli: 27.5.1
@@ -10439,7 +10439,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.4.0
       tsutils: 3.21.0_typescript@4.3.5
       typescript: 4.3.5
     transitivePeerDependencies:
@@ -10460,7 +10460,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.4.0
       tsutils: 3.21.0_typescript@4.4.4
       typescript: 4.4.4
     transitivePeerDependencies:
@@ -10480,7 +10480,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.4.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
     transitivePeerDependencies:
@@ -11170,17 +11170,6 @@ packages:
     resolution: {integrity: sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==}
     dev: true
 
-  /array-includes/3.1.4:
-    resolution: {integrity: sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.19.4
-      get-intrinsic: 1.1.1
-      is-string: 1.0.7
-    dev: true
-
   /array-includes/3.1.6:
     resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==}
     engines: {node: '>= 0.4'}
@@ -11233,16 +11222,6 @@ packages:
       define-properties: 1.2.0
       es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
-
-  /array.prototype.flatmap/1.3.0:
-    resolution: {integrity: sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.19.4
-      es-shim-unscopables: 1.0.0
-    dev: true
 
   /array.prototype.flatmap/1.3.1:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
@@ -13844,7 +13823,7 @@ packages:
       eslint-plugin-import: 2.23.4_eslint@7.32.0
       glob: 7.2.0
       is-glob: 4.0.3
-      resolve: 1.22.0
+      resolve: 1.22.2
       tsconfig-paths: 3.14.1
     transitivePeerDependencies:
       - supports-color
@@ -14247,42 +14226,19 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     dependencies:
-      array-includes: 3.1.4
-      array.prototype.flatmap: 1.3.0
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
       doctrine: 2.1.0
       eslint: 7.32.0
       has: 1.0.3
-      jsx-ast-utils: 3.2.2
+      jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
-      object.entries: 1.1.5
-      object.fromentries: 2.0.5
-      object.values: 1.1.5
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      object.values: 1.1.6
       prop-types: 15.8.1
-      resolve: 2.0.0-next.3
-      string.prototype.matchall: 4.0.7
-    dev: true
-
-  /eslint-plugin-react/7.29.4_eslint@7.32.0:
-    resolution: {integrity: sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.4
-      array.prototype.flatmap: 1.3.0
-      doctrine: 2.1.0
-      eslint: 7.32.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.2.2
-      minimatch: 3.1.2
-      object.entries: 1.1.5
-      object.fromentries: 2.0.5
-      object.hasown: 1.1.0
-      object.values: 1.1.5
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.3
-      semver: 6.3.0
-      string.prototype.matchall: 4.0.7
+      resolve: 2.0.0-next.4
+      string.prototype.matchall: 4.0.8
     dev: true
 
   /eslint-plugin-react/7.32.2_eslint@7.32.0:
@@ -15256,14 +15212,6 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
-  /get-intrinsic/1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
-    dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.3
-    dev: true
-
   /get-intrinsic/1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
@@ -16166,12 +16114,6 @@ packages:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
-
-  /is-core-module/2.8.1:
-    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
-    dependencies:
-      has: 1.0.3
-    dev: true
 
   /is-data-descriptor/0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
@@ -19012,15 +18954,6 @@ packages:
       define-properties: 1.2.0
       es-abstract: 1.21.2
 
-  /object.fromentries/2.0.5:
-    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.19.4
-    dev: true
-
   /object.fromentries/2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
@@ -19034,13 +18967,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.19.4
-    dev: true
-
-  /object.hasown/1.1.0:
-    resolution: {integrity: sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==}
-    dependencies:
       define-properties: 1.1.3
       es-abstract: 1.19.4
     dev: true
@@ -21473,13 +21399,6 @@ packages:
       path-parse: 1.0.7
     dev: true
 
-  /resolve/2.0.0-next.3:
-    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==}
-    dependencies:
-      is-core-module: 2.8.1
-      path-parse: 1.0.7
-    dev: true
-
   /resolve/2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
@@ -22313,19 +22232,6 @@ packages:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  /string.prototype.matchall/4.0.7:
-    resolution: {integrity: sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.19.4
-      get-intrinsic: 1.1.1
-      has-symbols: 1.0.3
-      internal-slot: 1.0.3
-      regexp.prototype.flags: 1.4.2
-      side-channel: 1.0.4
-    dev: true
-
   /string.prototype.matchall/4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
@@ -22567,7 +22473,7 @@ packages:
       mime: 2.6.0
       qs: 6.10.3
       readable-stream: 3.6.0
-      semver: 7.3.7
+      semver: 7.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/packages/itwin/tree-widget/.eslintrc.js
+++ b/packages/itwin/tree-widget/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     ],
     "@typescript-eslint/consistent-type-imports": "error",
     "no-duplicate-imports": "off",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "object-curly-spacing": ["error", "always"]
   },
 };

--- a/packages/itwin/tree-widget/.eslintrc.js
+++ b/packages/itwin/tree-widget/.eslintrc.js
@@ -6,12 +6,15 @@ require("@rushstack/eslint-patch/modern-module-resolution");
 
 module.exports = {
   plugins: ["@itwin"],
-  extends: "plugin:@itwin/ui",
+  extends: ["plugin:@itwin/ui", "plugin:react/jsx-runtime"],
   rules: {
     "@itwin/no-internal": ["error"],
     "@typescript-eslint/no-floating-promises": [
       "error",
       { "ignoreIIFE": true }
-    ]
+    ],
+    "@typescript-eslint/consistent-type-imports": "error",
+    "no-duplicate-imports": "off",
+    "import/no-duplicates": "error"
   },
 };

--- a/packages/itwin/tree-widget/src/components/TreeFilteringState.ts
+++ b/packages/itwin/tree-widget/src/components/TreeFilteringState.ts
@@ -2,8 +2,10 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import React, { useState } from "react";
-import { IPresentationTreeDataProvider } from "@itwin/presentation-components";
+
+import { useCallback, useState } from "react";
+
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
 
 /** @internal */
 export interface SearchOptions {
@@ -26,19 +28,19 @@ interface TreeFilteringState {
 export const useTreeFilteringState = () => {
   const [{ filterString, matchedResultCount, activeMatchIndex, filteredProvider }, setState] = useState<TreeFilteringState>({ filterString: "" });
 
-  const onFilterCancel = React.useCallback(() => {
+  const onFilterCancel = useCallback(() => {
     setState({ filterString: "" });
   }, []);
 
-  const onFilterStart = React.useCallback((newFilter: string) => {
+  const onFilterStart = useCallback((newFilter: string) => {
     setState({ filterString: newFilter });
   }, []);
 
-  const onResultSelectedChanged = React.useCallback((index: number) => {
+  const onResultSelectedChanged = useCallback((index: number) => {
     setState((prev) => ({ ...prev, activeMatchIndex: index }));
   }, []);
 
-  const onFilterApplied = React.useCallback((provider: IPresentationTreeDataProvider, matches: number) => {
+  const onFilterApplied = useCallback((provider: IPresentationTreeDataProvider, matches: number) => {
     setState((prev) => ({
       ...prev,
       activeMatchIndex: prev.activeMatchIndex === undefined ? 1 : Math.min(prev.activeMatchIndex, matches),

--- a/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
@@ -11,7 +11,7 @@ import { FillCentered } from "@itwin/core-react";
 import { ProgressLinear } from "@itwin/itwinui-react";
 import { TreeWidget } from "../TreeWidget";
 
-import type { PropsWithChildren} from "react";
+import type { PropsWithChildren } from "react";
 import type { SelectableContentDefinition, SelectableContentProps } from "@itwin/components-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 

--- a/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetComponent.tsx
@@ -4,13 +4,16 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "./TreeWidgetComponent.scss";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { useActiveIModelConnection } from "@itwin/appui-react";
-import { SelectableContent, SelectableContentDefinition, SelectableContentProps } from "@itwin/components-react";
-import { IModelConnection } from "@itwin/core-frontend";
+import { SelectableContent } from "@itwin/components-react";
 import { FillCentered } from "@itwin/core-react";
 import { ProgressLinear } from "@itwin/itwinui-react";
 import { TreeWidget } from "../TreeWidget";
+
+import type { PropsWithChildren} from "react";
+import type { SelectableContentDefinition, SelectableContentProps } from "@itwin/components-react";
+import type { IModelConnection } from "@itwin/core-frontend";
 
 /**
  * Definition of a tree component displayed in [[TreeWidgetComponent]]
@@ -63,9 +66,9 @@ function TreeWidgetComponentContent(props: TreeWidgetComponentProps & { imodel: 
 }
 
 function useActiveTrees(treeDefinitions: TreeDefinition[], imodel: IModelConnection) {
-  const [trees, setTrees] = React.useState<SelectableContentDefinition[]>();
+  const [trees, setTrees] = useState<SelectableContentDefinition[]>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let disposed = false;
     (async () => {
       const visibleTrees = await getActiveTrees(treeDefinitions, imodel);
@@ -133,10 +136,10 @@ function getSelectableContentProps(trees?: SelectableContentDefinition[]): Selec
   };
 }
 
-function Delayed({ delay = 200, children }: React.PropsWithChildren<{ delay?: number }>) {
-  const [show, setShow] = React.useState(false);
+function Delayed({ delay = 200, children }: PropsWithChildren<{ delay?: number }>) {
+  const [show, setShow] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const id = setTimeout(() => { setShow(true); }, delay);
     return () => { clearTimeout(id); };
   }, [delay]);

--- a/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
@@ -3,12 +3,14 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import React from "react";
-import { StagePanelLocation, StagePanelSection, StageUsage, UiItemsProvider, Widget } from "@itwin/appui-react";
+import { StagePanelLocation, StagePanelSection, StageUsage } from "@itwin/appui-react";
 import { TreeWidget } from "../TreeWidget";
 import { CategoriesTreeComponent } from "./trees/category-tree/CategoriesTreeComponent";
 import { ModelsTreeComponent } from "./trees/models-tree/ModelsTreeComponent";
-import { TreeDefinition, TreeWidgetComponent } from "./TreeWidgetComponent";
+import { TreeWidgetComponent } from "./TreeWidgetComponent";
+
+import type { UiItemsProvider, Widget } from "@itwin/appui-react";
+import type { TreeDefinition} from "./TreeWidgetComponent";
 
 /**
  * Parameters for creating a [[TreeWidgetUiItemsProvider]].

--- a/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
+++ b/packages/itwin/tree-widget/src/components/TreeWidgetUiItemsProvider.tsx
@@ -10,7 +10,7 @@ import { ModelsTreeComponent } from "./trees/models-tree/ModelsTreeComponent";
 import { TreeWidgetComponent } from "./TreeWidgetComponent";
 
 import type { UiItemsProvider, Widget } from "@itwin/appui-react";
-import type { TreeDefinition} from "./TreeWidgetComponent";
+import type { TreeDefinition } from "./TreeWidgetComponent";
 
 /**
  * Parameters for creating a [[TreeWidgetUiItemsProvider]].

--- a/packages/itwin/tree-widget/src/components/tree-header/SearchBox.tsx
+++ b/packages/itwin/tree-widget/src/components/tree-header/SearchBox.tsx
@@ -5,11 +5,12 @@
 
 import "./SearchBox.scss";
 import classnames from "classnames";
-import * as React from "react";
-import { CommonProps } from "@itwin/core-react";
+import { useEffect, useRef, useState } from "react";
 import { SvgChevronDown, SvgChevronUp, SvgCloseSmall, SvgSearch } from "@itwin/itwinui-icons-react";
 import { IconButton } from "@itwin/itwinui-react";
 import { TreeWidget } from "../../TreeWidget";
+
+import type { CommonProps } from "@itwin/core-react";
 
 /** @internal */
 export interface SearchBoxProps extends CommonProps {
@@ -37,10 +38,10 @@ export interface SearchBoxProps extends CommonProps {
 export function SearchBox(props: SearchBoxProps) {
   const { className, valueChangedDelay = 500, style, onFilterStart, selectedIndex, resultCount,
     onSelectedChanged, onFilterClear, searchOpen, onSearchOpen, onSearchClose } = props;
-  const [searchText, setSearchText] = React.useState("");
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!searchText) {
       onFilterClear();
       return;
@@ -53,7 +54,7 @@ export function SearchBox(props: SearchBoxProps) {
     return () => clearTimeout(timeoutId);
   }, [searchText, valueChangedDelay, onFilterClear, onFilterStart]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (searchOpen && inputRef.current ) {
       inputRef.current.focus();
     }

--- a/packages/itwin/tree-widget/src/components/tree-header/TreeHeader.tsx
+++ b/packages/itwin/tree-widget/src/components/tree-header/TreeHeader.tsx
@@ -5,11 +5,13 @@
 
 import "./TreeHeader.scss";
 import classnames from "classnames";
-import * as React from "react";
-import { Viewport } from "@itwin/core-frontend";
+import { Children, useState } from "react";
 import { SvgMore } from "@itwin/itwinui-icons-react";
 import { ButtonGroup, DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
-import { SearchBox, SearchBoxProps } from "./SearchBox";
+import { SearchBox } from "./SearchBox";
+
+import type { Viewport } from "@itwin/core-frontend";
+import type { SearchBoxProps } from "./SearchBox";
 
 /** @internal */
 export interface TreeHeaderButtonProps {
@@ -31,7 +33,7 @@ export interface TreeHeaderProps extends Omit<SearchBoxProps,
 /** @internal */
 export function TreeHeader(props: TreeHeaderProps) {
   const { children, ...restProps } = props;
-  const [searchOpen, setSearchOpen] = React.useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   return (
     <div className={classnames("tree-widget-search-bar", props.className)}>
@@ -65,7 +67,7 @@ function HeaderButtons(props: HeaderButtonsProps) {
       overflowButton={(overflowStart) => (
         <DropdownMenu
           menuItems={() =>
-            React.Children.toArray(props.children)
+            Children.toArray(props.children)
               .slice(overflowStart - 1)
               .map((btn, index) => <MenuItem key={index} className="search-bar-dropdown-menu-item">{btn}</MenuItem>)
           }

--- a/packages/itwin/tree-widget/src/components/trees/CategoriesVisibilityUtils.ts
+++ b/packages/itwin/tree-widget/src/components/trees/CategoriesVisibilityUtils.ts
@@ -4,8 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { QueryRowFormat } from "@itwin/core-common";
-import { IModelConnection, PerModelCategoryVisibility, ViewManager, Viewport } from "@itwin/core-frontend";
-import { CategoryInfo } from "./category-tree/CategoryVisibilityHandler";
+import { PerModelCategoryVisibility } from "@itwin/core-frontend";
+
+import type { IModelConnection, ViewManager, Viewport } from "@itwin/core-frontend";
+import type { CategoryInfo } from "./category-tree/CategoryVisibilityHandler";
 
 const EMPTY_CATEGORIES_ARRAY: CategoryInfo[] = [];
 

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeEventHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeEventHandler.ts
@@ -11,14 +11,16 @@ import { EMPTY } from "rxjs/internal/observable/empty";
 import { from } from "rxjs/internal/observable/from";
 import { map } from "rxjs/internal/operators/map";
 import { mergeMap } from "rxjs/internal/operators/mergeMap";
-import {
+import { CheckBoxState } from "@itwin/core-react";
+import { UnifiedSelectionTreeEventHandler } from "@itwin/presentation-components";
+import { isPromiseLike } from "../utils/IsPromiseLike";
+
+import type {
   CheckBoxInfo, CheckboxStateChange, TreeCheckboxStateChangeEventArgs, TreeModelNode, TreeNodeItem, TreeSelectionChange,
   TreeSelectionModificationEventArgs, TreeSelectionReplacementEventArgs,
 } from "@itwin/components-react";
-import { BeEvent, IDisposable } from "@itwin/core-bentley";
-import { CheckBoxState } from "@itwin/core-react";
-import { UnifiedSelectionTreeEventHandler, UnifiedSelectionTreeEventHandlerParams } from "@itwin/presentation-components";
-import { isPromiseLike } from "../utils/IsPromiseLike";
+import type { BeEvent, IDisposable } from "@itwin/core-bentley";
+import type { UnifiedSelectionTreeEventHandlerParams } from "@itwin/presentation-components";
 
 /**
  * Data structure that describes instance visibility status.

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -8,9 +8,9 @@ import { TreeImageLoader, TreeNodeRenderer, TreeRenderer } from "@itwin/componen
 import { Checkbox } from "@itwin/itwinui-react";
 import { useControlledPresentationTreeFiltering } from "@itwin/presentation-components";
 
-import type {AbstractTreeNodeLoaderWithProvider, TreeNodeRendererProps, TreeRendererProps } from "@itwin/components-react";
+import type { AbstractTreeNodeLoaderWithProvider, TreeNodeRendererProps, TreeRendererProps } from "@itwin/components-react";
 import type { NodeCheckboxRenderProps } from "@itwin/core-react";
-import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { VisibilityTreeFilterInfo } from "./Common";
 
 /**

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -3,14 +3,15 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
-import {
-  AbstractTreeNodeLoaderWithProvider, TreeImageLoader, TreeNodeRenderer, TreeNodeRendererProps, TreeRenderer, TreeRendererProps,
-} from "@itwin/components-react";
-import { NodeCheckboxRenderProps } from "@itwin/core-react";
+import { useCallback, useEffect } from "react";
+import { TreeImageLoader, TreeNodeRenderer, TreeRenderer } from "@itwin/components-react";
 import { Checkbox } from "@itwin/itwinui-react";
-import { IPresentationTreeDataProvider, useControlledPresentationTreeFiltering } from "@itwin/presentation-components";
-import { VisibilityTreeFilterInfo } from "./Common";
+import { useControlledPresentationTreeFiltering } from "@itwin/presentation-components";
+
+import type {AbstractTreeNodeLoaderWithProvider, TreeNodeRendererProps, TreeRendererProps } from "@itwin/components-react";
+import type { NodeCheckboxRenderProps } from "@itwin/core-react";
+import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { VisibilityTreeFilterInfo } from "./Common";
 
 /**
  * Creates Visibility tree renderer which renders nodes with eye checkbox.
@@ -18,8 +19,8 @@ import { VisibilityTreeFilterInfo } from "./Common";
  */
 export const useVisibilityTreeRenderer = (iconsEnabled: boolean, descriptionsEnabled: boolean) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const nodeRenderer = React.useCallback(createVisibilityTreeNodeRenderer(iconsEnabled, descriptionsEnabled), [iconsEnabled, descriptionsEnabled]);
-  return React.useCallback((props: TreeRendererProps) => (
+  const nodeRenderer = useCallback(createVisibilityTreeNodeRenderer(iconsEnabled, descriptionsEnabled), [iconsEnabled, descriptionsEnabled]);
+  return useCallback((props: TreeRendererProps) => (
     <TreeRenderer
       {...props}
       nodeRenderer={nodeRenderer}
@@ -76,7 +77,7 @@ export const useVisibilityTreeFiltering = (
     nodeHighlightingProps,
   } = useControlledPresentationTreeFiltering({ nodeLoader, filter, activeMatchIndex });
 
-  React.useEffect(
+  useEffect(
     () => {
       if (filter && matchesCount !== undefined && filteredNodeLoader !== nodeLoader)
         onFilterApplied && onFilterApplied(filteredNodeLoader.dataProvider, matchesCount);

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
@@ -4,18 +4,22 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import * as React from "react";
+import { useCallback, useEffect } from "react";
 import { ControlledTree, SelectionMode, useTreeModel } from "@itwin/components-react";
-import { IModelApp, IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
+import { IModelApp } from "@itwin/core-frontend";
 import { useDisposable } from "@itwin/core-react";
-import { Ruleset } from "@itwin/presentation-common";
-import { IPresentationTreeDataProvider, usePresentationTreeNodeLoader } from "@itwin/presentation-components";
+import { usePresentationTreeNodeLoader } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import { TreeWidget } from "../../../TreeWidget";
-import { VisibilityTreeFilterInfo } from "../Common";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
 import { useVisibilityTreeFiltering, useVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
-import { CategoryInfo, CategoryVisibilityHandler } from "./CategoryVisibilityHandler";
+import { CategoryVisibilityHandler } from "./CategoryVisibilityHandler";
+
+import type { IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
+import type { Ruleset } from "@itwin/presentation-common";
+import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { VisibilityTreeFilterInfo } from "../Common";
+import type { CategoryInfo} from "./CategoryVisibilityHandler";
 
 const PAGING_SIZE = 20;
 
@@ -84,11 +88,11 @@ export function CategoryTree(props: CategoryTreeProps) {
   const { activeView, allViewports, categoryVisibilityHandler } = props;
   const visibilityHandler = useCategoryVisibilityHandler(viewManager, props.iModel, props.categories, activeView, allViewports, categoryVisibilityHandler);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setViewType(activeView); // eslint-disable-line @typescript-eslint/no-floating-promises
   }, [activeView]);
 
-  const eventHandler = useDisposable(React.useCallback(() => new VisibilityTreeEventHandler({
+  const eventHandler = useDisposable(useCallback(() => new VisibilityTreeEventHandler({
     nodeLoader: filteredNodeLoader,
     visibilityHandler,
     collapsedChildrenDisposalEnabled: true,
@@ -99,7 +103,7 @@ export function CategoryTree(props: CategoryTreeProps) {
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
   const filterApplied = filteredNodeLoader !== nodeLoader;
 
-  const noFilteredDataRenderer = React.useCallback(() => {
+  const noFilteredDataRenderer = useCallback(() => {
     return <VisibilityTreeNoFilteredData
       title={TreeWidget.translate("categoriesTree.noCategoryFound")}
       message={TreeWidget.translate("categoriesTree.noMatchingCategoryNames")}
@@ -126,7 +130,7 @@ export function CategoryTree(props: CategoryTreeProps) {
 }
 
 function useCategoryVisibilityHandler(viewManager: ViewManager, imodel: IModelConnection, categories: CategoryInfo[], activeView: Viewport, allViewports?: boolean, visibilityHandler?: CategoryVisibilityHandler) {
-  const defaultVisibilityHandler = useDisposable(React.useCallback(
+  const defaultVisibilityHandler = useDisposable(useCallback(
     () =>
       new CategoryVisibilityHandler({ viewManager, imodel, categories, activeView, allViewports }),
     [viewManager, imodel, categories, activeView, allViewports]),

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
@@ -17,9 +17,9 @@ import { CategoryVisibilityHandler } from "./CategoryVisibilityHandler";
 
 import type { IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
 import type { Ruleset } from "@itwin/presentation-common";
-import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { VisibilityTreeFilterInfo } from "../Common";
-import type { CategoryInfo} from "./CategoryVisibilityHandler";
+import type { CategoryInfo } from "./CategoryVisibilityHandler";
 
 const PAGING_SIZE = 20;
 

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
@@ -18,7 +18,7 @@ import { CategoryTree } from "./CategoriesTree";
 import { CategoryVisibilityHandler, hideAllCategories, invertAllCategories, showAllCategories, useCategories } from "./CategoryVisibilityHandler";
 
 import type { IModelConnection, ScreenViewport } from "@itwin/core-frontend";
-import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
 import type { CategoryTreeProps } from "./CategoriesTree";
 import type { CategoryInfo } from "./CategoryVisibilityHandler";

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTreeComponent.tsx
@@ -4,20 +4,24 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import React, { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useActiveIModelConnection, useActiveViewport } from "@itwin/appui-react";
-import { IModelApp, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import { IModelApp } from "@itwin/core-frontend";
 import { SvgVisibilityHalf, SvgVisibilityHide, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
 import { IconButton } from "@itwin/itwinui-react";
-import { IPresentationTreeDataProvider, isPresentationTreeNodeItem } from "@itwin/presentation-components";
+import { isPresentationTreeNodeItem } from "@itwin/presentation-components";
 import { TreeWidget } from "../../../TreeWidget";
-import { TreeHeader, TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
+import { TreeHeader } from "../../tree-header/TreeHeader";
 import { useTreeFilteringState } from "../../TreeFilteringState";
 import { AutoSizer } from "../../utils/AutoSizer";
-import { CategoryTree, CategoryTreeProps } from "./CategoriesTree";
-import {
-  CategoryInfo, CategoryVisibilityHandler, hideAllCategories, invertAllCategories, showAllCategories, useCategories,
-} from "./CategoryVisibilityHandler";
+import { CategoryTree } from "./CategoriesTree";
+import { CategoryVisibilityHandler, hideAllCategories, invertAllCategories, showAllCategories, useCategories } from "./CategoryVisibilityHandler";
+
+import type { IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import type { IPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
+import type { CategoryTreeProps } from "./CategoriesTree";
+import type { CategoryInfo } from "./CategoryVisibilityHandler";
 
 /**
  * Props that get passed to [[CategoriesTreeComponent]] header button renderer.
@@ -138,9 +142,9 @@ function CategoriesTreeComponentImpl(props: CategoriesTreeComponentProps & { iMo
         {props.headerButtons
           ? props.headerButtons.map(
             (btn, index) =>
-              <React.Fragment key={index}>
+              <Fragment key={index}>
                 {btn({ viewport: props.viewport, categories, filteredCategories })}
-              </React.Fragment>
+              </Fragment>
           )
           : [
             <ShowAllButton viewport={props.viewport} categories={categories} filteredCategories={filteredCategories} key="show-all-btn" />,

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoryVisibilityHandler.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoryVisibilityHandler.tsx
@@ -3,14 +3,17 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
-import { TreeNodeItem, useAsyncValue } from "@itwin/components-react";
+import { useMemo } from "react";
+import { useAsyncValue } from "@itwin/components-react";
 import { BeEvent } from "@itwin/core-bentley";
-import { IModelApp, IModelConnection, ViewManager, Viewport } from "@itwin/core-frontend";
+import { IModelApp } from "@itwin/core-frontend";
 import { NodeKey } from "@itwin/presentation-common";
 import { isPresentationTreeNodeItem } from "@itwin/presentation-components";
 import { enableCategory, enableSubCategory, loadCategoriesFromViewport } from "../CategoriesVisibilityUtils";
-import { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
+
+import type { TreeNodeItem} from "@itwin/components-react";
+import type { IModelConnection, ViewManager, Viewport } from "@itwin/core-frontend";
+import type { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
 
 const EMPTY_CATEGORIES_ARRAY: CategoryInfo[] = [];
 
@@ -20,7 +23,7 @@ const EMPTY_CATEGORIES_ARRAY: CategoryInfo[] = [];
  */
 export function useCategories(viewManager: ViewManager, imodel: IModelConnection, view?: Viewport) {
   const currentView = view || viewManager.getFirstOpenView();
-  const categoriesPromise = React.useMemo(async () => loadCategoriesFromViewport(imodel, currentView), [imodel, currentView]);
+  const categoriesPromise = useMemo(async () => loadCategoriesFromViewport(imodel, currentView), [imodel, currentView]);
   return useAsyncValue(categoriesPromise) ?? EMPTY_CATEGORIES_ARRAY;
 }
 

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoryVisibilityHandler.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoryVisibilityHandler.tsx
@@ -11,7 +11,7 @@ import { NodeKey } from "@itwin/presentation-common";
 import { isPresentationTreeNodeItem } from "@itwin/presentation-components";
 import { enableCategory, enableSubCategory, loadCategoriesFromViewport } from "../CategoriesVisibilityUtils";
 
-import type { TreeNodeItem} from "@itwin/components-react";
+import type { TreeNodeItem } from "@itwin/components-react";
 import type { IModelConnection, ViewManager, Viewport } from "@itwin/core-frontend";
 import type { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
 

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -4,12 +4,13 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import * as React from "react";
-import { ControlledTree, DelayLoadedTreeNodeItem, SelectionMode, useTreeModel } from "@itwin/components-react";
-import { IModelConnection } from "@itwin/core-frontend";
-import { Node, Ruleset } from "@itwin/presentation-common";
+import { ControlledTree, SelectionMode, useTreeModel } from "@itwin/components-react";
 import { usePresentationTreeNodeLoader, useUnifiedSelectionTreeEventHandler } from "@itwin/presentation-components";
 import * as RULESET_EXTERNAL_SOURCES_IMPORT from "./ExternalSources.json";
+
+import type { DelayLoadedTreeNodeItem } from "@itwin/components-react";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { Node, Ruleset } from "@itwin/presentation-common";
 
 /**
  * Presentation rules used by ControlledCategoriesTree

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
@@ -4,11 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import * as React from "react";
 import { useActiveIModelConnection } from "@itwin/appui-react";
 import { AutoSizer } from "../../utils/AutoSizer";
 import { ExternalSourcesTree } from "./ExternalSourcesTree";
-import { IModelConnection } from "@itwin/core-frontend";
+
+import type { IModelConnection } from "@itwin/core-frontend";
 
 /**
  * A component that displays an External Sources tree and any necessary "chrome".

--- a/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -4,11 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 
 import classNames from "classnames";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { ControlledTree, SelectionMode, useTreeEventsHandler, useTreeModel } from "@itwin/components-react";
-import { IModelConnection } from "@itwin/core-frontend";
-import { Ruleset } from "@itwin/presentation-common";
 import { usePresentationTreeNodeLoader } from "@itwin/presentation-components";
+
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { Ruleset } from "@itwin/presentation-common";
 
 /**
  * Presentation rules used by IModelContentTree

--- a/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
@@ -4,11 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import React from "react";
 import { useActiveIModelConnection } from "@itwin/appui-react";
 import { TreeWidget } from "../../../TreeWidget";
 import { AutoSizer } from "../../utils/AutoSizer";
-import { IModelContentTree, IModelContentTreeProps } from "./IModelContentTree";
+import { IModelContentTree } from "./IModelContentTree";
+
+import type { IModelContentTreeProps } from "./IModelContentTree";
 
 /**
  * Props for [[IModelContentTreeComponent]].

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -4,20 +4,22 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import * as React from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { ControlledTree, SelectionMode, useTreeModel } from "@itwin/components-react";
-import { IModelConnection, Viewport } from "@itwin/core-frontend";
 import { useDisposable } from "@itwin/core-react";
-import { SingleSchemaClassSpecification } from "@itwin/presentation-common";
-import {
-  IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider, isPresentationTreeNodeItem, usePresentationTreeNodeLoader,
-} from "@itwin/presentation-components";
+import { isPresentationTreeNodeItem, usePresentationTreeNodeLoader } from "@itwin/presentation-components";
 import { TreeWidget } from "../../../TreeWidget";
-import { ClassGroupingOption, VisibilityTreeFilterInfo } from "../Common";
+import { ClassGroupingOption } from "../Common";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
 import { useVisibilityTreeFiltering, useVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
-import { ModelsTreeSelectionPredicate, ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
+import { ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
 import { createRuleset, createSearchRuleset } from "./Utils";
+
+import type { IModelConnection, Viewport } from "@itwin/core-frontend";
+import type { SingleSchemaClassSpecification } from "@itwin/presentation-common";
+import type { IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider } from "@itwin/presentation-components";
+import type { VisibilityTreeFilterInfo } from "../Common";
+import type { ModelsTreeSelectionPredicate } from "./ModelsVisibilityHandler";
 
 const PAGING_SIZE = 20;
 
@@ -107,7 +109,7 @@ export function ModelsTree(props: ModelsTreeProps) {
     modelsVisibilityHandler,
     getFilteredDataProvider(filteredNodeLoader.dataProvider),
     props.enableHierarchyAutoUpdate);
-  const eventHandler = useDisposable(React.useCallback(() => new VisibilityTreeEventHandler({
+  const eventHandler = useDisposable(useCallback(() => new VisibilityTreeEventHandler({
     nodeLoader: filteredNodeLoader,
     visibilityHandler,
     collapsedChildrenDisposalEnabled: true,
@@ -120,7 +122,7 @@ export function ModelsTree(props: ModelsTreeProps) {
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
 
   // istanbul ignore next
-  const noFilteredDataRenderer = React.useCallback(() => {
+  const noFilteredDataRenderer = useCallback(() => {
     return <VisibilityTreeNoFilteredData
       title={TreeWidget.translate("modelTree.noModelFound")}
       message={TreeWidget.translate("modelTree.noMatchingModelNames")}
@@ -148,11 +150,11 @@ export function ModelsTree(props: ModelsTreeProps) {
 
 function useModelsTreeNodeLoader(props: ModelsTreeProps) {
   const rulesets = {
-    general: React.useMemo(() => createRuleset({
+    general: useMemo(() => createRuleset({
       enableElementsClassGrouping: !!props.hierarchyConfig?.enableElementsClassGrouping,
       elementClassSpecification: props.hierarchyConfig?.elementClassSpecification,
     }), [props.hierarchyConfig?.enableElementsClassGrouping, props.hierarchyConfig?.elementClassSpecification]),
-    search: React.useMemo(() => createSearchRuleset({
+    search: useMemo(() => createSearchRuleset({
       elementClassSpecification: props.hierarchyConfig?.elementClassSpecification,
     }), [props.hierarchyConfig?.elementClassSpecification]),
   };
@@ -188,9 +190,9 @@ function useVisibilityHandler(
   filteredDataProvider?: IFilteredPresentationTreeDataProvider,
   hierarchyAutoUpdateEnabled?: boolean,
 ) {
-  const subjectModelIdsCache = React.useMemo(() => new SubjectModelIdsCache(iModel), [iModel]);
+  const subjectModelIdsCache = useMemo(() => new SubjectModelIdsCache(iModel), [iModel]);
 
-  const defaultVisibilityHandler = useDisposable(React.useCallback(
+  const defaultVisibilityHandler = useDisposable(useCallback(
     () =>
       new ModelsVisibilityHandler({ rulesetId, viewport: activeView, hierarchyAutoUpdateEnabled, subjectModelIdsCache }),
     [rulesetId, activeView, subjectModelIdsCache, hierarchyAutoUpdateEnabled])
@@ -198,7 +200,7 @@ function useVisibilityHandler(
 
   const handler = visibilityHandler ?? defaultVisibilityHandler;
 
-  React.useEffect(() => {
+  useEffect(() => {
     handler && handler.setFilteredDataProvider(filteredDataProvider);
   }, [handler, filteredDataProvider]);
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -4,18 +4,21 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useActiveIModelConnection, useActiveViewport } from "@itwin/appui-react";
-import { GeometricModel3dProps, ModelQueryParams } from "@itwin/core-common";
-import { IModelConnection, ScreenViewport, Viewport } from "@itwin/core-frontend";
 import { SvgVisibilityHalf, SvgVisibilityHide, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
 import { Button, IconButton } from "@itwin/itwinui-react";
 import { TreeWidget } from "../../../TreeWidget";
-import { TreeHeader, TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
+import { TreeHeader } from "../../tree-header/TreeHeader";
 import { useTreeFilteringState } from "../../TreeFilteringState";
 import { AutoSizer } from "../../utils/AutoSizer";
-import { ModelsTree, ModelsTreeProps } from "./ModelsTree";
+import { ModelsTree } from "./ModelsTree";
 import { areAllModelsVisible, hideAllModels, invertAllModels, showAllModels, toggleModels } from "./ModelsVisibilityHandler";
+
+import type { GeometricModel3dProps, ModelQueryParams } from "@itwin/core-common";
+import type { IModelConnection, ScreenViewport, Viewport } from "@itwin/core-frontend";
+import type { TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
+import type { ModelsTreeProps } from "./ModelsTree";
 
 /**
  * Information about a single Model.
@@ -167,9 +170,9 @@ function ModelsTreeComponentImpl(props: ModelTreeComponentProps & { iModel: IMod
         {props.headerButtons
           ? props.headerButtons.map(
             (btn, index) =>
-              <React.Fragment key={index}>
+              <Fragment key={index}>
                 {btn({ viewport, models: availableModels })}
-              </React.Fragment>
+              </Fragment>
           )
           : [
             <ShowAllButton viewport={viewport} models={availableModels} key="show-all-btn" />,

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -16,8 +16,8 @@ import { CachingElementIdsContainer } from "./Utils";
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection, Viewport } from "@itwin/core-frontend";
-import type { ECClassGroupingNodeKey, GroupingNodeKey, Keys} from "@itwin/presentation-common";
-import type { IFilteredPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { ECClassGroupingNodeKey, GroupingNodeKey, Keys } from "@itwin/presentation-common";
+import type { IFilteredPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
 
 /**

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -3,17 +3,22 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { TreeNodeItem } from "@itwin/components-react";
-import { BeEvent, Id64String } from "@itwin/core-bentley";
+import { BeEvent } from "@itwin/core-bentley";
 import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
-import { IModelApp, IModelConnection, PerModelCategoryVisibility, Viewport } from "@itwin/core-frontend";
-import { ECClassGroupingNodeKey, GroupingNodeKey, Keys, KeySet, NodeKey } from "@itwin/presentation-common";
-import { IFilteredPresentationTreeDataProvider, isPresentationTreeNodeItem } from "@itwin/presentation-components";
+import { IModelApp, PerModelCategoryVisibility } from "@itwin/core-frontend";
+import { KeySet, NodeKey } from "@itwin/presentation-common";
+import { isPresentationTreeNodeItem } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import { TreeWidget } from "../../../TreeWidget";
 import { toggleAllCategories } from "../CategoriesVisibilityUtils";
-import { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
 import { CachingElementIdsContainer } from "./Utils";
+
+import type { TreeNodeItem } from "@itwin/components-react";
+import type { Id64String } from "@itwin/core-bentley";
+import type { IModelConnection, Viewport } from "@itwin/core-frontend";
+import type { ECClassGroupingNodeKey, GroupingNodeKey, Keys} from "@itwin/presentation-common";
+import type { IFilteredPresentationTreeDataProvider} from "@itwin/presentation-components";
+import type { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
 
 /**
  * Models tree node types.

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import type { Id64String } from "@itwin/core-bentley";
-import { Ruleset } from "@itwin/presentation-common";
-import { ModelsTreeHierarchyConfiguration } from "./ModelsTree";
+import type { Ruleset } from "@itwin/presentation-common";
+import type { ModelsTreeHierarchyConfiguration } from "./ModelsTree";
 
 /** @internal */
 export class CachingElementIdsContainer {

--- a/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
+++ b/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { ResizableContainerObserver } from "@itwin/core-react";
 
 /** @internal */

--- a/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
+++ b/packages/itwin/tree-widget/src/components/utils/AutoSizer.tsx
@@ -20,8 +20,8 @@ export interface AutoSizerProps {
 // istanbul ignore next
 /** @internal */
 export function AutoSizer(props: AutoSizerProps) {
-  const [{height, width}, setSize] = useState<Size>({height: 0, width: 0});
-  const handleResize = useCallback((w: number, h: number) => { setSize({height: h, width: w}); }, []);
+  const [{ height, width }, setSize] = useState<Size>({ height: 0, width: 0 });
+  const handleResize = useCallback((w: number, h: number) => { setSize({ height: h, width: w }); }, []);
 
   return (
     <ResizableContainerObserver onResize={handleResize}>

--- a/packages/itwin/tree-widget/src/test/IModelUtils.ts
+++ b/packages/itwin/tree-widget/src/test/IModelUtils.ts
@@ -6,7 +6,7 @@
 import { BisCodeSpec, Code, IModel } from "@itwin/core-common";
 
 import type { Id64String } from "@itwin/core-bentley";
-import type { CategoryProps, GeometricElement3dProps, PhysicalElementProps, RelatedElementProps, SubCategoryProps} from "@itwin/core-common";
+import type { CategoryProps, GeometricElement3dProps, PhysicalElementProps, RelatedElementProps, SubCategoryProps } from "@itwin/core-common";
 import type { TestIModelBuilder } from "@itwin/presentation-testing";
 
 export function addSubject(builder: TestIModelBuilder, name: string, parentId = IModel.rootSubjectId) {

--- a/packages/itwin/tree-widget/src/test/IModelUtils.ts
+++ b/packages/itwin/tree-widget/src/test/IModelUtils.ts
@@ -3,11 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Id64String } from "@itwin/core-bentley";
-import {
-  BisCodeSpec, CategoryProps, Code, GeometricElement3dProps, IModel, PhysicalElementProps, RelatedElementProps, SubCategoryProps,
-} from "@itwin/core-common";
-import { TestIModelBuilder } from "@itwin/presentation-testing";
+import { BisCodeSpec, Code, IModel } from "@itwin/core-common";
+
+import type { Id64String } from "@itwin/core-bentley";
+import type { CategoryProps, GeometricElement3dProps, PhysicalElementProps, RelatedElementProps, SubCategoryProps} from "@itwin/core-common";
+import type { TestIModelBuilder } from "@itwin/presentation-testing";
 
 export function addSubject(builder: TestIModelBuilder, name: string, parentId = IModel.rootSubjectId) {
   const parentProps: RelatedElementProps = {

--- a/packages/itwin/tree-widget/src/test/TestUtils.ts
+++ b/packages/itwin/tree-widget/src/test/TestUtils.ts
@@ -8,11 +8,12 @@ import * as moq from "typemoq";
 import { UiFramework } from "@itwin/appui-react";
 import { BeEvent } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
-import { IModelConnection, PerModelCategoryVisibility, Viewport, ViewState } from "@itwin/core-frontend";
 import { TreeWidget } from "../TreeWidget";
 
+import type { IModelConnection, PerModelCategoryVisibility, Viewport, ViewState } from "@itwin/core-frontend";
 import type { PresentationManager, RulesetVariablesManager } from "@itwin/presentation-frontend";
 import type { VariableValue } from "@itwin/presentation-common";
+
 export class TestUtils {
   private static _initialized = false;
 

--- a/packages/itwin/tree-widget/src/test/TreeFilteringState.test.ts
+++ b/packages/itwin/tree-widget/src/test/TreeFilteringState.test.ts
@@ -3,10 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { expect } from "chai";
 import { renderHook } from "@testing-library/react-hooks";
 import { useTreeFilteringState } from "../components/TreeFilteringState";
-import { expect } from "chai";
-import { IPresentationTreeDataProvider } from "@itwin/presentation-components";
+
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
 
 describe("useTreeFilteringState", () => {
   it("updates filterString when `onFilterStart` is called", () => {

--- a/packages/itwin/tree-widget/src/test/TreeWidgetComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/TreeWidgetComponent.test.tsx
@@ -3,16 +3,17 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 import { UiFramework } from "@itwin/appui-react";
 import { BeEvent } from "@itwin/core-bentley";
-import { IModelConnection } from "@itwin/core-frontend";
 import { cleanup, render, waitFor } from "@testing-library/react";
-import { TreeDefinition, TreeWidgetComponent } from "../tree-widget-react";
+import { TreeWidgetComponent } from "../tree-widget-react";
 import { TreeWidget } from "../TreeWidget";
 import { TestUtils } from "./TestUtils";
+
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { TreeDefinition} from "../tree-widget-react";
 
 describe("<TreeWidgetComponent />", () => {
   before(async () => {

--- a/packages/itwin/tree-widget/src/test/TreeWidgetComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/TreeWidgetComponent.test.tsx
@@ -13,7 +13,7 @@ import { TreeWidget } from "../TreeWidget";
 import { TestUtils } from "./TestUtils";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { TreeDefinition} from "../tree-widget-react";
+import type { TreeDefinition } from "../tree-widget-react";
 
 describe("<TreeWidgetComponent />", () => {
   before(async () => {
@@ -46,13 +46,13 @@ describe("<TreeWidgetComponent />", () => {
       getLabel: () => "Tree Label 1",
       render: () => <div>Tree Content 1</div>,
     }];
-    const {container} = render(<TreeWidgetComponent trees={trees} />);
+    const { container } = render(<TreeWidgetComponent trees={trees} />);
     expect(container.children).to.be.empty;
   });
 
   it("renders without trees", async () => {
     const trees: TreeDefinition[] = [];
-    const {queryByText} = render(<TreeWidgetComponent trees={trees} />);
+    const { queryByText } = render(<TreeWidgetComponent trees={trees} />);
     await waitFor(() => expect(queryByText(TreeWidget.translate("noTrees"))).to.not.be.null);
   });
 
@@ -67,7 +67,7 @@ describe("<TreeWidgetComponent />", () => {
       getLabel: () => "Tree Label 2",
       render: () => <div>Tree Content 2</div>,
     }];
-    const {queryByText} = render(<TreeWidgetComponent trees={trees} />);
+    const { queryByText } = render(<TreeWidgetComponent trees={trees} />);
     await waitFor(() => expect(queryByText("Tree Content 1")).to.not.be.null);
   });
 
@@ -83,7 +83,7 @@ describe("<TreeWidgetComponent />", () => {
       getLabel: () => "Tree Label 2",
       render: () => <div>Tree Content 2</div>,
     }];
-    const {queryByText} = render(<TreeWidgetComponent trees={trees} />);
+    const { queryByText } = render(<TreeWidgetComponent trees={trees} />);
     await waitFor(() => {
       expect(queryByText("Tree Content 1")).to.be.null;
       expect(queryByText("Tree Content 2")).to.not.be.null;
@@ -99,7 +99,7 @@ describe("<TreeWidgetComponent />", () => {
       shouldShow: async () => promise,
     }];
 
-    const {container, queryByText} = render(<TreeWidgetComponent trees={trees} />);
+    const { container, queryByText } = render(<TreeWidgetComponent trees={trees} />);
     await waitFor(() => {
       const content = container.querySelector(".components-selectable-content-wrapper");
       expect(content?.children).to.not.be.empty;
@@ -115,5 +115,5 @@ describe("<TreeWidgetComponent />", () => {
 function createResolvablePromise<T>() {
   let resolve: (value: T) => void = () => {};
   const promise = new Promise<T>((resolvePromise) => {resolve = resolvePromise;});
-  return {promise, resolve};
+  return { promise, resolve };
 }

--- a/packages/itwin/tree-widget/src/test/TreeWidgetUiItemsProvider.test.tsx
+++ b/packages/itwin/tree-widget/src/test/TreeWidgetUiItemsProvider.test.tsx
@@ -4,15 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import React from "react";
 import sinon from "sinon";
 import { StagePanelLocation, StagePanelSection, StageUsage } from "@itwin/appui-react";
 import { render } from "@testing-library/react";
+import * as categoriesTreeComponents from "../components/trees/category-tree/CategoriesTreeComponent";
+import * as modelsTreeComponents from "../components/trees/models-tree/ModelsTreeComponent";
 import * as widgetComponent from "../components/TreeWidgetComponent";
 import { TreeWidgetUiItemsProvider } from "../components/TreeWidgetUiItemsProvider";
 import { TestUtils } from "./TestUtils";
-import * as modelsTreeComponents from "../components/trees/models-tree/ModelsTreeComponent";
-import * as categoriesTreeComponents from "../components/trees/category-tree/CategoriesTreeComponent";
 
 describe("TreeWidgetUiItemsProvider", () => {
   before(async () => {

--- a/packages/itwin/tree-widget/src/test/TreeWidgetUiItemsProvider.test.tsx
+++ b/packages/itwin/tree-widget/src/test/TreeWidgetUiItemsProvider.test.tsx
@@ -71,7 +71,7 @@ describe("TreeWidgetUiItemsProvider", () => {
       getLabel: () => "Tree Label",
       render: () => <div>Tree Content</div>,
     }];
-    const provider = new TreeWidgetUiItemsProvider({trees});
+    const provider = new TreeWidgetUiItemsProvider({ trees });
     const [widget] = provider.provideWidgets("", StageUsage.General, StagePanelLocation.Right, StagePanelSection.Start);
     render(<>{widget.content}</>);
 

--- a/packages/itwin/tree-widget/src/test/setup.ts
+++ b/packages/itwin/tree-widget/src/test/setup.ts
@@ -13,7 +13,7 @@ if (commonjsGlobal.MessageChannel)
 import jsdomGlobal from "jsdom-global";
 jsdomGlobal();
 
-import * as chai from "chai";
+import chai from "chai";
 import chaiJestSnapshot from "chai-jest-snapshot";
 import sinonChai from "sinon-chai";
 import path from "path";

--- a/packages/itwin/tree-widget/src/test/tree-header/SearchBox.test.tsx
+++ b/packages/itwin/tree-widget/src/test/tree-header/SearchBox.test.tsx
@@ -3,14 +3,15 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 import { EmptyLocalization } from "@itwin/core-common";
 import { render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
-import { SearchBox, SearchBoxProps } from "../../components/tree-header/SearchBox";
+import { SearchBox } from "../../components/tree-header/SearchBox";
 import { TreeWidget } from "../../TreeWidget";
+
+import type { SearchBoxProps } from "../../components/tree-header/SearchBox";
 
 describe("<SearchBox />", () => {
   const defaultProps: SearchBoxProps = {

--- a/packages/itwin/tree-widget/src/test/tree-header/TreeHeader.test.tsx
+++ b/packages/itwin/tree-widget/src/test/tree-header/TreeHeader.test.tsx
@@ -45,8 +45,8 @@ describe("<TreeHeader />", () => {
     );
 
     await waitFor(() => {
-      expect(queryByRole("button", {name: "Button1"})).to.not.be.null;
-      expect(queryByRole("button", {name: "Button2"})).to.not.be.null;
+      expect(queryByRole("button", { name: "Button1" })).to.not.be.null;
+      expect(queryByRole("button", { name: "Button2" })).to.not.be.null;
     });
   });
 

--- a/packages/itwin/tree-widget/src/test/tree-header/TreeHeader.test.tsx
+++ b/packages/itwin/tree-widget/src/test/tree-header/TreeHeader.test.tsx
@@ -3,15 +3,16 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 import { EmptyLocalization } from "@itwin/core-common";
 import { Button } from "@itwin/itwinui-react";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
-import { TreeHeader, TreeHeaderProps } from "../../components/tree-header/TreeHeader";
+import { TreeHeader } from "../../components/tree-header/TreeHeader";
 import { TreeWidget } from "../../TreeWidget";
+
+import type { TreeHeaderProps } from "../../components/tree-header/TreeHeader";
 
 describe("<TreeHeader />", () => {
   const defaultProps: TreeHeaderProps = {

--- a/packages/itwin/tree-widget/src/test/trees/CategoriesVisibilityUtils.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/CategoriesVisibilityUtils.test.ts
@@ -3,14 +3,15 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
-import { ECSqlReader, SubCategoryAppearance } from "@itwin/core-common";
-import {
-  IModelApp, IModelConnection, NoRenderApp, PerModelCategoryVisibility, ScreenViewport, SpatialViewState, ViewManager, Viewport, ViewState,
-} from "@itwin/core-frontend";
+import { SubCategoryAppearance } from "@itwin/core-common";
+import { IModelApp, NoRenderApp, PerModelCategoryVisibility } from "@itwin/core-frontend";
 import { enableCategory, enableSubCategory, toggleAllCategories } from "../../components/trees/CategoriesVisibilityUtils";
 import { TestUtils } from "../TestUtils";
+
+import type { ECSqlReader} from "@itwin/core-common";
+import type { IModelConnection, ScreenViewport, SpatialViewState, ViewManager, Viewport, ViewState} from "@itwin/core-frontend";
 
 describe("CategoryVisibilityUtils", () => {
   before(async () => {

--- a/packages/itwin/tree-widget/src/test/trees/CategoriesVisibilityUtils.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/CategoriesVisibilityUtils.test.ts
@@ -10,8 +10,8 @@ import { IModelApp, NoRenderApp, PerModelCategoryVisibility } from "@itwin/core-
 import { enableCategory, enableSubCategory, toggleAllCategories } from "../../components/trees/CategoriesVisibilityUtils";
 import { TestUtils } from "../TestUtils";
 
-import type { ECSqlReader} from "@itwin/core-common";
-import type { IModelConnection, ScreenViewport, SpatialViewState, ViewManager, Viewport, ViewState} from "@itwin/core-frontend";
+import type { ECSqlReader } from "@itwin/core-common";
+import type { IModelConnection, ScreenViewport, SpatialViewState, ViewManager, Viewport, ViewState } from "@itwin/core-frontend";
 
 describe("CategoryVisibilityUtils", () => {
   before(async () => {

--- a/packages/itwin/tree-widget/src/test/trees/Common.ts
+++ b/packages/itwin/tree-widget/src/test/trees/Common.ts
@@ -8,10 +8,10 @@ import { Id64 } from "@itwin/core-bentley";
 import { CheckBoxState } from "@itwin/core-react";
 import { StandardNodeTypes } from "@itwin/presentation-common";
 
-import type { PropertyDescription, PropertyValue} from "@itwin/appui-abstract";
+import type { PropertyDescription, PropertyValue } from "@itwin/appui-abstract";
 import type { TreeModelNode } from "@itwin/components-react";
 import type { Id64String } from "@itwin/core-bentley";
-import type { ECClassGroupingNodeKey, ECInstancesNodeKey, InstanceKey} from "@itwin/presentation-common";
+import type { ECClassGroupingNodeKey, ECInstancesNodeKey, InstanceKey } from "@itwin/presentation-common";
 import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
 
 export const createSimpleTreeModelNode = (id?: string): TreeModelNode => {

--- a/packages/itwin/tree-widget/src/test/trees/Common.ts
+++ b/packages/itwin/tree-widget/src/test/trees/Common.ts
@@ -3,12 +3,16 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { PropertyDescription, PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
-import { TreeModelNode } from "@itwin/components-react";
-import { Id64, Id64String } from "@itwin/core-bentley";
+import { PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
+import { Id64 } from "@itwin/core-bentley";
 import { CheckBoxState } from "@itwin/core-react";
-import { ECClassGroupingNodeKey, ECInstancesNodeKey, InstanceKey, StandardNodeTypes } from "@itwin/presentation-common";
-import { PresentationTreeNodeItem } from "@itwin/presentation-components";
+import { StandardNodeTypes } from "@itwin/presentation-common";
+
+import type { PropertyDescription, PropertyValue} from "@itwin/appui-abstract";
+import type { TreeModelNode } from "@itwin/components-react";
+import type { Id64String } from "@itwin/core-bentley";
+import type { ECClassGroupingNodeKey, ECInstancesNodeKey, InstanceKey} from "@itwin/presentation-common";
+import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
 
 export const createSimpleTreeModelNode = (id?: string): TreeModelNode => {
   const label = createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Node Label" });

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeEventHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeEventHandler.test.ts
@@ -5,18 +5,18 @@
 
 import { expect } from "chai";
 import { EMPTY, from, Subject } from "rxjs";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
-import { AbstractTreeNodeLoaderWithProvider, CheckboxStateChange, TreeModel, TreeModelChanges, TreeModelSource } from "@itwin/components-react";
 import { BeEvent, BeUiEvent, using } from "@itwin/core-bentley";
 import { CheckBoxState } from "@itwin/core-react";
-import { IPresentationTreeDataProvider } from "@itwin/presentation-components";
-import { SelectionHandler } from "@itwin/presentation-frontend";
-import {
-  IVisibilityHandler, VisibilityChangeListener, VisibilityStatus, VisibilityTreeEventHandler, VisibilityTreeEventHandlerParams,
-} from "../../components/trees/VisibilityTreeEventHandler";
+import { VisibilityTreeEventHandler } from "../../components/trees/VisibilityTreeEventHandler";
 import { flushAsyncOperations } from "../TestUtils";
 import { createSimpleTreeModelNode } from "./Common";
+
+import type { AbstractTreeNodeLoaderWithProvider, CheckboxStateChange, TreeModel, TreeModelChanges, TreeModelSource } from "@itwin/components-react";
+import type { IPresentationTreeDataProvider } from "@itwin/presentation-components";
+import type { SelectionHandler } from "@itwin/presentation-frontend";
+import type { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus, VisibilityTreeEventHandlerParams } from "../../components/trees/VisibilityTreeEventHandler";
 
 describe("VisibilityTreeEventHandler", () => {
   const modelSourceMock = moq.Mock.ofType<TreeModelSource>();

--- a/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTree.test.tsx
@@ -5,27 +5,32 @@
 
 import { expect } from "chai";
 import { join } from "path";
-import * as React from "react";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import { TreeNodeItem } from "@itwin/components-react";
-import { BeEvent, Id64String } from "@itwin/core-bentley";
-import { IModelApp, IModelConnection, NoRenderApp, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
-import { ECInstancesNodeKey, KeySet, LabelDefinition, Node, NodePathElement, StandardNodeTypes } from "@itwin/presentation-common";
-import { PresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
-import { Presentation, RulesetVariablesManager, SelectionChangeEvent, SelectionManager } from "@itwin/presentation-frontend";
+import { BeEvent } from "@itwin/core-bentley";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { KeySet, LabelDefinition, StandardNodeTypes } from "@itwin/presentation-common";
+import { PresentationTreeDataProvider } from "@itwin/presentation-components";
+import { Presentation, SelectionChangeEvent } from "@itwin/presentation-frontend";
 import {
   buildTestIModel, HierarchyBuilder, HierarchyCacheMode, initialize as initializePresentationTesting, terminate as terminatePresentationTesting,
 } from "@itwin/presentation-testing";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { CategoryTree, RULESET_CATEGORIES } from "../../../components/trees/category-tree/CategoriesTree";
-import { CategoryVisibilityHandler } from "../../../components/trees/category-tree/CategoryVisibilityHandler";
-import { VisibilityChangeListener } from "../../../components/trees/VisibilityTreeEventHandler";
 import {
   addDrawingCategory, addDrawingGraphic, addModel, addPartition, addPhysicalObject, addSpatialCategory, addSubCategory,
 } from "../../IModelUtils";
 import { mockPresentationManager, mockViewport, TestUtils } from "../../TestUtils";
+
+import type { TreeNodeItem } from "@itwin/components-react";
+import type { Id64String } from "@itwin/core-bentley";
+import type { IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
+import type { ECInstancesNodeKey, Node, NodePathElement} from "@itwin/presentation-common";
+import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
+import type { RulesetVariablesManager, SelectionManager } from "@itwin/presentation-frontend";
+import type { CategoryVisibilityHandler } from "../../../components/trees/category-tree/CategoryVisibilityHandler";
+import type { VisibilityChangeListener } from "../../../components/trees/VisibilityTreeEventHandler";
 
 describe("CategoryTree", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTree.test.tsx
@@ -26,7 +26,7 @@ import { mockPresentationManager, mockViewport, TestUtils } from "../../TestUtil
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
-import type { ECInstancesNodeKey, Node, NodePathElement} from "@itwin/presentation-common";
+import type { ECInstancesNodeKey, Node, NodePathElement } from "@itwin/presentation-common";
 import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
 import type { RulesetVariablesManager, SelectionManager } from "@itwin/presentation-frontend";
 import type { CategoryVisibilityHandler } from "../../../components/trees/category-tree/CategoryVisibilityHandler";

--- a/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesTreeComponent.test.tsx
@@ -3,15 +3,17 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
-import * as moq from "typemoq";
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { CategoriesTreeComponent, CategoryInfo } from "../../../tree-widget-react";
-import { IModelApp, IModelConnection, NoRenderApp, Viewport } from "@itwin/core-frontend";
-import { mockViewport, TestUtils } from "../../TestUtils";
-import sinon from "sinon";
 import { expect } from "chai";
+import sinon from "sinon";
+import * as moq from "typemoq";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import * as categoriesVisibilityHandler from "../../../components/trees/category-tree/CategoryVisibilityHandler";
+import { CategoriesTreeComponent } from "../../../tree-widget-react";
+import { mockViewport, TestUtils } from "../../TestUtils";
+
+import type { CategoryInfo } from "../../../tree-widget-react";
+import type { IModelConnection, Viewport } from "@itwin/core-frontend";
 
 describe("<CategoriesTreeComponent />", () => {
   before(async () => {

--- a/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesVisibilityHandler.test.ts
@@ -17,11 +17,11 @@ import {
 } from "../../../components/trees/category-tree/CategoryVisibilityHandler";
 import { mockViewport } from "../../TestUtils";
 
-import type { Id64String} from "@itwin/core-bentley";
+import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection, ViewManager, Viewport, ViewState } from "@itwin/core-frontend";
-import type { ECInstancesNodeKey} from "@itwin/presentation-common";
+import type { ECInstancesNodeKey } from "@itwin/presentation-common";
 import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
-import type { CategoryInfo, CategoryVisibilityHandlerParams} from "../../../components/trees/category-tree/CategoryVisibilityHandler";
+import type { CategoryInfo, CategoryVisibilityHandlerParams } from "../../../components/trees/category-tree/CategoryVisibilityHandler";
 
 const createKey = (id: Id64String): ECInstancesNodeKey => {
   return {

--- a/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/category-tree/CategoriesVisibilityHandler.test.ts
@@ -4,22 +4,24 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
 import * as UiComponents from "@itwin/components-react";
-import { BeEvent, Id64String, using } from "@itwin/core-bentley";
-import {
-  IModelConnection, ViewManager, Viewport, ViewState,
-} from "@itwin/core-frontend";
-import { ECInstancesNodeKey, StandardNodeTypes } from "@itwin/presentation-common";
-import { PresentationTreeNodeItem } from "@itwin/presentation-components";
+import { BeEvent, using } from "@itwin/core-bentley";
+import { StandardNodeTypes } from "@itwin/presentation-common";
 import { renderHook } from "@testing-library/react-hooks";
-import {
-  CategoryInfo, CategoryVisibilityHandler, CategoryVisibilityHandlerParams, hideAllCategories, invertAllCategories, showAllCategories, useCategories,
-} from "../../../components/trees/category-tree/CategoryVisibilityHandler";
 import * as categoriesVisibilityUtils from "../../../components/trees/CategoriesVisibilityUtils";
+import {
+  CategoryVisibilityHandler, hideAllCategories, invertAllCategories, showAllCategories, useCategories,
+} from "../../../components/trees/category-tree/CategoryVisibilityHandler";
 import { mockViewport } from "../../TestUtils";
+
+import type { Id64String} from "@itwin/core-bentley";
+import type { IModelConnection, ViewManager, Viewport, ViewState } from "@itwin/core-frontend";
+import type { ECInstancesNodeKey} from "@itwin/presentation-common";
+import type { PresentationTreeNodeItem } from "@itwin/presentation-components";
+import type { CategoryInfo, CategoryVisibilityHandlerParams} from "../../../components/trees/category-tree/CategoryVisibilityHandler";
 
 const createKey = (id: Id64String): ECInstancesNodeKey => {
   return {

--- a/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTree.test.tsx
@@ -6,20 +6,25 @@
 import { expect } from "chai";
 import { join } from "path";
 import * as sinon from "sinon";
-import * as React from "react";
 import * as moq from "typemoq";
-import { Guid, Id64String } from "@itwin/core-bentley";
-import { BisCodeSpec, ElementProps, IModel } from "@itwin/core-common";
-import { IModelApp, IModelConnection, NoRenderApp } from "@itwin/core-frontend";
-import { KeySet, LabelDefinition, Node, NodeKey } from "@itwin/presentation-common";
-import { Presentation, PresentationManager, SelectionChangeEvent, SelectionManager } from "@itwin/presentation-frontend";
+import { Guid } from "@itwin/core-bentley";
+import { BisCodeSpec, IModel } from "@itwin/core-common";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { KeySet, LabelDefinition } from "@itwin/presentation-common";
+import { Presentation, SelectionChangeEvent } from "@itwin/presentation-frontend";
 import {
   buildTestIModel, HierarchyBuilder, HierarchyCacheMode, initialize as initializePresentationTesting, terminate as terminatePresentationTesting,
-  TestIModelBuilder,
 } from "@itwin/presentation-testing";
 import { render, waitFor } from "@testing-library/react";
 import { ExternalSourcesTree, RULESET_EXTERNAL_SOURCES } from "../../../components/trees/external-sources-tree/ExternalSourcesTree";
 import { mockPresentationManager, TestUtils } from "../../TestUtils";
+
+import type { Id64String } from "@itwin/core-bentley";
+import type { ElementProps } from "@itwin/core-common";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { Node, NodeKey } from "@itwin/presentation-common";
+import type { PresentationManager, SelectionManager } from "@itwin/presentation-frontend";
+import type { TestIModelBuilder } from "@itwin/presentation-testing";
 
 describe("ExternalSourcesTree", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTreeComponent.test.tsx
@@ -5,7 +5,6 @@
 
 import { expect } from "chai";
 import * as sinon from "sinon";
-import * as React from "react";
 import { UiFramework } from "@itwin/appui-react";
 import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
 import { render } from "@testing-library/react";

--- a/packages/itwin/tree-widget/src/test/trees/imodel-content-tree/IModelContentTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/imodel-content-tree/IModelContentTree.test.tsx
@@ -25,8 +25,8 @@ import { mockPresentationManager, TestUtils } from "../../TestUtils";
 
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { Id64String } from "@itwin/core-bentley";
-import type { IModelConnection} from "@itwin/core-frontend";
-import type { ECInstancesNodeKey} from "@itwin/presentation-common";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { ECInstancesNodeKey } from "@itwin/presentation-common";
 
 describe("IModelContentTree", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/imodel-content-tree/IModelContentTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/imodel-content-tree/IModelContentTree.test.tsx
@@ -5,15 +5,12 @@
 
 import { expect } from "chai";
 import { join } from "path";
-import * as React from "react";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import { TreeNodeItem } from "@itwin/components-react";
-import { Id64String } from "@itwin/core-bentley";
 import { BisCodeSpec, IModel } from "@itwin/core-common";
-import { IModelApp, IModelConnection, NoRenderApp } from "@itwin/core-frontend";
-import { ECInstancesNodeKey, StandardNodeTypes } from "@itwin/presentation-common";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { StandardNodeTypes } from "@itwin/presentation-common";
 import { PresentationTreeDataProvider } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import {
@@ -25,6 +22,11 @@ import {
   addDocument, addDrawingCategory, addDrawingGraphic, addGroup, addModel, addPartition, addPhysicalObject, addSpatialCategory, addSubject,
 } from "../../IModelUtils";
 import { mockPresentationManager, TestUtils } from "../../TestUtils";
+
+import type { TreeNodeItem } from "@itwin/components-react";
+import type { Id64String } from "@itwin/core-bentley";
+import type { IModelConnection} from "@itwin/core-frontend";
+import type { ECInstancesNodeKey} from "@itwin/presentation-common";
 
 describe("IModelContentTree", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -5,28 +5,33 @@
 
 import { expect } from "chai";
 import { join } from "path";
-import * as React from "react";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import { SelectionMode, TreeNodeItem } from "@itwin/components-react";
+import { SelectionMode } from "@itwin/components-react";
 import { BeEvent } from "@itwin/core-bentley";
-import { IModelApp, IModelConnection, NoRenderApp } from "@itwin/core-frontend";
-import { ECInstancesNodeKey, KeySet, LabelDefinition, Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
+import { IModel } from "@itwin/core-common";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { KeySet, LabelDefinition } from "@itwin/presentation-common";
 import { PresentationTreeDataProvider } from "@itwin/presentation-components";
-import { Presentation, SelectionChangeEvent, SelectionManager } from "@itwin/presentation-frontend";
+import { Presentation, SelectionChangeEvent } from "@itwin/presentation-frontend";
 import {
   buildTestIModel, HierarchyBuilder, HierarchyCacheMode, initialize as initializePresentationTesting, terminate as terminatePresentationTesting,
 } from "@itwin/presentation-testing";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { ModelsTree } from "../../../components/trees/models-tree/ModelsTree";
-import { ModelsTreeNodeType, ModelsVisibilityHandler } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import { ModelsTreeNodeType } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
 import { createRuleset } from "../../../components/trees/models-tree/Utils";
-import { VisibilityChangeListener } from "../../../components/trees/VisibilityTreeEventHandler";
 import { addModel, addPartition, addPhysicalObject, addSpatialCategory, addSpatialLocationElement } from "../../IModelUtils";
 import { deepEquals, mockPresentationManager, mockViewport, TestUtils } from "../../TestUtils";
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createKey, createModelNode, createSubjectNode } from "../Common";
-import { IModel } from "@itwin/core-common";
+
+import type { TreeNodeItem } from "@itwin/components-react";
+import type { IModelConnection} from "@itwin/core-frontend";
+import type { ECInstancesNodeKey, Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
+import type { SelectionManager } from "@itwin/presentation-frontend";
+import type { ModelsVisibilityHandler } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import type { VisibilityChangeListener } from "../../../components/trees/VisibilityTreeEventHandler";
 
 describe("ModelsTree", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -27,7 +27,7 @@ import { deepEquals, mockPresentationManager, mockViewport, TestUtils } from "..
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createKey, createModelNode, createSubjectNode } from "../Common";
 
 import type { TreeNodeItem } from "@itwin/components-react";
-import type { IModelConnection} from "@itwin/core-frontend";
+import type { IModelConnection } from "@itwin/core-frontend";
 import type { ECInstancesNodeKey, Node, NodeKey, NodePathElement } from "@itwin/presentation-common";
 import type { SelectionManager } from "@itwin/presentation-frontend";
 import type { ModelsVisibilityHandler } from "../../../components/trees/models-tree/ModelsVisibilityHandler";

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
@@ -13,7 +13,7 @@ import * as modelsVisibilityHandler from "../../../components/trees/models-tree/
 import { ModelsTreeComponent } from "../../../tree-widget-react";
 import { mockViewport, TestUtils } from "../../TestUtils";
 
-import type { ModelInfo} from "../../../tree-widget-react";
+import type { ModelInfo } from "../../../tree-widget-react";
 import type { Viewport } from "@itwin/core-frontend";
 
 describe("<ModelsTreeComponent />", () => {
@@ -37,7 +37,7 @@ describe("<ModelsTreeComponent />", () => {
     vpMock = mockViewport();
   });
 
-  const models: ModelInfo[] = [{id: "testModelId1"}, {id: "testModelId2"}];
+  const models: ModelInfo[] = [{ id: "testModelId1" }, { id: "testModelId2" }];
 
   describe("models tree header buttons", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
@@ -3,16 +3,18 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
-import * as moq from "typemoq";
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { ModelInfo, ModelsTreeComponent } from "../../../tree-widget-react";
-import { IModelApp, NoRenderApp, Viewport } from "@itwin/core-frontend";
-import sinon from "sinon";
-import { mockViewport, TestUtils } from "../../TestUtils";
 import { expect } from "chai";
-import * as modelsVisibilityHandler from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import sinon from "sinon";
+import * as moq from "typemoq";
 import { BeEvent } from "@itwin/core-bentley";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import * as modelsVisibilityHandler from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import { ModelsTreeComponent } from "../../../tree-widget-react";
+import { mockViewport, TestUtils } from "../../TestUtils";
+
+import type { ModelInfo} from "../../../tree-widget-react";
+import type { Viewport } from "@itwin/core-frontend";
 
 describe("<ModelsTreeComponent />", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsVisibilityHandler.test.ts
@@ -20,13 +20,13 @@ import { isPromiseLike } from "../../../components/utils/IsPromiseLike";
 import { mockViewport, TestUtils } from "../../TestUtils";
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createModelNode, createSubjectNode } from "../Common";
 
-import type { Id64String} from "@itwin/core-bentley";
-import type { ECSqlReader} from "@itwin/core-common";
+import type { Id64String } from "@itwin/core-bentley";
+import type { ECSqlReader } from "@itwin/core-common";
 import type { IModelConnection, Viewport, ViewState, ViewState3d } from "@itwin/core-frontend";
 import type { ECInstancesNodeKey } from "@itwin/presentation-common";
 import type { IFilteredPresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
 import type { IModelHierarchyChangeEventArgs, PresentationManager } from "@itwin/presentation-frontend";
-import type { ModelsVisibilityHandlerProps} from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import type { ModelsVisibilityHandlerProps } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
 import type { ModelInfo } from "../../../tree-widget-react";
 
 describe("ModelsVisibilityHandler", () => {
@@ -97,7 +97,7 @@ describe("ModelsVisibilityHandler", () => {
 
   };
 
-  const modelsInfo: ModelInfo[] = [{ id: "ModelId1"}, { id: "ModelId2" }];
+  const modelsInfo: ModelInfo[] = [{ id: "ModelId1" }, { id: "ModelId2" }];
 
   describe("constructor", () => {
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsVisibilityHandler.test.ts
@@ -4,22 +4,30 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import { BeEvent, Id64String, using } from "@itwin/core-bentley";
-import { ECSqlReader, QueryRowFormat } from "@itwin/core-common";
-import { IModelApp, IModelConnection, NoRenderApp, PerModelCategoryVisibility, Viewport, ViewState, ViewState3d } from "@itwin/core-frontend";
-import { ECInstancesNodeKey } from "@itwin/presentation-common";
-import { IFilteredPresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
-import { IModelHierarchyChangeEventArgs, Presentation, PresentationManager } from "@itwin/presentation-frontend";
-import { areAllModelsVisible, hideAllModels, invertAllModels, ModelsVisibilityHandler, ModelsVisibilityHandlerProps, showAllModels, toggleModels } from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import { BeEvent, using } from "@itwin/core-bentley";
+import { QueryRowFormat } from "@itwin/core-common";
+import { IModelApp, NoRenderApp, PerModelCategoryVisibility } from "@itwin/core-frontend";
+import { Presentation } from "@itwin/presentation-frontend";
+import * as categoriesVisibilityUtils from "../../../components/trees/CategoriesVisibilityUtils";
+import {
+  areAllModelsVisible, hideAllModels, invertAllModels, ModelsVisibilityHandler, showAllModels, toggleModels,
+} from "../../../components/trees/models-tree/ModelsVisibilityHandler";
 import { CachingElementIdsContainer } from "../../../components/trees/models-tree/Utils";
 import { isPromiseLike } from "../../../components/utils/IsPromiseLike";
 import { mockViewport, TestUtils } from "../../TestUtils";
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createModelNode, createSubjectNode } from "../Common";
-import { ModelInfo } from "../../../tree-widget-react";
-import * as categoriesVisibilityUtils from "../../../components/trees/CategoriesVisibilityUtils";
+
+import type { Id64String} from "@itwin/core-bentley";
+import type { ECSqlReader} from "@itwin/core-common";
+import type { IModelConnection, Viewport, ViewState, ViewState3d } from "@itwin/core-frontend";
+import type { ECInstancesNodeKey } from "@itwin/presentation-common";
+import type { IFilteredPresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
+import type { IModelHierarchyChangeEventArgs, PresentationManager } from "@itwin/presentation-frontend";
+import type { ModelsVisibilityHandlerProps} from "../../../components/trees/models-tree/ModelsVisibilityHandler";
+import type { ModelInfo } from "../../../tree-widget-react";
 
 describe("ModelsVisibilityHandler", () => {
 

--- a/packages/itwin/tree-widget/tsconfig.json
+++ b/packages/itwin/tree-widget/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "./node_modules/@itwin/build-tools/tsconfig-base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitOverride": false,
     "resolveJsonModule": true,
-
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/470

Added eslint rule to force consistent usage of type imports.
Switched to using JSX without importing React.