### PR TITLE
Property grid: Remove `customOnDataChanged` property

### DIFF
--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -82,7 +82,6 @@ const configuredUiItems = new Map<string, UiItem>([
           enableCopyingPropertyText: true,
           enableFavoriteProperties: true,
           enableNullValueToggle: true,
-          enablePropertyGroupNesting: true,
           orientation: Orientation.Horizontal
         }
       })],

--- a/common/changes/@itwin/property-grid-react/property_grid_remove_custom_on_data_change_2023-05-19-12-11.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_remove_custom_on_data_change_2023-05-19-12-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "**BREAKING** Removed `customOnDataChanged` property. `createDataProvider` and `IPresentationPropertyDataProvider.onDataChanged` should be used.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/common/changes/@itwin/property-grid-react/property_grid_remove_custom_on_data_change_2023-05-19-12-11.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_remove_custom_on_data_change_2023-05-19-12-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/property-grid-react",
-      "comment": "**BREAKING** Removed `customOnDataChanged` property. `createDataProvider` and `IPresentationPropertyDataProvider.onDataChanged` should be used.",
+      "comment": "**BREAKING** Removed `customOnDataChanged` property. `createDataProvider` and `IPresentationPropertyDataProvider.onDataChanged` should be used instead.",
       "type": "patch"
     }
   ],

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -24,7 +24,6 @@ import type { IPresentationPropertyDataProvider } from "@itwin/presentation-comp
 import type { FilteringPropertyGridProps } from "./FilteringPropertyGrid";
 import type { ContextMenuProps } from "../hooks/UseContextMenu";
 import type { NullValueSettingProps } from "../hooks/UseNullValuesSetting";
-import type { PropertyGridDataProps } from "../hooks/UsePropertyGridData";
 
 /** Base props for rendering `PropertyGridContent` component. */
 export interface PropertyGridContentBaseProps extends Omit<FilteringPropertyGridProps, "dataProvider" | "filterer" | "isPropertyHoverEnabled" | "isPropertySelectionEnabled" | "onPropertyContextMenu" | "width" | "height"> {
@@ -36,7 +35,7 @@ export interface PropertyGridContentBaseProps extends Omit<FilteringPropertyGrid
 }
 
 /** Props for `PropertyGridContent` component. */
-export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & NullValueSettingProps & PropertyGridDataProps;
+export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & NullValueSettingProps;
 
 /** Component that renders property grid with header and context menu. */
 export function PropertyGridContent({
@@ -49,13 +48,12 @@ export function PropertyGridContent({
   persistNullValueToggle,
   additionalContextMenuOptions,
   defaultContextMenuOptions,
-  customOnDataChanged,
   rootClassName,
   onBackButton,
   headerContent,
   ...props
 }: PropertyGridContentProps) {
-  const { item } = usePropertyGridData({ dataProvider, customOnDataChanged });
+  const { item } = usePropertyGridData({ dataProvider });
   const { showNullValues, setShowNullValues, filterer } = useNullValueSetting({ persistNullValueToggle });
   const { renderContextMenu, onPropertyContextMenu } = useContextMenu({
     dataProvider,

--- a/packages/itwin/property-grid/src/hooks/UsePropertyGridData.ts
+++ b/packages/itwin/property-grid/src/hooks/UsePropertyGridData.ts
@@ -8,35 +8,26 @@ import { useEffect, useState } from "react";
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
 
-export interface PropertyGridDataProps {
-  /** Callback that is invoked when property data changes. */
-  customOnDataChanged?: (dataProvider: IPresentationPropertyDataProvider) => Promise<void>;
-}
-
 /** Props for `usePropertyGridData` hook. */
-export interface UsePropertyGridDataProps extends PropertyGridDataProps {
+export interface UsePropertyGridDataProps {
   dataProvider: IPresentationPropertyDataProvider;
 }
 
 /** Returns className and label of the instance that properties are currently loaded. */
-export function usePropertyGridData({ dataProvider, customOnDataChanged }: UsePropertyGridDataProps) {
+export function usePropertyGridData({ dataProvider }: UsePropertyGridDataProps) {
   const [item, setItem] = useState<{className: string, label: PropertyRecord}>();
 
   useEffect(() => {
     const onDataChanged = async () => {
       const propertyData = await dataProvider.getData();
       setItem({ label: propertyData.label, className: propertyData.description ?? "" });
-
-      customOnDataChanged && await customOnDataChanged(dataProvider);
     };
 
     const removeListener = dataProvider.onDataChanged.addListener(onDataChanged);
     void onDataChanged();
 
-    return () => {
-      removeListener();
-    };
-  }, [dataProvider, customOnDataChanged]);
+    return () => { removeListener(); };
+  }, [dataProvider]);
 
   return { item };
 }


### PR DESCRIPTION
Removed `customOnDataChanged` callback from property grid props. This callback was invoked when `onDataChanged` event was raised. Same behavior can be replicated using `createDataProvider` and `onDataChanged` event:

```typescript
new PropertyGridUiItemsProvider({
  propertyGridProps: {
    createDataProvider: (imodel) => {
      const provider = new PresentationPropertyDataProvider({ imodel });
      provider.onDataChanged.addListener(() => { someCallback(); });
      return provider;
    }
  }
})
```