### PR TITLE
Property Widget: Cleanup data provider config

### DIFF
--- a/common/changes/@itwin/property-grid-react/property_grid_cleanup_data_provider_config_2023-05-16-13-49.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_cleanup_data_provider_config_2023-05-16-13-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "**BREAKING** Removed properties used to configure data provider in favor of `createDataProvider` prop for supplying custom data provider.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -6,55 +6,21 @@
 import "./PropertyGrid.scss";
 import { FillCentered } from "@itwin/core-react";
 import { usePropertyDataProviderWithUnifiedSelection } from "@itwin/presentation-components";
-import { useCustomDataProvider, useDefaultDataProvider } from "../hooks/UseDataProvider";
+import { useDataProvider } from "../hooks/UseDataProvider";
 import { PropertyGridManager } from "../PropertyGridManager";
 import { PropertyGridContent } from "./PropertyGridContent";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { CustomDataProviderProps , DataProviderProps , DefaultDataProviderProps } from "../hooks/UseDataProvider";
+import type { DataProviderProps } from "../hooks/UseDataProvider";
 import type { PropertyGridContentProps } from "./PropertyGridContent";
 
 /** Props for `PropertyGrid` component. */
 export type PropertyGridProps = Omit<PropertyGridContentProps, "dataProvider"> & DataProviderProps;
 
 /** Component that renders property grid for instances in `UnifiedSelection`. */
-export function PropertyGrid(props: PropertyGridProps) {
-  if (isCustomPropertyGridProps(props)) {
-    return <CustomPropertyGrid {...props} />;
-  }
+export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps) {
+  const { dataProvider, isOverLimit } = useUnifiedSelectionDataProvider({ imodel: props.imodel, createDataProvider });
 
-  return <DefaultPropertyGrid {...props} />;
-}
-
-function DefaultPropertyGrid({ enableFavoriteProperties, enablePropertyGroupNesting, rulesetId, ...props }: PropertyGridProps & DefaultDataProviderProps) {
-  const { dataProvider, isOverLimit } = useUnifiedSelectionDataProvider({
-    imodel: props.imodel,
-    enableFavoriteProperties,
-    enablePropertyGroupNesting,
-    rulesetId,
-  });
-
-  return <PropertyGridWithProvider
-    {...props}
-    dataProvider={dataProvider}
-    isOverLimit={isOverLimit}
-  />;
-}
-
-function CustomPropertyGrid({ createDataProvider, ...props }: PropertyGridProps & CustomDataProviderProps) {
-  const { dataProvider, isOverLimit } = useUnifiedSelectionCustomDataProvider({
-    imodel: props.imodel,
-    createDataProvider,
-  });
-
-  return <PropertyGridWithProvider
-    {...props}
-    dataProvider={dataProvider}
-    isOverLimit={isOverLimit}
-  />;
-}
-
-function PropertyGridWithProvider({ isOverLimit, ...props }: PropertyGridContentProps & { isOverLimit: boolean }) {
   if (isOverLimit) {
     return (
       <FillCentered style={{ flexDirection: "column" }}>
@@ -70,24 +36,15 @@ function PropertyGridWithProvider({ isOverLimit, ...props }: PropertyGridContent
   return (
     <PropertyGridContent
       {...props}
+      dataProvider={dataProvider}
     />
   );
 }
 
-/** Custom hook that creates default data provider and hooks provider into unified selection. */
-function useUnifiedSelectionDataProvider(props: DefaultDataProviderProps & { imodel: IModelConnection }) {
-  const dataProvider = useDefaultDataProvider(props);
+/** Custom hook that creates data provider and hooks provider into unified selection. */
+function useUnifiedSelectionDataProvider(props: DataProviderProps & { imodel: IModelConnection }) {
+  const dataProvider = useDataProvider(props);
   const { isOverLimit } = usePropertyDataProviderWithUnifiedSelection({ dataProvider });
   return { dataProvider, isOverLimit };
 }
 
-/** Custom hook that creates custom data provider and hooks provider into unified selection. */
-function useUnifiedSelectionCustomDataProvider(props: CustomDataProviderProps & { imodel: IModelConnection }) {
-  const dataProvider = useCustomDataProvider(props);
-  const { isOverLimit } = usePropertyDataProviderWithUnifiedSelection({ dataProvider });
-  return { dataProvider, isOverLimit };
-}
-
-function isCustomPropertyGridProps(props: PropertyGridProps): props is PropertyGridProps & CustomDataProviderProps {
-  return (props as CustomDataProviderProps).createDataProvider !== undefined;
-}

--- a/packages/itwin/property-grid/src/components/SingleElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/SingleElementPropertyGrid.tsx
@@ -5,64 +5,26 @@
 
 import { useEffect } from "react";
 import { KeySet } from "@itwin/presentation-common";
-import { useCustomDataProvider, useDefaultDataProvider } from "../hooks/UseDataProvider";
+import { useDataProvider } from "../hooks/UseDataProvider";
 import { PropertyGridContent } from "./PropertyGridContent";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { InstanceKey } from "@itwin/presentation-common";
 import type { PropertyGridContentProps } from "./PropertyGridContent";
-import type { CustomDataProviderProps, DefaultDataProviderProps } from "../hooks/UseDataProvider";
+import type {  DataProviderProps } from "../hooks/UseDataProvider";
 
-/** Base props for data provider used by `SingleElementPropertyGrid. */
-export interface SingleElementDataProviderBaseProps {
+/** Props for data provider used by `SingleElementPropertyGrid. */
+export interface SingleElementDataProviderProps extends DataProviderProps {
   /** Key of the instance which data should be loaded. */
   instanceKey: InstanceKey;
 }
-
-/** Props for configuring default data provider used by `SingleElementPropertyGrid`. */
-export type SingleElementDefaultDataProviderProps = DefaultDataProviderProps & SingleElementDataProviderBaseProps;
-
-/** Props for providing custom data provider that will be used by `SingleElementPropertyGrid`. */
-export type SingleElementCustomDataProviderProps = CustomDataProviderProps & SingleElementDataProviderBaseProps;
-
-/** Props for data provider used by `SingleElementPropertyGrid`. */
-export type SingleElementDataProviderProps = SingleElementDefaultDataProviderProps | SingleElementCustomDataProviderProps;
 
 /** Props for `SingleElementPropertyGrid` component. */
 export type SingleElementPropertyGridProps = Omit<PropertyGridContentProps, "dataProvider"> & SingleElementDataProviderProps;
 
 /** Component that renders property grid for single element. */
-export function SingleElementPropertyGrid(props: SingleElementPropertyGridProps) {
-  if (isCustomDataProviderProps(props)) {
-    return <SingleElementCustomPropertyGrid {...props} />;
-  }
-
-  return <SingleElementDefaultPropertyGrid {...props} />;
-}
-
-function SingleElementDefaultPropertyGrid({ instanceKey, enableFavoriteProperties, enablePropertyGroupNesting, rulesetId,...props }: SingleElementPropertyGridProps & SingleElementDefaultDataProviderProps) {
-  const dataProvider = useSingleElementDataProvider({
-    imodel: props.imodel,
-    instanceKey,
-    enableFavoriteProperties,
-    enablePropertyGroupNesting,
-    rulesetId,
-  });
-
-  return (
-    <PropertyGridContent
-      {...props}
-      dataProvider={dataProvider}
-    />
-  );
-}
-
-function SingleElementCustomPropertyGrid({ instanceKey, createDataProvider,...props }: SingleElementPropertyGridProps & SingleElementCustomDataProviderProps) {
-  const dataProvider = useSingleElementCustomDataProvider({
-    imodel: props.imodel,
-    instanceKey,
-    createDataProvider,
-  });
+export function SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps) {
+  const dataProvider = useSingleElementDataProvider({ imodel: props.imodel, instanceKey, createDataProvider  });
 
   return (
     <PropertyGridContent
@@ -73,23 +35,10 @@ function SingleElementCustomPropertyGrid({ instanceKey, createDataProvider,...pr
 }
 
 /** Custom hook that creates data provider and setup it to load data for specific instance. */
-function useSingleElementDataProvider({ instanceKey, ...props }: SingleElementDefaultDataProviderProps & { imodel: IModelConnection }) {
-  const dataProvider = useDefaultDataProvider(props);
+function useSingleElementDataProvider({ instanceKey, ...props }: SingleElementDataProviderProps & { imodel: IModelConnection }) {
+  const dataProvider = useDataProvider(props);
   useEffect(() => {
     dataProvider.keys = new KeySet([instanceKey]);
   }, [dataProvider, instanceKey]);
   return dataProvider;
-}
-
-/** Custom hook that creates custom data provider and setup it to load data for specific instance. */
-function useSingleElementCustomDataProvider({ instanceKey, ...props }: SingleElementCustomDataProviderProps & { imodel: IModelConnection }) {
-  const dataProvider = useCustomDataProvider(props);
-  useEffect(() => {
-    dataProvider.keys = new KeySet([instanceKey]);
-  }, [dataProvider, instanceKey]);
-  return dataProvider;
-}
-
-function isCustomDataProviderProps(props: SingleElementPropertyGridProps): props is SingleElementPropertyGridProps & SingleElementCustomDataProviderProps {
-  return (props as SingleElementCustomDataProviderProps).createDataProvider !== undefined;
 }

--- a/packages/itwin/property-grid/src/hooks/UseDataProvider.ts
+++ b/packages/itwin/property-grid/src/hooks/UseDataProvider.ts
@@ -10,47 +10,19 @@ import { PresentationPropertyDataProvider } from "@itwin/presentation-components
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
 
-/** Props for configuring default data provider used by `PropertyGrid` */
-export interface DefaultDataProviderProps {
-  /** Flag that specified whether data provider should create `Favorites` category. */
-  enableFavoriteProperties?: boolean;
-  /** Flag that specified whether nested property categories are enabled. */
-  enablePropertyGroupNesting?: boolean;
-  /** Id of ruleset that should be used when pulling data. */
-  rulesetId?: string;
-}
-
-/** Props for providing custom data provider that will be used by `PropertyGrid` */
-export interface CustomDataProviderProps {
+/** Props for data provider used by `PropertyGrid` */
+export interface DataProviderProps {
   /** Callback that creates custom data provider that should be used instead of default one. */
-  createDataProvider: (imodel: IModelConnection) => IPresentationPropertyDataProvider;
+  createDataProvider?: (imodel: IModelConnection) => IPresentationPropertyDataProvider;
 }
 
-/** Props for data provider used by `PropertyGrid`. */
-export type DataProviderProps = DefaultDataProviderProps | CustomDataProviderProps;
-
-/** Custom hook that creates default data provider. */
-export function useDefaultDataProvider({ imodel, rulesetId, enableFavoriteProperties, enablePropertyGroupNesting }: DefaultDataProviderProps & { imodel: IModelConnection }) {
-  return useDisposable(useCallback(
-    () => {
-      const dp = new PresentationPropertyDataProvider({
-        imodel,
-        ruleset: rulesetId,
-        disableFavoritesCategory: !enableFavoriteProperties,
-      });
-
-      dp.pagingSize = 50;
-      dp.isNestedPropertyCategoryGroupingEnabled = !!enablePropertyGroupNesting;
-      return dp;
-    },
-    [imodel, rulesetId, enableFavoriteProperties, enablePropertyGroupNesting])
+/** Custom hook that creates data provider. */
+export function useDataProvider({ imodel, createDataProvider }: DataProviderProps & { imodel: IModelConnection }) {
+  return useDisposable(
+    useCallback(
+      () => createDataProvider ? createDataProvider(imodel) : new PresentationPropertyDataProvider({ imodel }),
+      [imodel, createDataProvider]
+    )
   );
 }
 
-/** Custom hook that creates custom data provider. */
-export function useCustomDataProvider({ imodel, createDataProvider }: CustomDataProviderProps & { imodel: IModelConnection }) {
-  return useDisposable(useCallback(
-    () => createDataProvider(imodel),
-    [createDataProvider, imodel])
-  );
-}


### PR DESCRIPTION
Removed these properties that were used to configure default property data provider:
- `enableFavoriteProperties`
- `enablePropertyGroupNesting`
- `rulesetId`

Instead of these properties `createDataProvider` property should be used to provide customized property data provider.