### PR TITLE
Tree widget: Setup linter to cleanup unused type imports

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1319,6 +1319,8 @@ importers:
       cpx2: ^3.0.0
       deep-equal: ^1.0.0
       eslint: ^7.11.0
+      eslint-plugin-react: ^7.32.2
+      eslint-plugin-unused-imports: ^1.0.0
       i18next: ^10.2.2
       jsdom: ^19.0.0
       jsdom-global: 3.0.2
@@ -1396,6 +1398,8 @@ importers:
       cpx2: 3.0.2
       deep-equal: 1.1.1
       eslint: 7.32.0
+      eslint-plugin-react: 7.32.2_eslint@7.32.0
+      eslint-plugin-unused-imports: 1.1.5_5d2865250479a29d8cdea08dacebb052
       jsdom: 19.0.0
       jsdom-global: 3.0.2_jsdom@19.0.0
       mocha: 10.1.0
@@ -14318,6 +14322,26 @@ packages:
       - supports-color
       - typescript
     dev: false
+
+  /eslint-plugin-unused-imports/1.1.5_5d2865250479a29d8cdea08dacebb052:
+    resolution: {integrity: sha512-TeV8l8zkLQrq9LBeYFCQmYVIXMjfHgdRQLw7dEZp4ZB3PeR10Y5Uif11heCsHRmhdRIYMoewr1d9ouUHLbLHew==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^4.14.2
+      eslint: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.19.0_b7395fa40fa1e8c5dfd8e4cf5188e7c1
+      eslint: 7.32.0
+      eslint-rule-composer: 0.3.0
+    dev: true
+
+  /eslint-rule-composer/0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
+    dev: true
 
   /eslint-scope/5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}

--- a/packages/itwin/tree-widget/.eslintrc.js
+++ b/packages/itwin/tree-widget/.eslintrc.js
@@ -5,7 +5,7 @@
 require("@rushstack/eslint-patch/modern-module-resolution");
 
 module.exports = {
-  plugins: ["@itwin"],
+  plugins: ["@itwin", "unused-imports"],
   extends: ["plugin:@itwin/ui", "plugin:react/jsx-runtime"],
   rules: {
     "@itwin/no-internal": ["error"],
@@ -16,6 +16,12 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": "error",
     "no-duplicate-imports": "off",
     "import/no-duplicates": "error",
-    "object-curly-spacing": ["error", "always"]
+    "object-curly-spacing": ["error", "always"],
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "error",
+      { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
+    ]
   },
 };

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -99,6 +99,8 @@
     "cpx2": "^3.0.0",
     "deep-equal": "^1.0.0",
     "eslint": "^7.11.0",
+    "eslint-plugin-unused-imports": "^1.0.0",
+    "eslint-plugin-react": "^7.32.2",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^10.0.0",


### PR DESCRIPTION
Extension of https://github.com/iTwin/viewer-components-react/pull/475. 

Use `eslint-plugin-unused-imports` instead of `@typescript-eslint/no-unused-vars` - it knows how to auto-fix unused type imports.

