### PR TITLE
Keep eye checkbox position static on horizontal scroll, make model and categories tree whitespace between eye checkbox and node label smalelr

### DIFF
--- a/common/api/summary/tree-widget-react.exports.csv
+++ b/common/api/summary/tree-widget-react.exports.csv
@@ -15,7 +15,7 @@ internal;createRuleset(props: CreateRulesetProps): Ruleset
 internal;CreateRulesetProps = Omit
 internal;createSearchRuleset(props: CreateSearchRulesetProps): Ruleset
 internal;CreateSearchRulesetProps = Omit
-public;createVisibilityTreeNodeRenderer: ({ levelOffset, leafNodeOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
+public;createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element
 alpha;ExternalSourcesTreeComponent:
 alpha;ExternalSourcesTreeProps

--- a/common/api/summary/tree-widget-react.exports.csv
+++ b/common/api/summary/tree-widget-react.exports.csv
@@ -16,6 +16,7 @@ internal;CreateRulesetProps = Omit
 internal;createSearchRuleset(props: CreateSearchRulesetProps): Ruleset
 internal;CreateSearchRulesetProps = Omit
 public;createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
+public;createVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element
 alpha;ExternalSourcesTreeComponent:
 alpha;ExternalSourcesTreeProps
@@ -55,7 +56,6 @@ public;TreeWidgetOptions
 public;TreeWidgetUiItemsProvider 
 internal;useCategories(viewManager: ViewManager, imodel: IModelConnection, view?: Viewport): CategoryInfo[]
 public;useVisibilityTreeFiltering: (nodeLoader: AbstractTreeNodeLoaderWithProvider
-public;useVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element
 public;VisibilityChangeListener = (nodeIds?: string[], visibilityStatus?: Map
 public;VisibilityStatus
 public;VisibilityTreeEventHandler 

--- a/common/api/summary/tree-widget-react.exports.csv
+++ b/common/api/summary/tree-widget-react.exports.csv
@@ -15,7 +15,7 @@ internal;createRuleset(props: CreateRulesetProps): Ruleset
 internal;CreateRulesetProps = Omit
 internal;createSearchRuleset(props: CreateSearchRulesetProps): Ruleset
 internal;CreateSearchRulesetProps = Omit
-public;createVisibilityTreeNodeRenderer: (iconsEnabled: boolean, descriptionEnabled: boolean) => (props: TreeNodeRendererProps) => JSX.Element
+public;createVisibilityTreeNodeRenderer: ({ levelOffset, leafNodeOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element
 alpha;ExternalSourcesTreeComponent:
 alpha;ExternalSourcesTreeProps
@@ -55,13 +55,14 @@ public;TreeWidgetOptions
 public;TreeWidgetUiItemsProvider 
 internal;useCategories(viewManager: ViewManager, imodel: IModelConnection, view?: Viewport): CategoryInfo[]
 public;useVisibilityTreeFiltering: (nodeLoader: AbstractTreeNodeLoaderWithProvider
-public;useVisibilityTreeRenderer: (iconsEnabled: boolean, descriptionsEnabled: boolean) => (props: TreeRendererProps) => JSX.Element
+public;useVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element
 public;VisibilityChangeListener = (nodeIds?: string[], visibilityStatus?: Map
 public;VisibilityStatus
 public;VisibilityTreeEventHandler 
 public;VisibilityTreeEventHandlerParams 
 public;VisibilityTreeFilterInfo
-public;visibilityTreeNodeCheckboxRenderer: (props: NodeCheckboxRenderProps) => JSX.Element
+public;VisibilityTreeNodeCheckbox: (props: NodeCheckboxRenderProps) => JSX.Element
 public;VisibilityTreeNoFilteredData(props: VisibilityTreeNoFilteredDataProps): JSX.Element
 public;VisibilityTreeNoFilteredDataProps
+public;VisibilityTreeRendererProps
 public;VisibilityTreeSelectionPredicate = (node: TreeNodeItem) => boolean

--- a/common/api/summary/tree-widget-react.exports.csv
+++ b/common/api/summary/tree-widget-react.exports.csv
@@ -15,7 +15,7 @@ internal;createRuleset(props: CreateRulesetProps): Ruleset
 internal;CreateRulesetProps = Omit
 internal;createSearchRuleset(props: CreateSearchRulesetProps): Ruleset
 internal;CreateSearchRulesetProps = Omit
-public;createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
+public;createVisibilityTreeNodeRenderer: ({ levelOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element
 public;createVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element
 alpha;ExternalSourcesTreeComponent:

--- a/common/api/tree-widget-react.api.md
+++ b/common/api/tree-widget-react.api.md
@@ -160,6 +160,9 @@ export type CreateSearchRulesetProps = Omit<ModelsTreeHierarchyConfiguration, "e
 // @public
 export const createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
 
+// @public
+export const createVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element;
+
 // @alpha
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element;
 
@@ -433,9 +436,6 @@ export const useVisibilityTreeFiltering: (nodeLoader: AbstractTreeNodeLoaderWith
     isFiltering: boolean;
     nodeHighlightingProps: HighlightableTreeProps | undefined;
 };
-
-// @public
-export const useVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element;
 
 // @public
 export type VisibilityChangeListener = (nodeIds?: string[], visibilityStatus?: Map<string, VisibilityStatus>) => void;

--- a/common/api/tree-widget-react.api.md
+++ b/common/api/tree-widget-react.api.md
@@ -158,7 +158,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset;
 export type CreateSearchRulesetProps = Omit<ModelsTreeHierarchyConfiguration, "enableElementsClassGrouping">;
 
 // @public
-export const createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
+export const createVisibilityTreeNodeRenderer: ({ levelOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
 
 // @public
 export const createVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element;
@@ -497,7 +497,6 @@ export interface VisibilityTreeNoFilteredDataProps {
 export interface VisibilityTreeRendererProps {
     descriptionEnabled: boolean;
     disableRootNodeCollapse?: boolean;
-    expansionToggleWidth?: number;
     iconsEnabled: boolean;
     levelOffset?: number;
 }

--- a/common/api/tree-widget-react.api.md
+++ b/common/api/tree-widget-react.api.md
@@ -109,13 +109,13 @@ export class CategoryVisibilityHandler implements IVisibilityHandler {
     // (undocumented)
     enableSubCategory(key: string, enabled: boolean): void;
     // (undocumented)
-    getCategoryVisibility(id: string): "visible" | "hidden";
+    getCategoryVisibility(id: string): "hidden" | "visible";
     // (undocumented)
     static getInstanceIdFromTreeNodeKey(nodeKey: NodeKey): string;
     // (undocumented)
     getParent(key: string): CategoryInfo | undefined;
     // (undocumented)
-    getSubCategoryVisibility(id: string): "visible" | "hidden";
+    getSubCategoryVisibility(id: string): "hidden" | "visible";
     // (undocumented)
     getVisibilityStatus(node: TreeNodeItem): VisibilityStatus;
     // (undocumented)
@@ -158,7 +158,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset;
 export type CreateSearchRulesetProps = Omit<ModelsTreeHierarchyConfiguration, "enableElementsClassGrouping">;
 
 // @public
-export const createVisibilityTreeNodeRenderer: (iconsEnabled: boolean, descriptionEnabled: boolean) => (props: TreeNodeRendererProps) => JSX.Element;
+export const createVisibilityTreeNodeRenderer: ({ levelOffset, leafNodeOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
 
 // @alpha
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element;
@@ -428,14 +428,14 @@ export class TreeWidgetUiItemsProvider implements UiItemsProvider {
 export function useCategories(viewManager: ViewManager, imodel: IModelConnection, view?: Viewport): CategoryInfo[];
 
 // @public
-export const useVisibilityTreeFiltering: (nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>, filterInfo?: VisibilityTreeFilterInfo | undefined, onFilterApplied?: ((filteredDataProvider: IPresentationTreeDataProvider, matchesCount: number) => void) | undefined) => {
+export const useVisibilityTreeFiltering: (nodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>, filterInfo?: VisibilityTreeFilterInfo, onFilterApplied?: ((filteredDataProvider: IPresentationTreeDataProvider, matchesCount: number) => void) | undefined) => {
     filteredNodeLoader: AbstractTreeNodeLoaderWithProvider<IPresentationTreeDataProvider>;
     isFiltering: boolean;
     nodeHighlightingProps: HighlightableTreeProps | undefined;
 };
 
 // @public
-export const useVisibilityTreeRenderer: (iconsEnabled: boolean, descriptionsEnabled: boolean) => (props: TreeRendererProps) => JSX.Element;
+export const useVisibilityTreeRenderer: (visibilityTreeRendererProps: VisibilityTreeRendererProps) => (props: TreeRendererProps) => JSX.Element;
 
 // @public
 export type VisibilityChangeListener = (nodeIds?: string[], visibilityStatus?: Map<string, VisibilityStatus>) => void;
@@ -468,7 +468,7 @@ export interface VisibilityTreeEventHandlerParams extends UnifiedSelectionTreeEv
     // (undocumented)
     selectionPredicate?: VisibilityTreeSelectionPredicate;
     // (undocumented)
-    visibilityHandler: IVisibilityHandler | undefined;
+    visibilityHandler: IVisibilityHandler;
 }
 
 // @public
@@ -480,7 +480,7 @@ export interface VisibilityTreeFilterInfo {
 }
 
 // @public
-export const visibilityTreeNodeCheckboxRenderer: (props: NodeCheckboxRenderProps) => JSX.Element;
+export const VisibilityTreeNodeCheckbox: (props: NodeCheckboxRenderProps) => JSX.Element;
 
 // @public
 export function VisibilityTreeNoFilteredData(props: VisibilityTreeNoFilteredDataProps): JSX.Element;
@@ -491,6 +491,15 @@ export interface VisibilityTreeNoFilteredDataProps {
     message: string;
     // (undocumented)
     title: string;
+}
+
+// @public
+export interface VisibilityTreeRendererProps {
+    descriptionEnabled: boolean;
+    disableRootNodeCollapse?: boolean;
+    iconsEnabled: boolean;
+    leafNodeOffset?: number;
+    levelOffset?: number;
 }
 
 // @public

--- a/common/api/tree-widget-react.api.md
+++ b/common/api/tree-widget-react.api.md
@@ -158,7 +158,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset;
 export type CreateSearchRulesetProps = Omit<ModelsTreeHierarchyConfiguration, "enableElementsClassGrouping">;
 
 // @public
-export const createVisibilityTreeNodeRenderer: ({ levelOffset, leafNodeOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
+export const createVisibilityTreeNodeRenderer: ({ levelOffset, expansionToggleWidth, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => (treeNodeProps: TreeNodeRendererProps) => JSX.Element;
 
 // @alpha
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element;
@@ -497,8 +497,8 @@ export interface VisibilityTreeNoFilteredDataProps {
 export interface VisibilityTreeRendererProps {
     descriptionEnabled: boolean;
     disableRootNodeCollapse?: boolean;
+    expansionToggleWidth?: number;
     iconsEnabled: boolean;
-    leafNodeOffset?: number;
     levelOffset?: number;
 }
 

--- a/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
+++ b/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between node label and eye checkbox, `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `leafNodeOffset` and `disableRootNodeCollapse`.",
+      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between the node label and eye checkbox, `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `expansionToggleWidth` and `disableRootNodeCollapse`.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
+++ b/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
@@ -2,7 +2,23 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between the node label and eye checkbox, useVisibilityTreeRenderer is renamed to `createVisibilityTreeRenderer`, `createVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `expansionToggleWidth` and `disableRootNodeCollapse`.",
+      "comment": [
+        "**BREAKING** Trees: Make eye checkboxes static on horizontal scroll."
+      ],
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": [
+        "Trees: Decrease whitespace size between the node label and eye checkbox."
+      ],
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": [
+        "**BREAKING** `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take a `props` object of type `VisibilityTreeRendererProps`. It contains two new configuration options: `levelOffset`, and `disableRootNodeCollapse`."
+      ],
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
+++ b/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between node label and eye checkbox, `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `leafNodeOffset` and `disableRootNodeCollapse`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
+++ b/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
@@ -2,23 +2,22 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": [
-        "**BREAKING** Trees: Make eye checkboxes static on horizontal scroll."
-      ],
+      "comment": "**BREAKING** Trees: Make eye checkboxes static on horizontal scroll.",
       "type": "none"
     },
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": [
-        "Trees: Decrease whitespace size between the node label and eye checkbox."
-      ],
+      "comment": "Trees: Decrease whitespace size between the node label and eye checkbox.",
       "type": "none"
     },
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": [
-        "**BREAKING** `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take a `props` object of type `VisibilityTreeRendererProps`. It contains two new configuration options: `levelOffset`, and `disableRootNodeCollapse`."
-      ],
+      "comment": "**BREAKING** `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take a `props` object of type `VisibilityTreeRendererProps`. It contains two new configuration options: `levelOffset`, and `disableRootNodeCollapse`.",
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "**BREAKING** Rename `useVisibilityTreeRenderer` to `createVisibilityTreeRenderer`.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
+++ b/common/changes/@itwin/tree-widget-react/Keep_eye_checkbox_position_static_on_horizontal_scroll_2023-05-26-11-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/tree-widget-react",
-      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between the node label and eye checkbox, `useVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `expansionToggleWidth` and `disableRootNodeCollapse`.",
+      "comment": "**BREAKING** Make eye checkboxes static on horizontal scroll, decrease whitespace size between the node label and eye checkbox, useVisibilityTreeRenderer is renamed to `createVisibilityTreeRenderer`, `createVisibilityTreeRenderer` and `createVisibilityTreeNodeRenderer` now can take three new arguments - `levelfOffset`, `expansionToggleWidth` and `disableRootNodeCollapse`.",
       "type": "none"
     }
   ],

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -70,7 +70,7 @@ While we expect this package to be mostly used with [AppUI](https://github.com/i
 
   - `useVisibilityTreeRenderer` returns a tree renderer that renders nodes with "eye" checkboxes. Its building blocks:
     - `createVisibilityTreeNodeRenderer`
-    - `VisibilityTreeNodeCheckboxRenderer`
+    - `VisibilityTreeNodeCheckbox`
   - `useVisibilityTreeFiltering` is used to filter the hierarchy.
   - `VisibilityTreeNoFilteredData` is used to render a "no results" when filtering.
   - `VisibilityTreeEventHandler` is an extension of [UnifiedSelectionTreeEventHandler](https://www.itwinjs.org/reference/presentation-components/tree/unifiedselectiontreeeventhandler/), that additionally handles checkbox events and calls provided `IVisibilityHandler` to get/set display of the elements in the hierarchy.

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -68,7 +68,7 @@ While we expect this package to be mostly used with [AppUI](https://github.com/i
 
 - Visibility tree components help you build trees that look and feel like [Models](#models-tree) and [Categories](#categories-tree) trees, letting you control display of elements in the hierarchy.
 
-  - `useVisibilityTreeRenderer` returns a tree renderer that renders nodes with "eye" checkboxes. Its building blocks:
+  - `createVisibilityTreeRenderer` returns a tree renderer that renders nodes with "eye" checkboxes. Its building blocks:
     - `createVisibilityTreeNodeRenderer`
     - `VisibilityTreeNodeCheckbox`
   - `useVisibilityTreeFiltering` is used to filter the hierarchy.

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -70,7 +70,7 @@ While we expect this package to be mostly used with [AppUI](https://github.com/i
 
   - `useVisibilityTreeRenderer` returns a tree renderer that renders nodes with "eye" checkboxes. Its building blocks:
     - `createVisibilityTreeNodeRenderer`
-    - `visibilityTreeNodeCheckboxRenderer`
+    - `VisibilityTreeNodeCheckboxRenderer`
   - `useVisibilityTreeFiltering` is used to filter the hierarchy.
   - `VisibilityTreeNoFilteredData` is used to render a "no results" when filtering.
   - `VisibilityTreeEventHandler` is an extension of [UnifiedSelectionTreeEventHandler](https://www.itwinjs.org/reference/presentation-components/tree/unifiedselectiontreeeventhandler/), that additionally handles checkbox events and calls provided `IVisibilityHandler` to get/set display of the elements in the hierarchy.

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeBase.scss
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeBase.scss
@@ -10,10 +10,15 @@
   flex-direction: column;
   position: relative;
 
+  .ReactWindow__VariableSizeList {
+    >div {
+      width: max-content !important; // to override inline class
+    }
+  }
   .core-tree-node {
     &.with-checkbox {
       >.contents {
-        padding-left: var(--iui-size-xl);
+        padding-left: calc(var(--iui-size-3xs) / 2);
       }
     }
 
@@ -26,13 +31,34 @@
     }
   }
 
-  .contents > .visibility-tree-checkbox {
-    position: absolute;
-    top: unset;
-    left: 5px;
+  .contents {
+    &:hover {
+      > .checkboxWrapper {
+        background-color: var(--iui-color-background-hover);
+      }
+    }
 
-    &:hover, &:disabled {
-      background-color: transparent;
+    > .checkboxWrapper {
+      height: var(--iui-size-l);
+      width: var(--iui-size-l);
+      position: sticky;
+      order: -1;
+      left: 0;
+      background-color: var(--iui-color-background);
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      .visibility-tree-checkbox {
+        &:disabled {
+          background-color: var(--iui-color-background);
+        }
+
+        &:hover {
+          background-color: var(--iui-color-background-hover);
+        }
+      }
     }
   }
 

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeBase.scss
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeBase.scss
@@ -12,7 +12,7 @@
 
   .ReactWindow__VariableSizeList {
     >div {
-      width: max-content !important; // to override inline class
+      min-width: max-content !important; // to override inline class
     }
   }
   .core-tree-node {
@@ -29,16 +29,24 @@
         }
       }
     }
+
+    &.is-selected {
+      >.contents {
+        >.visibility-tree-checkbox-container {
+          background-color: var(--iui-color-background-accent-muted)
+        }
+      }
+    }
   }
 
   .contents {
     &:hover {
-      > .checkboxWrapper {
+      > .visibility-tree-checkbox-container {
         background-color: var(--iui-color-background-hover);
       }
     }
 
-    > .checkboxWrapper {
+    > .visibility-tree-checkbox-container {
       height: var(--iui-size-l);
       width: var(--iui-size-l);
       position: sticky;
@@ -87,5 +95,4 @@
       font-weight: bold;
     }
   }
-
 }

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -33,11 +33,11 @@ export interface VisibilityTreeRendererProps {
    */
   levelOffset?: number;
   /**
-   * Defines the size in pixels of how much the leaf node label should be pushed to the right from the checkbox.
+   * Defines the size in pixels of the expansion toggle. It is used to keep same hierarchy nodes with children and nodes without children in the same line.
    * @note This value applies only to the leaf nodes.
    * Defaults to `24`.
    */
-  leafNodeOffset?: number;
+  expansionToggleWidth?: number;
   /**
    * Specifies whether the root node be expanded at all times.
    * Defaults to `false`.
@@ -66,9 +66,9 @@ const imageLoader = new TreeImageLoader();
  * Creates node renderer which renders node with eye checkbox.
  * @public
  */
-export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, leafNodeOffset = 24, disableRootNodeCollapse = false, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => {
+export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, expansionToggleWidth = 24, disableRootNodeCollapse = false, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => {
   return function VisibilityTreeNodeRenderer(treeNodeProps: TreeNodeRendererProps) {
-    const nodeOffset = treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? leafNodeOffset : 0);
+    const nodeOffset = treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? expansionToggleWidth : 0);
     return (
       <TreeNodeRenderer
         {...treeNodeProps}

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -15,6 +15,14 @@ import type { IPresentationTreeDataProvider } from "@itwin/presentation-componen
 import type { VisibilityTreeFilterInfo } from "./Common";
 
 /**
+ * This constant is taken from `@itwin/core-react`.
+ * Defines the size in pixels of the expansion toggle.
+ * It is used to keep same hierarchy nodes with children and nodes without children in the same line.
+ * @note This value applies only to the leaf nodes.
+ */
+const EXPANSION_TOGGLE_WIDTH = 24;
+
+/**
  * Props for visibility tree node renderer.
  * @public
  */
@@ -32,12 +40,6 @@ export interface VisibilityTreeRendererProps {
    * Defaults to `20`.
    */
   levelOffset?: number;
-  /**
-   * Defines the size in pixels of the expansion toggle. It is used to keep same hierarchy nodes with children and nodes without children in the same line.
-   * @note This value applies only to the leaf nodes.
-   * Defaults to `24`.
-   */
-  expansionToggleWidth?: number;
   /**
    * Specifies whether the root node be expanded at all times.
    * Defaults to `false`.
@@ -67,9 +69,9 @@ const imageLoader = new TreeImageLoader();
  * Creates node renderer which renders node with eye checkbox.
  * @public
  */
-export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, expansionToggleWidth = 24, disableRootNodeCollapse = false, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => {
+export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, disableRootNodeCollapse = false, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => {
   return function VisibilityTreeNodeRenderer(treeNodeProps: TreeNodeRendererProps) {
-    const nodeOffset = treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? expansionToggleWidth : 0);
+    const nodeOffset = treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? EXPANSION_TOGGLE_WIDTH : 0);
     return (
       <TreeNodeRenderer
         {...treeNodeProps}

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { TreeImageLoader, TreeNodeRenderer, TreeRenderer } from "@itwin/components-react";
 import { Checkbox } from "@itwin/itwinui-react";
 import { useControlledPresentationTreeFiltering } from "@itwin/presentation-components";
@@ -49,15 +49,16 @@ export interface VisibilityTreeRendererProps {
  * Creates Visibility tree renderer which renders nodes with eye checkbox.
  * @public
  */
-export const useVisibilityTreeRenderer = (visibilityTreeRendererProps: VisibilityTreeRendererProps) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const nodeRenderer = useCallback(createVisibilityTreeNodeRenderer(visibilityTreeRendererProps), [visibilityTreeRendererProps]);
-  return useCallback((props: TreeRendererProps) => (
-    <TreeRenderer
-      {...props}
-      nodeRenderer={nodeRenderer}
-    />
-  ), [nodeRenderer]);
+export const createVisibilityTreeRenderer = (visibilityTreeRendererProps: VisibilityTreeRendererProps) => {
+  const nodeRenderer = createVisibilityTreeNodeRenderer(visibilityTreeRendererProps);
+  return function VisibilityTreeRenderer(props: TreeRendererProps) {
+    return (
+      <TreeRenderer
+        {...props}
+        nodeRenderer={nodeRenderer}
+      />
+    );
+  };
 };
 
 const imageLoader = new TreeImageLoader();
@@ -72,7 +73,7 @@ export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, expansionTo
     return (
       <TreeNodeRenderer
         {...treeNodeProps}
-        node={{ ...treeNodeProps.node, depth: 0, numChildren: 1 }}
+        node={{ ...treeNodeProps.node, depth: 0, numChildren: 1 }} // if we want to disable TreeNodeRenderer style calculations for tree nodes, we need to override these values.
         checkboxRenderer={(checkboxProps: NodeCheckboxRenderProps) => (
           <div className="visibility-tree-checkbox-container" style={{ marginRight: `${nodeOffset}px` }}>
             <VisibilityTreeNodeCheckbox { ...checkboxProps }/>

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -18,7 +18,7 @@ import type { VisibilityTreeFilterInfo } from "./Common";
  * Props for visibility tree node renderer.
  * @public
  */
-export interface visibilityTreeRendererProps {
+export interface VisibilityTreeRendererProps {
   /**
    * Specifies whether the icon at the left of the node label should be rendered.
    */
@@ -29,15 +29,15 @@ export interface visibilityTreeRendererProps {
   descriptionEnabled: boolean;
   /**
    * Defines the offset in pixels of how much each hierarchy level should be offset to the right from the checkbox.
-   * Default value is 20.
+   * Defaults to `20`.
    */
   levelOffset?: number;
   /**
    * Defines the size in pixels of how much the leaf node label should be pushed to the right from the checkbox.
    * @note This value applies only to the leaf nodes.
-   * Default value is 24.
+   * Defaults to `24`.
    */
-  expansionToggleWidth?: number;
+  leafNodeOffset?: number;
   /**
    * Specifies whether the root node be expanded at all times.
    * Defaults to `false`.
@@ -49,7 +49,7 @@ export interface visibilityTreeRendererProps {
  * Creates Visibility tree renderer which renders nodes with eye checkbox.
  * @public
  */
-export const useVisibilityTreeRenderer = (visibilityTreeRendererProps: visibilityTreeRendererProps) => {
+export const useVisibilityTreeRenderer = (visibilityTreeRendererProps: VisibilityTreeRendererProps) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const nodeRenderer = useCallback(createVisibilityTreeNodeRenderer(visibilityTreeRendererProps), [visibilityTreeRendererProps]);
   return useCallback((props: TreeRendererProps) => (
@@ -66,28 +66,31 @@ const imageLoader = new TreeImageLoader();
  * Creates node renderer which renders node with eye checkbox.
  * @public
  */
-export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, expansionToggleWidth = 24, disableRootNodeCollapse = false, ...props }: visibilityTreeRendererProps) => {
-  return (treeNodeProps: TreeNodeRendererProps) => ( // eslint-disable-line react/display-name
-    <TreeNodeRenderer
-      {...treeNodeProps}
-      node={{ ...treeNodeProps.node, depth: 0, numChildren: 1 }}
-      checkboxRenderer={(checkboxProps: NodeCheckboxRenderProps) => (
-        <div className="checkboxWrapper" style={{ marginRight: `${treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? expansionToggleWidth : 0)}px` }}>
-          <VisibilityTreeNodeCheckboxRenderer { ...checkboxProps }/>
-        </div>
-      )}
-      descriptionEnabled={props.descriptionEnabled}
-      imageLoader={props.iconsEnabled ? imageLoader : undefined}
-      className={classNames("with-checkbox", (treeNodeProps.node.numChildren === 0 || (disableRootNodeCollapse && treeNodeProps.node.parentId === undefined)) && "disable-expander", treeNodeProps.className)}
-    />
-  );
+export const createVisibilityTreeNodeRenderer = ({ levelOffset = 20, leafNodeOffset = 24, disableRootNodeCollapse = false, descriptionEnabled, iconsEnabled }: VisibilityTreeRendererProps) => {
+  return function VisibilityTreeNodeRenderer(treeNodeProps: TreeNodeRendererProps) {
+    const nodeOffset = treeNodeProps.node.depth * levelOffset + (treeNodeProps.node.numChildren === 0 ? leafNodeOffset : 0);
+    return (
+      <TreeNodeRenderer
+        {...treeNodeProps}
+        node={{ ...treeNodeProps.node, depth: 0, numChildren: 1 }}
+        checkboxRenderer={(checkboxProps: NodeCheckboxRenderProps) => (
+          <div className="visibility-tree-checkbox-container" style={{ marginRight: `${nodeOffset}px` }}>
+            <VisibilityTreeNodeCheckbox { ...checkboxProps }/>
+          </div>
+        )}
+        descriptionEnabled={descriptionEnabled}
+        imageLoader={iconsEnabled ? imageLoader : undefined}
+        className={classNames("with-checkbox", (treeNodeProps.node.numChildren === 0 || (disableRootNodeCollapse && treeNodeProps.node.parentId === undefined)) && "disable-expander", treeNodeProps.className)}
+      />
+    );
+  };
 };
 
 /**
  * Checkbox renderer that renders an eye.
  * @public
  */
-export const VisibilityTreeNodeCheckboxRenderer = (props: NodeCheckboxRenderProps) => (
+export const VisibilityTreeNodeCheckbox = (props: NodeCheckboxRenderProps) => (
   <Checkbox
     className="visibility-tree-checkbox"
     variant="eyeball"

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeRenderer.tsx
@@ -28,7 +28,7 @@ export interface visibilityTreeRendererProps {
    */
   descriptionEnabled: boolean;
   /**
-   * Defines the size in pixels of how much the node label should be pushed to the right from the checkbox.
+   * Defines the offset in pixels of how much each hierarchy level should be offset to the right from the checkbox.
    * Default value is 20.
    */
   levelOffset?: number;
@@ -40,7 +40,7 @@ export interface visibilityTreeRendererProps {
   expansionToggleWidth?: number;
   /**
    * Specifies whether the root node be expanded at all times.
-   * Default value is false.
+   * Defaults to `false`.
    */
   disableRootNodeCollapse?: boolean;
 }

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
@@ -98,7 +98,7 @@ export function CategoryTree(props: CategoryTreeProps) {
   }), [filteredNodeLoader, visibilityHandler]));
 
   const treeModel = useTreeModel(filteredNodeLoader.modelSource);
-  const treeRenderer = useVisibilityTreeRenderer(false, true);
+  const treeRenderer = useVisibilityTreeRenderer({ iconsEnabled: false, descriptionEnabled: true, levelOffset: 10 });
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
   const filterApplied = filteredNodeLoader !== nodeLoader;
 

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/CategoriesTree.tsx
@@ -12,7 +12,7 @@ import { usePresentationTreeNodeLoader } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import { TreeWidget } from "../../../TreeWidget";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
-import { useVisibilityTreeFiltering, useVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
+import { createVisibilityTreeRenderer, useVisibilityTreeFiltering, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
 import { CategoryVisibilityHandler } from "./CategoryVisibilityHandler";
 
 import type { IModelConnection, SpatialViewState, ViewManager, Viewport } from "@itwin/core-frontend";
@@ -98,7 +98,7 @@ export function CategoryTree(props: CategoryTreeProps) {
   }), [filteredNodeLoader, visibilityHandler]));
 
   const treeModel = useTreeModel(filteredNodeLoader.modelSource);
-  const treeRenderer = useVisibilityTreeRenderer({ iconsEnabled: false, descriptionEnabled: true, levelOffset: 10 });
+  const treeRenderer = createVisibilityTreeRenderer({ iconsEnabled: false, descriptionEnabled: true, levelOffset: 10 });
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
   const filterApplied = filteredNodeLoader !== nodeLoader;
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -5,13 +5,13 @@
 
 import "../VisibilityTreeBase.scss";
 import { useCallback, useEffect, useMemo } from "react";
-import { ControlledTree, SelectionMode, TreeRenderer, useTreeModel } from "@itwin/components-react";
+import { ControlledTree, SelectionMode, useTreeModel } from "@itwin/components-react";
 import { useDisposable } from "@itwin/core-react";
 import { isPresentationTreeNodeItem, usePresentationTreeNodeLoader } from "@itwin/presentation-components";
 import { TreeWidget } from "../../../TreeWidget";
 import { ClassGroupingOption } from "../Common";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
-import { createVisibilityTreeNodeRenderer, useVisibilityTreeFiltering, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
+import { useVisibilityTreeFiltering, useVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
 import { ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
 import { createRuleset, createSearchRuleset } from "./Utils";
 
@@ -20,7 +20,6 @@ import type { SingleSchemaClassSpecification } from "@itwin/presentation-common"
 import type { IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { VisibilityTreeFilterInfo } from "../Common";
 import type { ModelsTreeSelectionPredicate } from "./ModelsVisibilityHandler";
-import type { TreeNodeRendererProps, TreeRendererProps } from "@itwin/components-react";
 
 const PAGING_SIZE = 20;
 
@@ -117,7 +116,7 @@ export function ModelsTree(props: ModelsTreeProps) {
   }), [filteredNodeLoader, visibilityHandler, selectionPredicate]));
 
   const treeModel = useTreeModel(filteredNodeLoader.modelSource);
-  const treeRenderer = getModelsTreeRenderer();
+  const treeRenderer = useVisibilityTreeRenderer({ iconsEnabled: true, descriptionEnabled: false, levelOffset: 10, disableRootNodeCollapse: true });
 
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
 
@@ -215,18 +214,3 @@ const isFilteredDataProvider = (dataProvider: IPresentationTreeDataProvider | IF
 const getFilteredDataProvider = (dataProvider: IPresentationTreeDataProvider | IFilteredPresentationTreeDataProvider): IFilteredPresentationTreeDataProvider | undefined => {
   return isFilteredDataProvider(dataProvider) ? dataProvider : undefined;
 };
-
-function getModelsTreeRenderer() {
-  const nodeRenderer = (props: TreeNodeRendererProps) => (
-    createVisibilityTreeNodeRenderer(true, false)({ ...props, className: props.node.parentId === undefined ? "disable-expander": undefined })
-  );
-
-  return function ModelsTreeRenderer(props: TreeRendererProps) {
-    return (
-      <TreeRenderer
-        {...props}
-        nodeRenderer={nodeRenderer}
-      />
-    );
-  };
-}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -11,7 +11,7 @@ import { isPresentationTreeNodeItem, usePresentationTreeNodeLoader } from "@itwi
 import { TreeWidget } from "../../../TreeWidget";
 import { ClassGroupingOption } from "../Common";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
-import { useVisibilityTreeFiltering, useVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
+import { createVisibilityTreeRenderer, useVisibilityTreeFiltering, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
 import { ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
 import { createRuleset, createSearchRuleset } from "./Utils";
 
@@ -116,7 +116,7 @@ export function ModelsTree(props: ModelsTreeProps) {
   }), [filteredNodeLoader, visibilityHandler, selectionPredicate]));
 
   const treeModel = useTreeModel(filteredNodeLoader.modelSource);
-  const treeRenderer = useVisibilityTreeRenderer({ iconsEnabled: true, descriptionEnabled: false, levelOffset: 10, disableRootNodeCollapse: true });
+  const treeRenderer = createVisibilityTreeRenderer({ iconsEnabled: true, descriptionEnabled: false, levelOffset: 10, disableRootNodeCollapse: true });
 
   const overlay = isFiltering ? <div className="filteredTreeOverlay" /> : undefined;
 

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
@@ -88,15 +88,15 @@ describe("VisibilityTreeRenderer", () => {
     });
 
     it("renders nodes with custom levelOffset and expansionToggleWidth values", async () => {
-      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
       const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
       const renderedMiddleNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedMiddleNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("10px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
       const renderedLeafNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("22px");
     });

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
@@ -88,15 +88,15 @@ describe("VisibilityTreeRenderer", () => {
     });
 
     it("renders nodes with custom levelOffset and expansionToggleWidth values", async () => {
-      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
       const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
       const renderedMiddleNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedMiddleNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("10px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, leafNodeOffset: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
       const renderedLeafNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("22px");
     });

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { createVisibilityTreeNodeRenderer } from "../../components/trees/VisibilityTreeRenderer";
+import { render, waitFor } from "@testing-library/react";
+import { PropertyRecord } from "@itwin/appui-abstract";
+import { CheckBoxState } from "@itwin/core-react";
+import { expect } from "chai";
+
+import type { TreeActions, TreeModelNode } from "@itwin/components-react";
+
+describe("VisibilityTreeRenderer", () => {
+  const rootNode: TreeModelNode = {
+    id: "root-node",
+    description: "root-node-description",
+    label: PropertyRecord.fromString("root-node"),
+    isExpanded: true,
+    isSelected: false,
+    checkbox: {
+      state: CheckBoxState.Off,
+      isDisabled: false,
+      isVisible: true,
+    },
+    item: {
+      id: "root-node",
+      label: PropertyRecord.fromString("root-node"),
+    },
+    parentId: undefined,
+    depth: 0,
+    numChildren: 1,
+  };
+  const middleNode: TreeModelNode = {
+    ...rootNode,
+    id: "middle-node",
+    description: "middle-node-description",
+    label: PropertyRecord.fromString("middle-node"),
+    item: {
+      id: "middle-node",
+      label: PropertyRecord.fromString("middle-node"),
+    },
+    parentId: "root-node",
+    depth: 1,
+  };
+
+  const leafNode: TreeModelNode = {
+    ...middleNode,
+    id: "leaf-node",
+    description: "leaf-node-description",
+    label: PropertyRecord.fromString("leaf-node"),
+    item: {
+      id: "leaf-node",
+      label: PropertyRecord.fromString("leaf-node"),
+    },
+    parentId: "middle-node",
+    depth: 1,
+    numChildren: 0,
+  };
+
+  describe("createVisibilityTreeNodeRenderer", () => {
+    it("renders nodes with default values", async () => {
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false })({ node: rootNode, treeActions: {} as TreeActions }));
+      const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false })({ node: middleNode, treeActions: {} as TreeActions })));
+      const renderedMiddleNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedMiddleNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("20px");
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false })({ node: leafNode, treeActions: {} as TreeActions })));
+      const renderedLeafNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("44px");
+    });
+
+    it("disables expander for root node when disableRootNodeCollapse is set to true", async () => {
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, disableRootNodeCollapse: true })({ node: rootNode, treeActions: {} as TreeActions }));
+      const renderedRootNode = await waitFor(() => getByTestId("tree-node"));
+      expect(renderedRootNode.className.includes("disable-expander")).to.be.eq(true);
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, disableRootNodeCollapse: true })({ node: middleNode, treeActions: {} as TreeActions })));
+
+      const renderedMiddleNode = await waitFor(() => getByTestId("tree-node"));
+      expect(renderedMiddleNode.className.includes("disable-expander")).to.be.eq(false);
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, disableRootNodeCollapse: true })({ node: leafNode, treeActions: {} as TreeActions })));
+      const renderedLeafNode = await waitFor(() => getByTestId("tree-node"));
+      expect(renderedLeafNode.className.includes("disable-expander")).to.be.eq(true);
+    });
+
+    it("renders nodes with custom levelOffset and expansionToggleWidth values", async () => {
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
+      const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
+      const renderedMiddleNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedMiddleNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("10px");
+
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
+      const renderedLeafNode = await waitFor(() => getByTestId("tree-node-contents"));
+      expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("22px");
+    });
+  });
+});

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
@@ -72,7 +72,7 @@ describe("VisibilityTreeRenderer", () => {
       expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("44px");
     });
 
-    it("disables expander for root node when disableRootNodeCollapse is set to true", async () => {
+    it("disables expander for root node when `disableRootNodeCollapse` is set to true", async () => {
       const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, disableRootNodeCollapse: true })({ node: rootNode, treeActions: {} as TreeActions }));
       const renderedRootNode = await waitFor(() => getByTestId("tree-node"));
       expect(renderedRootNode.className.includes("disable-expander")).to.be.eq(true);
@@ -87,7 +87,7 @@ describe("VisibilityTreeRenderer", () => {
       expect(renderedLeafNode.className.includes("disable-expander")).to.be.eq(true);
     });
 
-    it("renders nodes with custom levelOffset and expansionToggleWidth values", async () => {
+    it("renders nodes with custom `levelOffset` and `expansionToggleWidth` values", async () => {
       const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
       const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeRenderer.test.tsx
@@ -87,18 +87,18 @@ describe("VisibilityTreeRenderer", () => {
       expect(renderedLeafNode.className.includes("disable-expander")).to.be.eq(true);
     });
 
-    it("renders nodes with custom `levelOffset` and `expansionToggleWidth` values", async () => {
-      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: rootNode, treeActions: {} as TreeActions }));
+    it("renders nodes with custom `levelOffset` value", async () => {
+      const { getByTestId, ...result } = render(createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10 })({ node: rootNode, treeActions: {} as TreeActions }));
       const renderedRootNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedRootNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("0px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: middleNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10 })({ node: middleNode, treeActions: {} as TreeActions })));
       const renderedMiddleNode = await waitFor(() => getByTestId("tree-node-contents"));
       expect((renderedMiddleNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("10px");
 
-      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10, expansionToggleWidth: 12 })({ node: leafNode, treeActions: {} as TreeActions })));
+      result.rerender((createVisibilityTreeNodeRenderer({ iconsEnabled: false, descriptionEnabled: false, levelOffset: 10 })({ node: leafNode, treeActions: {} as TreeActions })));
       const renderedLeafNode = await waitFor(() => getByTestId("tree-node-contents"));
-      expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("22px");
+      expect((renderedLeafNode.children[1] as HTMLDivElement).style.marginRight).to.be.eq("34px");
     });
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
@@ -363,7 +363,7 @@ exports[`ModelsTree #unit <ModelsTree /> should match snapshot 1`] = `
                     </i>
                   </div>
                   <div
-                    class="checkboxWrapper"
+                    class="visibility-tree-checkbox-container"
                     style="margin-right: 24px;"
                   >
                     <input

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
@@ -338,12 +338,39 @@ exports[`ModelsTree #unit <ModelsTree /> should match snapshot 1`] = `
                 <div
                   class="contents"
                   data-testid="tree-node-contents"
-                  style="margin-left: 24px;"
+                  style="margin-left: 0px;"
                 >
-                  <input
-                    class="iui-checkbox iui-checkbox-visibility visibility-tree-checkbox"
-                    type="checkbox"
-                  />
+                  <div
+                    aria-label="tree.expand"
+                    class="core-tree-expansionToggle expansion-toggle"
+                    data-testid="tree-node-expansion-toggle"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    <i
+                      class="icon core-svg-icon toggle icon"
+                    >
+                      <svg
+                        fill="var(--iui-color-icon-muted, currentColor)"
+                        height="1rem"
+                        viewBox="0 0 16 16"
+                        width="1rem"
+                      >
+                        <path
+                          d="M4.7 0L3.3 1.4 9.9 8l-6.6 6.6L4.7 16l8-8z"
+                        />
+                      </svg>
+                    </i>
+                  </div>
+                  <div
+                    class="checkboxWrapper"
+                    style="margin-right: 24px;"
+                  >
+                    <input
+                      class="iui-checkbox iui-checkbox-visibility visibility-tree-checkbox"
+                      type="checkbox"
+                    />
+                  </div>
                   <div
                     class="core-tree-node-icon"
                   />

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.tsx
@@ -129,38 +129,6 @@ describe("ModelsTree", () => {
         expect(node.className.includes("disable-expander")).to.be.true;
       });
 
-      it("renders node with expansion toggle if node has parent", async () => {
-        (PresentationTreeDataProvider.prototype.getNodesCount as any).restore();
-        sinon.stub(PresentationTreeDataProvider.prototype, "getNodesCount").resolves(1);
-
-        (PresentationTreeDataProvider.prototype.getNodes as any).restore();
-        sinon.stub(PresentationTreeDataProvider.prototype, "getNodes").callsFake(async (parent) => {
-          if (parent?.id === "root-node") {
-            return [
-              {
-                id: "child-node",
-                label: PropertyRecord.fromString("ChildNode"),
-                isCheckboxVisible: true,
-                hasChildren: false,
-              },
-            ];
-          } else {
-            return [
-              {
-                id: "root-node",
-                label: PropertyRecord.fromString("RootNode"),
-                hasChildren: true,
-                autoExpand: true,
-              },
-            ];
-          }
-        });
-        visibilityHandlerMock.setup((x) => x.getVisibilityStatus(moq.It.isAny())).returns(() => ({ state: "hidden" }));
-        const { getAllByTestId } = render(<ModelsTree {...sizeProps} iModel={imodelMock.object} modelsVisibilityHandler={visibilityHandlerMock.object} activeView={mockViewport().object} />);
-        const nodes = await waitFor(() => getAllByTestId("tree-node"));
-        expect(nodes[1].className.includes("disable-expander")).to.be.false;
-      });
-
       it("renders nodes as unchecked when they're not displayed", async () => {
         setupDataProviderForEachNodeType();
         visibilityHandlerMock.setup((x) => x.getVisibilityStatus(moq.It.isAny())).returns(() => ({ state: "hidden" }));


### PR DESCRIPTION
closes #493

before:
![image](https://github.com/iTwin/viewer-components-react/assets/124659623/afa18d63-1918-41f8-a0ad-9c7b2c2b51ca)
![image](https://github.com/iTwin/viewer-components-react/assets/124659623/e856e7f5-55ad-48d1-b6be-75b7d936ff78)


after:
![image](https://github.com/iTwin/viewer-components-react/assets/124659623/9e2d249d-2e56-41fa-92c3-c83f4ac8961d) 
![image](https://github.com/iTwin/viewer-components-react/assets/124659623/5e7e6a55-3663-4f14-b1de-6f551ce953f6)

