### PR TITLE
Tree widget: External sources tree

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree-widget-external-sources-tree_2023-04-07-13-59.json
+++ b/common/changes/@itwin/tree-widget-react/tree-widget-external-sources-tree_2023-04-07-13-59.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "**BREAKING** `IVisibilityHandler`: Methods `getVisibilityStatus` and `changeVisibility` don't take `NodeKey` argument anymore.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "External sources tree: Add `ExternalSourcesTreeComponent` (currently `@alpha`).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1264,6 +1264,7 @@ importers:
 
   ../../packages/itwin/tree-widget:
     specifiers:
+      '@bentley/icons-generic': ^1.0.34
       '@itwin/appui-abstract': ^3.7.0
       '@itwin/appui-layout-react': ^4.0.0-dev.17
       '@itwin/appui-react': ^4.0.0-dev.17
@@ -1299,6 +1300,7 @@ importers:
       '@testing-library/user-event': 14.4.3
       '@types/chai': 4.3.1
       '@types/chai-jest-snapshot': ^1.3.4
+      '@types/chai-subset': 1.3.1
       '@types/deep-equal': ^1.0.1
       '@types/i18next': ^8.4.2
       '@types/jsdom-global': 3.0.2
@@ -1312,6 +1314,7 @@ importers:
       '@typescript-eslint/parser': ^5.0.0
       chai: ^4.2.0
       chai-jest-snapshot: ^2.0.0
+      chai-subset: 1.6.0
       classnames: ^2.3.1
       cpx2: ^3.0.0
       deep-equal: ^1.0.0
@@ -1333,6 +1336,7 @@ importers:
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
     dependencies:
+      '@bentley/icons-generic': 1.0.34
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-react': 2.7.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-variables': 2.0.0
@@ -1374,6 +1378,7 @@ importers:
       '@testing-library/user-event': 14.4.3_@testing-library+dom@8.13.0
       '@types/chai': 4.3.1
       '@types/chai-jest-snapshot': 1.3.6
+      '@types/chai-subset': 1.3.1
       '@types/deep-equal': 1.0.1
       '@types/i18next': 8.4.6
       '@types/jsdom-global': 3.0.2
@@ -1387,6 +1392,7 @@ importers:
       '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.4.4
       chai: 4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
+      chai-subset: 1.6.0
       cpx2: 3.0.2
       deep-equal: 1.1.1
       eslint: 7.32.0
@@ -9206,6 +9212,12 @@ packages:
       '@types/mocha': 8.2.3
     dev: true
 
+  /@types/chai-subset/1.3.1:
+    resolution: {integrity: sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==}
+    dependencies:
+      '@types/chai': 4.3.1
+    dev: true
+
   /@types/chai/4.2.11:
     resolution: {integrity: sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==}
     dev: true
@@ -12038,6 +12050,11 @@ packages:
       chai: '*'
     dependencies:
       chai: 4.3.6
+    dev: true
+
+  /chai-subset/1.6.0:
+    resolution: {integrity: sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==}
+    engines: {node: '>=4'}
     dev: true
 
   /chai/4.3.6:
@@ -24735,6 +24752,7 @@ packages:
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
+      '@bentley/icons-generic': 1.0.34
       '@itwin/appui-abstract': 3.7.1_@itwin+core-bentley@3.7.1
       '@itwin/appui-react': 4.0.0-dev.16_3c7dc2811e2bd907465217366b920d4a
       '@itwin/components-react': 4.0.0-dev.16_d1cccb25e365807baf083cdc453a5b3a

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -38,6 +38,7 @@
     "rebuild": "npm run clean && npm run build"
   },
   "dependencies": {
+    "@bentley/icons-generic": "^1.0.34",
     "@itwin/itwinui-icons-react": "^2.1.0",
     "@itwin/itwinui-react": "^2.7.0",
     "@itwin/itwinui-variables": "^2.0.0",
@@ -80,6 +81,7 @@
     "@testing-library/user-event": "14.4.3",
     "@types/chai": "4.3.1",
     "@types/chai-jest-snapshot": "^1.3.4",
+    "@types/chai-subset": "1.3.1",
     "@types/deep-equal": "^1.0.1",
     "@types/i18next": "^8.4.2",
     "@types/jsdom-global": "3.0.2",
@@ -93,6 +95,7 @@
     "@typescript-eslint/parser": "^5.0.0",
     "chai": "^4.2.0",
     "chai-jest-snapshot": "^2.0.0",
+    "chai-subset": "1.6.0",
     "cpx2": "^3.0.0",
     "deep-equal": "^1.0.0",
     "eslint": "^7.11.0",

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSources.json
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSources.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "../../../../node_modules/@itwin/presentation-common/Ruleset.schema.json",
+  "id": "ExternalSources",
+  "requiredSchemas": [
+    {
+      "name": "BisCore",
+      "minVersion": "1.0.13"
+    }
+  ],
+  "rules": [
+    {
+      "ruleType": "RootNodes",
+      "specifications": [
+        {
+          "specType": "InstanceNodesOfSpecificClasses",
+          "classes": [
+            {
+              "schemaName": "BisCore",
+              "classNames": [
+                "ExternalSource"
+              ],
+              "arePolymorphic": false
+            }
+          ],
+          "relatedInstances": [
+            {
+              "relationshipPath": [
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "SynchronizationConfigSpecifiesRootSources"
+                  },
+                  "direction": "Backward"
+                }
+              ],
+              "isRequired": true,
+              "alias": "configRoot"
+            },
+            {
+              "relationshipPath": [
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceIsInRepository"
+                  },
+                  "direction": "Forward"
+                }
+              ],
+              "isRequired": true,
+              "alias": "repo"
+            }
+          ],
+          "instanceFilter": "configRoot.ECInstanceId <> NULL",
+          "groupByClass": false,
+          "groupByLabel": false
+        }
+      ],
+      "autoExpand": true
+    },
+    {
+      "ruleType": "ChildNodes",
+      "condition": "ParentNode.IsOfClass(\"ExternalSourceGroup\", \"BisCore\")",
+      "specifications": [
+        {
+          "specType": "RelatedInstanceNodes",
+          "relationshipPaths": [
+            [
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ExternalSourceGroupGroupsSources"
+                },
+                "direction": "Forward"
+              }
+            ]
+          ],
+          "groupByClass": false,
+          "groupByLabel": false
+        }
+      ]
+    },
+    {
+      "ruleType": "ChildNodes",
+      "condition": "ParentNode.IsOfClass(\"ExternalSource\", \"BisCore\")",
+      "specifications": [
+        {
+          "specType": "RelatedInstanceNodes",
+          "relationshipPaths": [
+            [
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ExternalSourceOwnsAttachments"
+                },
+                "direction": "Forward"
+              },
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ExternalSourceAttachmentAttachesSource"
+                },
+                "direction": "Forward"
+              }
+            ]
+          ],
+          "groupByClass": false,
+          "groupByLabel": false
+        },
+        {
+          "specType": "CustomNode",
+          "type": "T_ExternalSource_Elements",
+          "label": "Elements",
+          "hideIfNoChildren": true,
+          "nestedRules": [
+            {
+              "ruleType": "ChildNodes",
+              "specifications": [
+                {
+                  "specType": "RelatedInstanceNodes",
+                  "relationshipPaths": [
+                    [
+                      {
+                        "relationship": {
+                          "schemaName": "BisCore",
+                          "className": "ElementIsFromSource"
+                        },
+                        "direction": "Backward",
+                        "targetClass": {
+                          "schemaName": "BisCore",
+                          "className": "ExternalSourceAspect"
+                        }
+                      },
+                      {
+                        "relationship": {
+                          "schemaName": "BisCore",
+                          "className": "ElementOwnsMultiAspects"
+                        },
+                        "direction": "Backward",
+                        "targetClass": {
+                          "schemaName": "BisCore",
+                          "className": "GeometricElement"
+                        }
+                      }
+                    ]
+                  ],
+                  "groupByClass": true,
+                  "groupByLabel": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ruleType": "InstanceLabelOverride",
+      "class": {
+        "schemaName": "BisCore",
+        "className": "RepositoryLink"
+      },
+      "values": [
+        {
+          "specType": "Property",
+          "propertyName": "UserLabel"
+        }
+      ]
+    },
+    {
+      "ruleType": "InstanceLabelOverride",
+      "class": {
+        "schemaName": "BisCore",
+        "className": "ExternalSource"
+      },
+      "values": [
+        {
+          "specType": "Composite",
+          "separator": " - ",
+          "parts": [
+            {
+              "spec": {
+                "specType": "RelatedInstanceLabel",
+                "pathToRelatedInstance": {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceIsInRepository"
+                  },
+                  "direction": "Forward"
+                }
+              }
+            },
+            {
+              "spec": {
+                "specType": "Property",
+                "propertyName": "UserLabel"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ruleType": "ExtendedData",
+      "condition": "ThisNode.IsInstanceNode ANDALSO this.IsOfClass(\"ExternalSource\", \"BisCore\")",
+      "items": {
+        "imageId": "\"icon-document\""
+      }
+    },
+    {
+      "ruleType": "ExtendedData",
+      "condition": "ThisNode.Type = \"T_ExternalSource_Elements\"",
+      "items": {
+        "imageId": "\"icon-ec-schema\""
+      }
+    },
+    {
+      "ruleType": "ExtendedData",
+      "condition": "ThisNode.IsClassGroupingNode",
+      "items": {
+        "imageId": "\"icon-ec-class\""
+      }
+    },
+    {
+      "ruleType": "ExtendedData",
+      "condition": "ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass(\"GeometricElement\", \"BisCore\")",
+      "items": {
+        "imageId": "\"icon-item\""
+      }
+    }
+  ]
+}

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import "../VisibilityTreeBase.scss";
+import { ControlledTree, DelayLoadedTreeNodeItem, SelectionMode, useTreeModel } from "@itwin/components-react";
+import { IModelConnection } from "@itwin/core-frontend";
+import { Node, Ruleset } from "@itwin/presentation-common";
+import { usePresentationTreeNodeLoader, useUnifiedSelectionTreeEventHandler } from "@itwin/presentation-components";
+import * as RULESET_EXTERNAL_SOURCES_IMPORT from "./ExternalSources.json";
+
+/**
+ * Presentation rules used by ControlledCategoriesTree
+ * @internal
+ */
+export const RULESET_EXTERNAL_SOURCES = RULESET_EXTERNAL_SOURCES_IMPORT as Ruleset;
+
+const PAGING_SIZE = 20;
+
+/**
+ * Props for the [[ExternalSourcesTree]] component
+ * @alpha
+ */
+export interface ExternalSourcesTreeProps {
+  /** An IModel to pull data from */
+  iModel: IModelConnection;
+  /** Width of the component */
+  width: number;
+  /** Height of the component */
+  height: number;
+}
+
+/**
+ * Tree which displays a hierarchy of ExternalSources and their elements.
+ * @alpha
+ */
+export function ExternalSourcesTree(props: ExternalSourcesTreeProps) {
+  const { nodeLoader } = usePresentationTreeNodeLoader({
+    imodel: props.iModel,
+    ruleset: RULESET_EXTERNAL_SOURCES,
+    pagingSize: PAGING_SIZE,
+    customizeTreeNodeItem,
+  });
+  const eventsHandler = useUnifiedSelectionTreeEventHandler({ nodeLoader });
+  const treeModel = useTreeModel(nodeLoader.modelSource);
+  return (
+    <div className="tree-widget-visibility-tree-base">
+      <ControlledTree
+        nodeLoader={nodeLoader}
+        model={treeModel}
+        selectionMode={SelectionMode.Extended}
+        eventsHandler={eventsHandler}
+        width={props.width}
+        height={props.height}
+        iconsEnabled={true}
+      />
+    </div>
+  );
+}
+
+function customizeTreeNodeItem(item: Partial<DelayLoadedTreeNodeItem>, node: Partial<Node>) {
+  item.icon = node.extendedData?.imageId;
+}

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
+import * as React from "react";
 import { ControlledTree, DelayLoadedTreeNodeItem, SelectionMode, useTreeModel } from "@itwin/components-react";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Node, Ruleset } from "@itwin/presentation-common";

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import "../VisibilityTreeBase.scss";
+import * as React from "react";
 import { useActiveIModelConnection } from "@itwin/appui-react";
 import { AutoSizer } from "../../utils/AutoSizer";
 import { ExternalSourcesTree } from "./ExternalSourcesTree";

--- a/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import "../VisibilityTreeBase.scss";
+import { useActiveIModelConnection } from "@itwin/appui-react";
+import { AutoSizer } from "../../utils/AutoSizer";
+import { ExternalSourcesTree } from "./ExternalSourcesTree";
+import { IModelConnection } from "@itwin/core-frontend";
+
+/**
+ * A component that displays an External Sources tree and any necessary "chrome".
+ * @alpha
+ */
+export function ExternalSourcesTreeComponent(props: {}) {
+  const iModel = useActiveIModelConnection();
+  if (!iModel) {
+    return null;
+  }
+  return (
+    <ExternalSourcesTreeComponentImpl {...props} iModel={iModel} />
+  );
+}
+
+function ExternalSourcesTreeComponentImpl(props: { iModel: IModelConnection }) {
+  return (
+    <AutoSizer>
+      {({ width, height }) => (
+        <ExternalSourcesTree
+          {...props}
+          width={width}
+          height={height}
+        />
+      )}
+    </AutoSizer>
+  );
+}

--- a/packages/itwin/tree-widget/src/components/trees/index.ts
+++ b/packages/itwin/tree-widget/src/components/trees/index.ts
@@ -14,6 +14,9 @@ export * from "./category-tree/CategoriesTree";
 export * from "./category-tree/CategoriesTreeComponent";
 export * from "./category-tree/CategoryVisibilityHandler";
 
+export * from "./external-sources-tree/ExternalSourcesTree";
+export * from "./external-sources-tree/ExternalSourcesTreeComponent";
+
 export * from "./models-tree/ModelsTree";
 export * from "./models-tree/ModelsTreeComponent";
 export * from "./models-tree/ModelsVisibilityHandler";

--- a/packages/itwin/tree-widget/src/test/setup.ts
+++ b/packages/itwin/tree-widget/src/test/setup.ts
@@ -15,12 +15,14 @@ jsdomGlobal();
 
 import * as chai from "chai";
 import chaiJestSnapshot from "chai-jest-snapshot";
+import chaiSubset from "chai-subset";
 import sinonChai from "sinon-chai";
 import path from "path";
 
 // setup chai
 chai.should();
 chai.use(chaiJestSnapshot);
+chai.use(chaiSubset);
 chai.use(sinonChai);
 
 before(async function () {

--- a/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTree.test.tsx
@@ -1,0 +1,365 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { join } from "path";
+import * as sinon from "sinon";
+import * as moq from "typemoq";
+import { PropertyRecord } from "@itwin/appui-abstract";
+import { TreeNodeItem } from "@itwin/components-react";
+import { Guid, Id64String } from "@itwin/core-bentley";
+import { BisCodeSpec, ElementProps, IModel } from "@itwin/core-common";
+import { IModelApp, IModelConnection, NoRenderApp } from "@itwin/core-frontend";
+import { KeySet, NodeKey } from "@itwin/presentation-common";
+import { PresentationTreeDataProvider } from "@itwin/presentation-components";
+import { Presentation, SelectionChangeEvent, SelectionManager } from "@itwin/presentation-frontend";
+import {
+  buildTestIModel, HierarchyBuilder, HierarchyCacheMode, initialize as initializePresentationTesting, terminate as terminatePresentationTesting,
+  TestIModelBuilder,
+} from "@itwin/presentation-testing";
+import { render, waitFor } from "@testing-library/react";
+import { mockPresentationManager, TestUtils } from "../../TestUtils";
+import { ExternalSourcesTree, RULESET_EXTERNAL_SOURCES } from "../../../components/trees/external-sources-tree/ExternalSourcesTree";
+
+describe("ExternalSourcesTree", () => {
+
+  describe("#unit", () => {
+    const sizeProps = { width: 200, height: 200 };
+
+    before(async () => {
+      // TODO: remove this eslint rule when tree-widget uses itwinjs-core 4.0.0 version
+      await NoRenderApp.startup(); // eslint-disable-line @itwin/no-internal
+      await TestUtils.initialize();
+    });
+
+    after(async () => {
+      TestUtils.terminate();
+      await IModelApp.shutdown();
+    });
+
+    const imodelMock = moq.Mock.ofType<IModelConnection>();
+    const selectionManagerMock = moq.Mock.ofType<SelectionManager>();
+
+    beforeEach(() => {
+      imodelMock.reset();
+      selectionManagerMock.reset();
+
+      const selectionChangeEvent = new SelectionChangeEvent();
+      selectionManagerMock.setup((x) => x.selectionChange).returns(() => selectionChangeEvent);
+      selectionManagerMock.setup((x) => x.getSelectionLevels(imodelMock.object)).returns(() => []);
+      selectionManagerMock.setup((x) => x.getSelection(imodelMock.object, moq.It.isAny())).returns(() => new KeySet());
+
+      const mocks = mockPresentationManager();
+      sinon.stub(Presentation, "presentation").get(() => mocks.presentationManager.object);
+      sinon.stub(Presentation, "selection").get(() => selectionManagerMock.object);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    const createInvalidNodeKey = (): NodeKey => {
+      return { type: "invalid", version: 0, pathFromRoot: [] };
+    };
+
+    describe("<ExternalSourcesTree />", () => {
+      beforeEach(() => {
+        sinon.stub(PresentationTreeDataProvider.prototype, "imodel").get(() => imodelMock.object);
+        sinon.stub(PresentationTreeDataProvider.prototype, "rulesetId").get(() => "");
+        sinon.stub(PresentationTreeDataProvider.prototype, "dispose");
+        sinon.stub(PresentationTreeDataProvider.prototype, "getFilteredNodePaths").resolves([]);
+        sinon.stub(PresentationTreeDataProvider.prototype, "getNodeKey").callsFake((node: any) => node.__key);
+        sinon.stub(PresentationTreeDataProvider.prototype, "getNodesCount").resolves(0);
+        sinon.stub(PresentationTreeDataProvider.prototype, "getNodes").resolves([]);
+      });
+
+      const setupDataProvider = (nodes: TreeNodeItem[]) => {
+        (PresentationTreeDataProvider.prototype.getNodesCount as any).restore();
+        sinon.stub(PresentationTreeDataProvider.prototype, "getNodesCount").resolves(nodes.length);
+
+        (PresentationTreeDataProvider.prototype.getNodes as any).restore();
+        sinon.stub(PresentationTreeDataProvider.prototype, "getNodes").callsFake(
+          async () => nodes.map((n) => ({ __key: createInvalidNodeKey(), ...n })),
+        );
+      };
+
+      it("should have expected structure", async () => {
+        setupDataProvider([{ id: "test", label: PropertyRecord.fromString("test-node") }]);
+        const result = render(
+          <ExternalSourcesTree {...sizeProps} iModel={imodelMock.object} />,
+        );
+        await waitFor(() => result.getByText("test-node"));
+        result.getByRole("tree");
+        result.getByRole("treeitem");
+      });
+    });
+  });
+
+  describe("#integration", () => {
+    beforeEach(async () => {
+      await initializePresentationTesting({
+        backendProps: {
+          caching: {
+            hierarchies: {
+              mode: HierarchyCacheMode.Memory,
+            },
+          },
+        },
+        testOutputDir: join(__dirname, "output"),
+      });
+    });
+
+    afterEach(async () => {
+      await terminatePresentationTesting();
+    });
+
+    it("creates auto-expanded root nodes with correct icons", async function () {
+      const iModel: IModelConnection = await buildTestIModel(this, (builder) => {
+        addRootExternalSource(builder, "Test external source");
+      });
+      const hierarchyBuilder = new HierarchyBuilder({ imodel: iModel });
+      const hierarchy = await hierarchyBuilder.createHierarchy(RULESET_EXTERNAL_SOURCES);
+      expect(hierarchy).to.have.lengthOf(1).and.to.containSubset([{
+        label: { value: { displayValue: "Root repo link - Test external source" } },
+        autoExpand: true,
+        extendedData: {
+          // note: would be better to test this through `TreeNodeItem.icon`, but `HierarchyBuilder` doesn't
+          // allow us to pass the node customization function used by the external sources tree
+          imageId: "icon-document",
+        },
+      }]);
+    });
+
+    it("creates external sources as external source group node children", async function () {
+      const iModel: IModelConnection = await buildTestIModel(this, (builder) => {
+        const { externalSourceId: rootSourceId } = addRootExternalSource(builder, "Root external source");
+        const groupId = addExternalSourceGroup(builder, "External source group");
+        addExternalSourceAttachment(builder, rootSourceId, groupId);
+        const childId = addExternalSource(builder, "Child external source");
+        groupExternalSources(builder, groupId, [childId]);
+      });
+      const hierarchyBuilder = new HierarchyBuilder({ imodel: iModel });
+      const hierarchy = await hierarchyBuilder.createHierarchy(RULESET_EXTERNAL_SOURCES);
+      expect(hierarchy).to.have.lengthOf(1).and.to.containSubset([{
+        label: { value: { displayValue: "Root repo link - Root external source" } },
+        extendedData: {
+          imageId: "icon-document",
+        },
+        children: [{
+          label: { value: { displayValue: "External source group" } },
+          extendedData: {
+            imageId: "icon-document",
+          },
+          children: [{
+            label: { value: { displayValue: "Child external source" } },
+            extendedData: {
+              imageId: "icon-document",
+            },
+          }],
+        }],
+      }]);
+    });
+
+    it("creates attached external sources as external source node children", async function () {
+      const iModel: IModelConnection = await buildTestIModel(this, (builder) => {
+        const { externalSourceId: rootSourceId } = addRootExternalSource(builder, "Root external source");
+        const childSourceId = addExternalSource(builder, "Child external source");
+        addExternalSourceAttachment(builder, rootSourceId, childSourceId);
+      });
+      const hierarchyBuilder = new HierarchyBuilder({ imodel: iModel });
+      const hierarchy = await hierarchyBuilder.createHierarchy(RULESET_EXTERNAL_SOURCES);
+      expect(hierarchy).to.have.lengthOf(1).and.to.containSubset([{
+        label: { value: { displayValue: "Root repo link - Root external source" } },
+        extendedData: {
+          imageId: "icon-document",
+        },
+        children: [{
+          label: { value: { displayValue: "Child external source" } },
+          extendedData: {
+            imageId: "icon-document",
+          },
+        }],
+      }]);
+    });
+
+    it("creates elements as external source node children", async function () {
+      const iModel: IModelConnection = await buildTestIModel(this, (builder) => {
+        const { externalSourceId } = addRootExternalSource(builder, "Root external source");
+        const modelId = addPhysicalModel(builder, "Model", IModel.rootSubjectId);
+        const categoryId = addSpatialCategory(builder, "Category");
+        addPhysicalObject(builder, "Element 1", modelId, categoryId, externalSourceId);
+        addPhysicalObject(builder, "Element 2", modelId, categoryId, externalSourceId);
+      });
+      const hierarchyBuilder = new HierarchyBuilder({ imodel: iModel });
+      const hierarchy = await hierarchyBuilder.createHierarchy(RULESET_EXTERNAL_SOURCES);
+      expect(hierarchy).to.have.lengthOf(1).and.to.containSubset([{
+        label: { value: { displayValue: "Root repo link - Root external source" } },
+        extendedData: {
+          imageId: "icon-document",
+        },
+        children: [{
+          label: { value: { displayValue: "Elements" } },
+          extendedData: {
+            imageId: "icon-ec-schema",
+          },
+          children: [{
+            label: { value: { displayValue: "Physical Object" } },
+            extendedData: {
+              imageId: "icon-ec-class",
+            },
+            children: [{
+              label: { value: { displayValue: "Code:Element 1" } },
+              extendedData: {
+                imageId: "icon-item",
+              },
+            }, {
+              label: { value: { displayValue: "Code:Element 2" } },
+              extendedData: {
+                imageId: "icon-item",
+              },
+            }],
+          }],
+        }],
+      }]);
+    });
+
+    function addSynchronizationConfigLink(builder: TestIModelBuilder, label: string) {
+      const props: ElementProps = {
+        classFullName: "BisCore:SynchronizationConfigLink",
+        model: IModel.repositoryModelId,
+        code: builder.createCode(IModel.repositoryModelId, BisCodeSpec.linkElement, `Code:${label}`),
+      };
+      return builder.insertElement(props);
+    }
+
+    function addRepositoryLink(builder: TestIModelBuilder, label: string) {
+      const repositoryLinkProps: ElementProps = {
+        classFullName: "BisCore:RepositoryLink",
+        model: IModel.repositoryModelId,
+        code: builder.createCode(IModel.repositoryModelId, BisCodeSpec.linkElement, `Code:${label}`),
+        userLabel: label,
+      };
+      return builder.insertElement(repositoryLinkProps);
+    }
+
+    function addExternalSourceGroup(builder: TestIModelBuilder, label: string, repositoryLinkId?: Id64String) {
+      const externalSourceProps: ElementProps = {
+        classFullName: "BisCore:ExternalSourceGroup",
+        model: IModel.repositoryModelId,
+        code: builder.createCode(IModel.repositoryModelId, BisCodeSpec.nullCodeSpec, `Code:${label}`),
+        userLabel: label,
+        ...(repositoryLinkId ? { repository: { id: repositoryLinkId } } : undefined),
+      };
+      return builder.insertElement(externalSourceProps);
+    }
+
+    function addExternalSource(builder: TestIModelBuilder, label: string, repositoryLinkId?: Id64String) {
+      const externalSourceProps: ElementProps = {
+        classFullName: "BisCore:ExternalSource",
+        model: IModel.repositoryModelId,
+        code: builder.createCode(IModel.repositoryModelId, BisCodeSpec.nullCodeSpec, `Code:${label}`),
+        userLabel: label,
+        ...(repositoryLinkId ? { repository: { id: repositoryLinkId } } : undefined),
+      };
+      return builder.insertElement(externalSourceProps);
+    }
+
+    function addRootExternalSource(builder: TestIModelBuilder, label: string) {
+      const configLinkId = addSynchronizationConfigLink(builder, "Root config link");
+      const repoLinkId = addRepositoryLink(builder, "Root repo link");
+      const externalSourceId = addExternalSource(builder, label, repoLinkId);
+      builder.insertRelationship({
+        classFullName: "BisCore:SynchronizationConfigSpecifiesRootSources",
+        sourceId: configLinkId,
+        targetId: externalSourceId,
+      });
+      return { configLinkId, repoLinkId, externalSourceId };
+    }
+
+    function addExternalSourceAttachment(builder: TestIModelBuilder, parentExternalSourceId: Id64String, attachedExternalSourceId: Id64String) {
+      return builder.insertElement({
+        classFullName: "BisCore:ExternalSourceAttachment",
+        model: IModel.repositoryModelId,
+        code: builder.createCode(IModel.repositoryModelId, BisCodeSpec.nullCodeSpec, `Code:${Guid.createValue()}`),
+        parent: {
+          relClassName: "BisCore:ExternalSourceOwnsAttachments",
+          id: parentExternalSourceId,
+        },
+        attaches: {
+          relClassName: "BisCore:ExternalSourceAttachmentAttachesSource",
+          id: attachedExternalSourceId,
+        },
+      });
+    }
+
+    function groupExternalSources(builder: TestIModelBuilder, groupId: Id64String, groupedExternalSourceIds: Id64String[]) {
+      groupedExternalSourceIds.forEach((groupedExternalSourceId) => {
+        builder.insertRelationship({
+          classFullName: "BisCore:ExternalSourceGroupGroupsSources",
+          sourceId: groupId,
+          targetId: groupedExternalSourceId,
+        });
+      });
+    }
+
+    function addPhysicalModel(builder: TestIModelBuilder, label: string, subjectId: Id64String) {
+      const partitionId = builder.insertElement({
+        classFullName: "BisCore:PhysicalPartition",
+        model: IModel.repositoryModelId,
+        parent: {
+          relClassName: "BisCore:SubjectOwnsPartitionElements",
+          id: subjectId,
+        },
+        code: builder.createCode(subjectId, BisCodeSpec.informationPartitionElement, `Code:${label}`),
+      });
+      return builder.insertModel({
+        classFullName: "BisCore:PhysicalModel",
+        modeledElement: { id: partitionId },
+      });
+    }
+
+    function addSpatialCategory(builder: TestIModelBuilder, label: string, modelId?: string) {
+      if (!modelId) {
+        modelId = builder.insertModel({
+          classFullName: "BisCore:DefinitionModel",
+          modeledElement: {
+            id: builder.insertElement({
+              classFullName: "BisCore:DefinitionPartition",
+              model: IModel.repositoryModelId,
+              parent: {
+                relClassName: "BisCore:SubjectOwnsPartitionElements",
+                id: IModel.rootSubjectId,
+              },
+              code: builder.createCode(IModel.rootSubjectId, BisCodeSpec.informationPartitionElement, `Code:RootDefinitionModel`),
+            }),
+          },
+        });
+      }
+      return builder.insertElement({
+        classFullName: "BisCore:SpatialCategory",
+        model: modelId,
+        code: builder.createCode(modelId, BisCodeSpec.spatialCategory, `Code:${label}`),
+      });
+    }
+
+    function addPhysicalObject(builder: TestIModelBuilder, label: string, modelId: string, categoryId: string, externalSourceId?: Id64String) {
+      const elementId = builder.insertElement({
+        classFullName: "Generic:PhysicalObject",
+        model: modelId,
+        category: categoryId,
+        code: builder.createCode(modelId, BisCodeSpec.nullCodeSpec, `Code:${label}`),
+        userLabel: label,
+      });
+      if (externalSourceId) {
+        builder.insertAspect({
+          classFullName: "BisCore:ExternalSourceAspect",
+          element: { id: elementId },
+          source: { id: externalSourceId },
+        });
+      }
+      return elementId;
+    }
+  });
+});

--- a/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/external-sources-tree/ExternalSourcesTreeComponent.test.tsx
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as React from "react";
+import { UiFramework } from "@itwin/appui-react";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { render } from "@testing-library/react";
+import * as externalSourcesTreeModule from "../../../components/trees/external-sources-tree/ExternalSourcesTree";
+import * as autoSizerModule from "../../../components/utils/AutoSizer";
+import { ExternalSourcesTreeComponent } from "../../../tree-widget-react";
+import { TestUtils } from "../../TestUtils";
+
+describe("<ExternalSourcesTreeComponent />", () => {
+
+  describe("#unit", () => {
+    before(async () => {
+      // TODO: remove this eslint rule when tree-widget uses itwinjs-core 4.0.0 version
+      await NoRenderApp.startup(); // eslint-disable-line @itwin/no-internal
+      await TestUtils.initialize();
+    });
+
+    after(async () => {
+      TestUtils.terminate();
+      await IModelApp.shutdown();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("renders `ExternalSourcesTree` with size and iModel props", async () => {
+      const imodel = {} as any;
+      sinon.stub(UiFramework, "getIModelConnection").returns(imodel);
+      sinon.stub(autoSizerModule, "AutoSizer").callsFake((props) => <>{props.children({ width: 123, height: 456 })}</>);
+      const treeStub = sinon.stub(externalSourcesTreeModule, "ExternalSourcesTree").returns(<>test result</>);
+
+      const { getByText } = render(
+        <ExternalSourcesTreeComponent />,
+      );
+
+      expect(treeStub).to.be.calledOnceWith({
+        width: 123,
+        height: 456,
+        iModel: imodel,
+      });
+      getByText("test result");
+    });
+
+    it("returns `null` if there's no active iModel", async () => {
+      sinon.stub(UiFramework, "getIModelConnection").returns(undefined);
+      const autosizerStub = sinon.stub(autoSizerModule, "AutoSizer").callsFake((props) => <>{props.children({ width: 123, height: 456 })}</>);
+      const treeStub = sinon.stub(externalSourcesTreeModule, "ExternalSourcesTree").returns(<></>);
+
+      const { container } = render(
+        <ExternalSourcesTreeComponent />,
+      );
+
+      expect(autosizerStub).to.not.be.called;
+      expect(treeStub).to.not.be.called;
+      expect(container.innerHTML).to.be.empty;
+    });
+  });
+});

--- a/packages/itwin/tree-widget/tsconfig.json
+++ b/packages/itwin/tree-widget/tsconfig.json
@@ -5,7 +5,12 @@
     "esModuleInterop": true,
     "noImplicitOverride": false,
     "resolveJsonModule": true,
-
+    "lib": [
+      "DOM"
+    ],
+    "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
This is based on #421 and now targets `tree_widget_1.0`.

Closes https://github.com/iTwin/viewer-components-react/issues/352.

