### PR TITLE
Property grid: Context menu refactor

### DIFF
--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,14 +4,13 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createHideNullValuesItemProvider, createRemoveFavoritePropertyItemProvider, createShowNullValuesItemProvider } from "@itwin/property-grid-react";
+import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createRemoveFavoritePropertyItemProvider } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
 import { DefaultMapFeatureInfoTool, FeatureInfoUiItemsProvider, MapLayersUI, MapLayersUiItemsProvider } from "@itwin/map-layers";
 import { GeoTools, GeoToolsAddressSearchProvider } from "@itwin/geo-tools-react";
 import { MapLayersFormats } from "@itwin/map-layers-formats";
-import { Orientation } from "@itwin/core-react";
 
 export interface UiProvidersConfig {
   initialize: () => Promise<void>;
@@ -82,8 +81,6 @@ const configuredUiItems = new Map<string, UiItem>([
           contextMenuItemProviders: [
             createAddFavoritePropertyItemProvider(),
             createRemoveFavoritePropertyItemProvider(),
-            createShowNullValuesItemProvider(),
-            createHideNullValuesItemProvider(),
             createCopyPropertyTextItemProvider(),
           ],
         }

--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { PropertyGridManager, PropertyGridUiItemsProvider } from "@itwin/property-grid-react";
+import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createHideNullValuesItemProvider, createRemoveFavoritePropertyItemProvider, createShowNullValuesItemProvider } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
@@ -79,11 +79,13 @@ const configuredUiItems = new Map<string, UiItem>([
         propertyGridProps: {
           enableAncestorNavigation: true,
           autoExpandChildCategories: true,
-          enableCopyingPropertyText: true,
-          enableFavoriteProperties: true,
-          enableNullValueToggle: true,
-          enablePropertyGroupNesting: true,
-          orientation: Orientation.Horizontal
+          contextMenuItemProviders: [
+            createAddFavoritePropertyItemProvider(),
+            createRemoveFavoritePropertyItemProvider(),
+            createShowNullValuesItemProvider(),
+            createHideNullValuesItemProvider(),
+            createCopyPropertyTextItemProvider(),
+          ],
         }
       })],
     }

--- a/common/changes/@itwin/property-grid-react/property_grid_menu_refactor_2023-05-19-10-58.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_menu_refactor_2023-05-19-10-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "**BREAKING** Removed properties used for enabling/disabling context menu items in favor of `ContextMenuItemProvider` list that is now used to populate context menu.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -42,13 +42,8 @@ export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMen
 export function PropertyGridContent({
   dataProvider,
   imodel,
-  enableFavoriteProperties,
-  favoritePropertiesScope,
-  enableCopyingPropertyText,
-  enableNullValueToggle,
+  contextMenuItemProviders,
   persistNullValueToggle,
-  additionalContextMenuOptions,
-  defaultContextMenuOptions,
   customOnDataChanged,
   rootClassName,
   onBackButton,
@@ -62,12 +57,7 @@ export function PropertyGridContent({
     imodel,
     setShowNullValues,
     showNullValues,
-    additionalContextMenuOptions,
-    defaultContextMenuOptions,
-    enableCopyingPropertyText,
-    enableFavoriteProperties,
-    enableNullValueToggle,
-    favoritePropertiesScope,
+    contextMenuItemProviders,
   });
 
   const [{ width, height }, setSize] = useState({ width: 0, height: 0 });

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -51,12 +51,10 @@ export function PropertyGridContent({
   ...props
 }: PropertyGridContentProps) {
   const { item } = usePropertyGridData({ dataProvider, customOnDataChanged });
-  const { showNullValues, setShowNullValues, filterer } = useNullValueSetting({ persistNullValueToggle });
+  const { filterer } = useNullValueSetting({ persistNullValueToggle });
   const { renderContextMenu, onPropertyContextMenu } = useContextMenu({
     dataProvider,
     imodel,
-    setShowNullValues,
-    showNullValues,
     contextMenuItemProviders,
   });
 

--- a/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
+++ b/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
@@ -47,6 +47,7 @@ export interface MenuItemContext {
   setShowNullValues: (values: boolean) => Promise<void>;
 }
 
+/** Type definition for context menu item provider. */
 export type ContextMenuItemProvider = (context: MenuItemContext) => ContextMenuItemDefinition | undefined;
 
 /** Props for configuring property grid context menu. */

--- a/packages/itwin/property-grid/src/property-grid-react.ts
+++ b/packages/itwin/property-grid/src/property-grid-react.ts
@@ -10,3 +10,4 @@ export * from "./components/PropertyGrid";
 export * from "./components/SingleElementPropertyGrid";
 export * from "./components/FilteringPropertyGrid";
 export * from "./components/MultiElementPropertyGrid";
+export * from "./hooks/UseContextMenu";


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/483

Dropped all properties related to context menu configuration in favor of single property `contextMenuItemProviders`. This Provides more flexibility when configuring context menu. Removed properties:
```
enableFavoriteProperties?: boolean;
enableCopyingPropertyText?: boolean;
enableNullValueToggle?: boolean;
additionalContextMenuOptions?: ContextMenuItemInfo[];
defaultContextMenuOptions?: Map<PropertyGridDefaultContextMenuKey, Partial<ContextMenuItemInfo>>;
```

Change `ContextMenuItemInfo` type into `ContextMenuItemDefinition`. It does not extend `ContextMenuItemProps` like `ContextMenuItemInfo` because they were not used anyway.

Some examples of the new API:

### Enabling default context menu items

In order to add default menu items, there is a list of `ContextMenuItemProvider` factories provided:

- `createAddFavoritePropertyItemProvider`,
- `createRemoveFavoritePropertyItemProvider`,
- `createCopyPropertyTextItemProvider`,

Before:

```typescript
new PropertyGridUiItemsProvider({
  favoritePropertiesScope: myFavoritePropertiesScope,
  enableFavoriteProperties: true,
  enableCopyingPropertyText: true,
});
```

After:

```typescript
new PropertyGridUiItemsProvider({
  propertyGridProps: {
    contextMenuItemProviders: [
      createAddFavoritePropertyItemProvider(myFavoritePropertiesScope),
      createRemoveFavoritePropertyItemProvider(myFavoritePropertiesScope),
      createCopyPropertyTextItemProvider(),
    ],
  },
});
```

### Ordering default context menu items

Order of context menu item matches provider position in the `ContextMenuItemProvider`s list. (Previously there was no clear way to change order of default items):

```typescript
new PropertyGridUiItemsProvider({
  propertyGridProps: {
    contextMenuItemProviders: [
      createCopyPropertyTextItemProvider(),
      createAddFavoritePropertyItemProvider(myFavoritePropertiesScope),
      createRemoveFavoritePropertyItemProvider(myFavoritePropertiesScope),
    ],
  },
});
```

### Adding new context menu items

In order to add custom context menu items new providers should be added the list:

```typescript
const removePropertyItemProvider = ({ record }: MenuItemContext) => ({
  key: "remove-property",
  execute: async () => {
    hideProperty(record.property.name);
  },
  label: "Remove Property",
  title: "Removes property from the grid",
});

new PropertyGridUiItemsProvider({
  propertyGridProps: {
    contextMenuItemProviders: [
      createAddFavoritePropertyItemProvider(),
      createRemoveFavoritePropertyItemProvider(),
      removePropertyItemProvider,
    ],
  },
});
```

### Conditionally showing menu items

If some context menu item should not be shown based on property `ContextMenuItemDefinition.hidden` property can be used:

```typescript
const removePropertyItemProvider = ({ record }: MenuItemContext) => {
  return {
    key: "remove-property",
    execute: async () => {
      hideProperty(record.property.name);
    },
    label: "Remove Property",
    title: "Removes property from the grid",
    hidden: !isPropertyRemovable(record.property.name)
  };
};

new PropertyGridUiItemsProvider({
  propertyGridProps: {
    contextMenuItemProviders: [
      createAddFavoritePropertyItemProvider(),
      createRemoveFavoritePropertyItemProvider(),
      removePropertyItemProvider,
    ],
  },
});
```

### Extending default item visibility conditions

In order to extend conditions used to determine if default menu item should be shown, default provider can be wrapped:

```typescript
const customRemoveFavoritePropertyItemProvider = (context: MenuItemContext) => {
  // get default item definition
  const defaultProvider = createRemoveFavoritePropertyItemProvider();
  const defaultItem = defaultProvider(context);
  return {
    ...defaultItem,
    hidden: defaultItem.hidden || !canUnfavoritreProperty(context.record.property.name),
};

new PropertyGridUiItemsProvider({
  propertyGridProps: {
    contextMenuItemProviders: [
      createAddFavoritePropertyItemProvider(),
      customRemoveFavoritePropertyItemProvider,
    ],
  },
});
```