### PR TITLE
Property grid: Settings dropdown

### DIFF
--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridManager, PropertyGridUiItemsProvider, RemoveFavoritePropertyMenuItem, ShowHideNullValuesSettingsMenuItem } from "@itwin/property-grid-react";
+import { AddFavoritePropertyContextMenuItem, CopyPropertyTextContextMenuItem, PropertyGridManager, PropertyGridUiItemsProvider, RemoveFavoritePropertyContextMenuItem, ShowHideNullValuesSettingsMenuItem } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
@@ -79,9 +79,9 @@ const configuredUiItems = new Map<string, UiItem>([
           enableAncestorNavigation: true,
           autoExpandChildCategories: true,
           contextMenuItems: [
-            (props) => <AddFavoritePropertyMenuItem {...props} />,
-            (props) => <RemoveFavoritePropertyMenuItem {...props} />,
-            (props) => <CopyPropertyTextMenuItem {...props} />,
+            (props) => <AddFavoritePropertyContextMenuItem {...props} />,
+            (props) => <RemoveFavoritePropertyContextMenuItem {...props} />,
+            (props) => <CopyPropertyTextContextMenuItem {...props} />,
           ],
           settingsMenuItems: [
             (props) => <ShowHideNullValuesSettingsMenuItem {...props} persist={true} />,

--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createRemoveFavoritePropertyItemProvider } from "@itwin/property-grid-react";
+import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createRemoveFavoritePropertyItemProvider, createShowNullValuesSettingProvider } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
@@ -83,6 +83,9 @@ const configuredUiItems = new Map<string, UiItem>([
             createRemoveFavoritePropertyItemProvider(),
             createCopyPropertyTextItemProvider(),
           ],
+          settingProviders: [
+            createShowNullValuesSettingProvider(true),
+          ]
         }
       })],
     }

--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridManager, PropertyGridUiItemsProvider, RemoveFavoritePropertyMenuItem, ShowHideNullValuesSetting } from "@itwin/property-grid-react";
+import { AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridManager, PropertyGridUiItemsProvider, RemoveFavoritePropertyMenuItem, ShowHideNullValuesSettingsMenuItem } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
@@ -83,8 +83,8 @@ const configuredUiItems = new Map<string, UiItem>([
             (props) => <RemoveFavoritePropertyMenuItem {...props} />,
             (props) => <CopyPropertyTextMenuItem {...props} />,
           ],
-          settings: [
-            (props) => <ShowHideNullValuesSetting {...props} persist={true} />,
+          settingsMenuItems: [
+            (props) => <ShowHideNullValuesSettingsMenuItem {...props} persist={true} />,
           ]
         }
       })],

--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { UiItemsProvider } from "@itwin/appui-react";
 import { TreeWidget, TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
-import { PropertyGridManager, PropertyGridUiItemsProvider, createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createRemoveFavoritePropertyItemProvider, createShowNullValuesSettingProvider } from "@itwin/property-grid-react";
+import { AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridManager, PropertyGridUiItemsProvider, RemoveFavoritePropertyMenuItem, ShowHideNullValuesSetting } from "@itwin/property-grid-react";
 import { MeasureTools, MeasureToolsUiItemsProvider, MeasurementActionToolbar } from "@itwin/measure-tools-react";
 import { BreakdownTrees } from "@itwin/breakdown-trees-react";
 import { SampleSpatialTree } from "./components/SampleSpatialTree";
@@ -78,13 +78,13 @@ const configuredUiItems = new Map<string, UiItem>([
         propertyGridProps: {
           enableAncestorNavigation: true,
           autoExpandChildCategories: true,
-          contextMenuItemProviders: [
-            createAddFavoritePropertyItemProvider(),
-            createRemoveFavoritePropertyItemProvider(),
-            createCopyPropertyTextItemProvider(),
+          contextMenuItems: [
+            (props) => <AddFavoritePropertyMenuItem {...props} />,
+            (props) => <RemoveFavoritePropertyMenuItem {...props} />,
+            (props) => <CopyPropertyTextMenuItem {...props} />,
           ],
-          settingProviders: [
-            createShowNullValuesSettingProvider(true),
+          settings: [
+            (props) => <ShowHideNullValuesSetting {...props} persist={true} />,
           ]
         }
       })],

--- a/common/api/property-grid-react.api.md
+++ b/common/api/property-grid-react.api.md
@@ -14,11 +14,12 @@ import type { IPresentationPropertyDataProvider } from '@itwin/presentation-comp
 import type { IPropertyDataFilterer } from '@itwin/components-react';
 import type { Localization } from '@itwin/core-common';
 import type { LocalizationOptions } from '@itwin/core-i18n';
-import { PresentationPropertyDataProvider } from '@itwin/presentation-components';
 import type { PropertyDataFilterResult } from '@itwin/components-react';
 import type { PropertyGridContextMenuArgs } from '@itwin/components-react';
 import type { PropertyRecord } from '@itwin/appui-abstract';
 import { PropertyRecordDataFiltererBase } from '@itwin/components-react';
+import type { PropsWithChildren } from 'react';
+import type { ReactNode } from 'react';
 import { StagePanelLocation } from '@itwin/appui-react';
 import { StagePanelSection } from '@itwin/appui-react';
 import type { UiItemsProvider } from '@itwin/appui-react';
@@ -26,39 +27,37 @@ import type { VirtualizedPropertyGridWithDataProviderProps } from '@itwin/compon
 import type { Widget } from '@itwin/appui-react';
 
 // @public
+export function AddFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null;
+
+// @public
 export interface AncestorNavigationProps {
     enableAncestorNavigation?: boolean;
 }
 
 // @public
-export interface ContextMenuItemDefinition {
-    execute: () => void;
-    hidden?: boolean;
-    key: string;
-    label: string;
-    title?: string;
+export interface ContextMenuItemProps {
+    dataProvider: IPresentationPropertyDataProvider;
+    field: Field | undefined;
+    imodel: IModelConnection;
+    record: PropertyRecord;
 }
-
-// @public
-export type ContextMenuItemProvider = (context: MenuItemContext) => ContextMenuItemDefinition;
 
 // @public
 export interface ContextMenuProps {
-    contextMenuItemProviders?: ContextMenuItemProvider[];
+    contextMenuItems?: Array<(props: ContextMenuItemProps) => ReactNode>;
 }
 
 // @public
-export function createAddFavoritePropertyItemProvider(favoritePropertiesScope?: FavoritePropertiesScope): ContextMenuItemProvider;
-
-// @public
-export function createCopyPropertyTextItemProvider(): ContextMenuItemProvider;
-
-// @public
-export function createRemoveFavoritePropertyItemProvider(favoritePropertiesScope?: FavoritePropertiesScope): ContextMenuItemProvider;
+export function CopyPropertyTextContextMenuItem({ record }: ContextMenuItemProps): JSX.Element;
 
 // @public
 export interface DataProviderProps {
     createDataProvider?: (imodel: IModelConnection) => IPresentationPropertyDataProvider;
+}
+
+// @public
+export interface FavoritePropertiesContextMenuItemProps extends ContextMenuItemProps {
+    scope?: FavoritePropertiesScope;
 }
 
 // @internal
@@ -72,6 +71,15 @@ export interface FilteringPropertyGridProps extends VirtualizedPropertyGridWithD
     filterer: IPropertyDataFilterer;
 }
 
+// @public
+export class IModelAppUserPreferencesStorage implements PreferencesStorage {
+    constructor(_nameSpace?: string);
+    // (undocumented)
+    get(key: string): Promise<string | undefined>;
+    // (undocumented)
+    set(key: string, value: string): Promise<void>;
+}
+
 // @internal
 export interface InstanceSelectionProps extends AncestorNavigationProps {
     // (undocumented)
@@ -79,18 +87,10 @@ export interface InstanceSelectionProps extends AncestorNavigationProps {
 }
 
 // @public
-export interface MenuItemContext {
-    dataProvider: IPresentationPropertyDataProvider;
-    field: Field | undefined;
-    imodel: IModelConnection;
-    record: PropertyRecord;
-}
-
-// @public
 export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }: MultiElementPropertyGridProps): JSX.Element;
 
 // @public
-export type MultiElementPropertyGridProps = Omit<PropertyGridProps, "headerContent" | "onBackButton"> & AncestorNavigationProps;
+export type MultiElementPropertyGridProps = Omit<PropertyGridProps, "headerControls" | "onBackButton"> & AncestorNavigationProps;
 
 // @internal
 export class NonEmptyValuesPropertyDataFilterer extends PropertyRecordDataFiltererBase {
@@ -109,41 +109,69 @@ export class NoopPropertyDataFilterer extends PropertyRecordDataFiltererBase {
 }
 
 // @public
-export interface NullValueSettingProps {
-    persistNullValueToggle?: boolean;
+export function NullValueSettingContext({ children }: PropsWithChildren<{}>): JSX.Element;
+
+// @internal (undocumented)
+export interface NullValueSettingContextValue {
+    // (undocumented)
+    setShowNullValues: (value: boolean, options: {
+        persist?: boolean;
+    }) => Promise<void>;
+    // (undocumented)
+    showNullValues: boolean;
+}
+
+// @public
+export interface PreferencesStorage {
+    // (undocumented)
+    get(key: string): Promise<string | undefined>;
+    // (undocumented)
+    set(key: string, value: string): Promise<void>;
 }
 
 // @public
 export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element;
 
 // @public
-export function PropertyGridComponent(props: PropertyGridComponentProps): JSX.Element | null;
+export function PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null;
 
 // @public
 export const PropertyGridComponentId = "vcr:PropertyGridComponent";
 
 // @public
-export type PropertyGridComponentProps = Omit<MultiElementPropertyGridProps, "imodel">;
+export interface PropertyGridComponentProps extends Omit<MultiElementPropertyGridProps, "imodel"> {
+    preferencesStorage?: PreferencesStorage;
+}
 
 // @internal
-export function PropertyGridContent({ dataProvider, imodel, contextMenuItemProviders, persistNullValueToggle, rootClassName, onBackButton, headerContent, ...props }: PropertyGridContentProps): JSX.Element;
+export function PropertyGridContent({ dataProvider, imodel, contextMenuItems, className, onBackButton, headerControls, settingsMenuItems, ...props }: PropertyGridContentProps): JSX.Element;
 
 // @public
 export interface PropertyGridContentBaseProps extends Omit<FilteringPropertyGridProps, "dataProvider" | "filterer" | "isPropertyHoverEnabled" | "isPropertySelectionEnabled" | "onPropertyContextMenu" | "width" | "height"> {
     // (undocumented)
+    className?: string;
+    // (undocumented)
     dataProvider: IPresentationPropertyDataProvider;
     // (undocumented)
-    headerContent?: JSX.Element;
+    headerControls?: JSX.Element;
     // (undocumented)
     imodel: IModelConnection;
     // (undocumented)
     onBackButton?: () => void;
-    // (undocumented)
-    rootClassName?: string;
 }
 
 // @public
-export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & NullValueSettingProps;
+export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & SettingsMenuProps;
+
+// @public
+export function PropertyGridContextMenuItem({ id, children, title, onSelect }: PropsWithChildren<PropertyGridContextMenuItemProps>): JSX.Element;
+
+// @public
+export interface PropertyGridContextMenuItemProps {
+    id: string;
+    onSelect: () => void;
+    title?: string;
+}
 
 // @public
 export class PropertyGridManager {
@@ -156,6 +184,16 @@ export class PropertyGridManager {
 
 // @public
 export type PropertyGridProps = Omit<PropertyGridContentProps, "dataProvider"> & DataProviderProps;
+
+// @public
+export function PropertyGridSettingsMenuItem({ id, onClick, title, children }: PropsWithChildren<PropertyGridSettingsMenuItemProps>): JSX.Element;
+
+// @public
+export interface PropertyGridSettingsMenuItemProps {
+    id: string;
+    onClick: () => void;
+    title?: string;
+}
 
 // @public
 export class PropertyGridUiItemsProvider implements UiItemsProvider {
@@ -173,6 +211,40 @@ export interface PropertyGridUiItemsProviderProps {
     defaultPanelWidgetPriority?: number;
     propertyGridProps?: PropertyGridComponentProps;
 }
+
+// @public
+export function RemoveFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null;
+
+// @internal
+export function SettingsDropdownMenu({ settingsMenuItems, dataProvider }: SettingsDropdownMenuProps): JSX.Element | null;
+
+// @internal
+export interface SettingsDropdownMenuProps extends SettingsMenuProps {
+    // (undocumented)
+    dataProvider: IPresentationPropertyDataProvider;
+}
+
+// @public
+export interface SettingsMenuItemProps {
+    close: () => void;
+    dataProvider: IPresentationPropertyDataProvider;
+}
+
+// @public
+export interface SettingsMenuProps {
+    settingsMenuItems?: Array<(props: SettingsMenuItemProps) => ReactNode>;
+}
+
+// @public
+export function ShowHideNullValuesSettingsMenuItem({ close, persist }: ShowHideNullValuesSettingsMenuItemProps): JSX.Element;
+
+// @public
+export interface ShowHideNullValuesSettingsMenuItemProps extends SettingsMenuItemProps {
+    persist?: boolean;
+}
+
+// @internal (undocumented)
+export const SHOWNULL_KEY = "showNullValues";
 
 // @public
 export interface SingleElementDataProviderProps extends DataProviderProps {
@@ -194,7 +266,7 @@ export interface UseContentMenuProps extends ContextMenuProps {
 }
 
 // @internal
-export function useContextMenu({ dataProvider, imodel, contextMenuItemProviders }: UseContentMenuProps): {
+export function useContextMenu({ dataProvider, imodel, contextMenuItems }: UseContentMenuProps): {
     onPropertyContextMenu: (args: PropertyGridContextMenuArgs) => Promise<void>;
     renderContextMenu: () => JSX.Element | undefined;
 };
@@ -202,7 +274,7 @@ export function useContextMenu({ dataProvider, imodel, contextMenuItemProviders 
 // @internal
 export function useDataProvider({ imodel, createDataProvider }: DataProviderProps & {
     imodel: IModelConnection;
-}): IPresentationPropertyDataProvider | PresentationPropertyDataProvider;
+}): IPresentationPropertyDataProvider;
 
 // @internal
 export function useInstanceSelection({ imodel, enableAncestorNavigation }: InstanceSelectionProps): {
@@ -219,11 +291,15 @@ export function useInstanceSelection({ imodel, enableAncestorNavigation }: Insta
 };
 
 // @internal
-export function useNullValueSetting({ persistNullValueToggle }: NullValueSettingProps): {
+export function useNullValueSetting(): {
     showNullValues: boolean;
-    filterer: IPropertyDataFilterer;
-    setShowNullValues: (value: boolean) => Promise<void>;
+    setShowNullValues: (value: boolean, options: {
+        persist?: boolean;
+    }) => Promise<void>;
 };
+
+// @internal (undocumented)
+export function useNullValueSettingContext(): NullValueSettingContextValue;
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/summary/property-grid-react.exports.csv
+++ b/common/api/summary/property-grid-react.exports.csv
@@ -1,38 +1,52 @@
 sep=;
 Release Tag;API Item
+public;AddFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null
 public;AncestorNavigationProps
-public;ContextMenuItemDefinition
-public;ContextMenuItemProvider = (context: MenuItemContext) => ContextMenuItemDefinition
+public;ContextMenuItemProps
 public;ContextMenuProps
-public;createAddFavoritePropertyItemProvider(favoritePropertiesScope?: FavoritePropertiesScope): ContextMenuItemProvider
-public;createCopyPropertyTextItemProvider(): ContextMenuItemProvider
-public;createRemoveFavoritePropertyItemProvider(favoritePropertiesScope?: FavoritePropertiesScope): ContextMenuItemProvider
+public;CopyPropertyTextContextMenuItem({ record }: ContextMenuItemProps): JSX.Element
 public;DataProviderProps
+public;FavoritePropertiesContextMenuItemProps 
 internal;FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildCategories, ...props }: FilteringPropertyGridProps): JSX.Element
 public;FilteringPropertyGridProps 
+public;IModelAppUserPreferencesStorage 
 internal;InstanceSelectionProps 
-public;MenuItemContext
 public;MultiElementPropertyGrid({ enableAncestorNavigation, ...props }: MultiElementPropertyGridProps): JSX.Element
 public;MultiElementPropertyGridProps = Omit
 internal;NonEmptyValuesPropertyDataFilterer 
 internal;NoopPropertyDataFilterer 
-public;NullValueSettingProps
+public;NullValueSettingContext({ children }: PropsWithChildren
+internal;NullValueSettingContextValue
+public;PreferencesStorage
 public;PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element
-public;PropertyGridComponent(props: PropertyGridComponentProps): JSX.Element | null
+public;PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null
 public;PropertyGridComponentId = "vcr:PropertyGridComponent"
-public;PropertyGridComponentProps = Omit
-internal;PropertyGridContent({ dataProvider, imodel, contextMenuItemProviders, persistNullValueToggle, rootClassName, onBackButton, headerContent, ...props }: PropertyGridContentProps): JSX.Element
+public;PropertyGridComponentProps 
+internal;PropertyGridContent({ dataProvider, imodel, contextMenuItems, className, onBackButton, headerControls, settingsMenuItems, ...props }: PropertyGridContentProps): JSX.Element
 public;PropertyGridContentBaseProps 
-public;PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & NullValueSettingProps
+public;PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & SettingsMenuProps
+public;PropertyGridContextMenuItem({ id, children, title, onSelect }: PropsWithChildren
+public;PropertyGridContextMenuItemProps
 public;PropertyGridManager
 public;PropertyGridProps = Omit
+public;PropertyGridSettingsMenuItem({ id, onClick, title, children }: PropsWithChildren
+public;PropertyGridSettingsMenuItemProps
 public;PropertyGridUiItemsProvider 
 public;PropertyGridUiItemsProviderProps
+public;RemoveFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null
+internal;SettingsDropdownMenu({ settingsMenuItems, dataProvider }: SettingsDropdownMenuProps): JSX.Element | null
+internal;SettingsDropdownMenuProps 
+public;SettingsMenuItemProps
+public;SettingsMenuProps
+public;ShowHideNullValuesSettingsMenuItem({ close, persist }: ShowHideNullValuesSettingsMenuItemProps): JSX.Element
+public;ShowHideNullValuesSettingsMenuItemProps 
+internal;SHOWNULL_KEY = "showNullValues"
 public;SingleElementDataProviderProps 
 public;SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element
 public;SingleElementPropertyGridProps = Omit
 internal;UseContentMenuProps 
-internal;useContextMenu({ dataProvider, imodel, contextMenuItemProviders }: UseContentMenuProps):
+internal;useContextMenu({ dataProvider, imodel, contextMenuItems }: UseContentMenuProps):
 internal;useDataProvider({ imodel, createDataProvider }: DataProviderProps &
 internal;useInstanceSelection({ imodel, enableAncestorNavigation }: InstanceSelectionProps):
-internal;useNullValueSetting({ persistNullValueToggle }: NullValueSettingProps):
+internal;useNullValueSetting():
+internal;useNullValueSettingContext(): NullValueSettingContextValue

--- a/common/changes/@itwin/property-grid-react/property_grid_menu_refactor_2023-05-19-10-58.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_menu_refactor_2023-05-19-10-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/property-grid-react",
-      "comment": "**BREAKING** Removed properties used for enabling/disabling context menu items in favor of `ContextMenuItemProvider` list that is now used to populate context menu.",
+      "comment": "**BREAKING** Removed properties used for enabling/disabling context menu items in favor of `contextMenuItems` list that is now used to populate context menu.",
       "type": "minor"
     }
   ],

--- a/common/changes/@itwin/property-grid-react/property_grid_settings_2023-06-08-08-48.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_settings_2023-06-08-08-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Added settings dropdown menu inside Property Grid header.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/common/changes/@itwin/property-grid-react/property_grid_settings_2023-06-08-08-49.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_settings_2023-06-08-08-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Removed `Show/Hide Empty Values` setting from context menu and moved it to the setting dropdown in header. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/public/locales/en/PropertyGrid.json
+++ b/packages/itwin/property-grid/public/locales/en/PropertyGrid.json
@@ -25,7 +25,10 @@
     "copy-text": {
       "label": "Copy Text",
       "description": "Copy text of this property"
-    },
+    }
+  },
+  "settings": {
+    "label": "Settings",
     "hide-null": {
       "label": "Hide Empty Values",
       "description": "Hide properties with empty values"

--- a/packages/itwin/property-grid/src/components/ElementList.scss
+++ b/packages/itwin/property-grid/src/components/ElementList.scss
@@ -3,42 +3,18 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-@import "~@itwin/core-react/lib/cjs/core-react/index";
-
-$header-height: 50px;
-
 .property-grid-react-element-list {
   height: 100%;
   display: flex;
   flex-direction: column;
-}
 
-.property-grid-react-element-list-header {
-  display: flex;
-  align-items: center;
-  height: $header-height;
-  box-sizing: border-box;
-  margin-left: 4px;
-  margin-right: 6px;
-}
-
-#property-grid-react-element-list-back-btn {
-  margin-right: 2px;
-  padding: 0 4px;
-
-  >svg {
-    width: 22px;
-    height: 22px;
-    margin: 0;
+  .property-grid-react-element-list-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
-}
 
-.property-grid-react-element-list-title {
-  @include uicore-text(leading);
-}
-
-.property-grid-react-element-list-container {
-  @include uicore-scrollbar();
-  flex: 1;
-  overflow: auto;
+  .property-grid-react-element-list-container {
+    overflow: auto;
+  }
 }

--- a/packages/itwin/property-grid/src/components/ElementList.tsx
+++ b/packages/itwin/property-grid/src/components/ElementList.tsx
@@ -6,10 +6,10 @@
 import "./ElementList.scss";
 import classnames from "classnames";
 import * as React from "react";
-import { SvgProgressBackwardCircular } from "@itwin/itwinui-icons-react";
-import { IconButton, MenuItem } from "@itwin/itwinui-react";
+import { MenuItem, Text } from "@itwin/itwinui-react";
 import { PresentationLabelsProvider } from "@itwin/presentation-components";
 import { PropertyGridManager } from "../PropertyGridManager";
+import { Header } from "./Header";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { InstanceKey } from "@itwin/presentation-common";
@@ -23,7 +23,7 @@ export interface ElementListProps {
   instanceKeys: InstanceKey[];
   onBack: () => void;
   onSelect: (instanceKey: InstanceKey) => void;
-  rootClassName?: string;
+  className?: string;
 }
 
 /**
@@ -35,7 +35,7 @@ export function ElementList({
   instanceKeys,
   onBack,
   onSelect,
-  rootClassName,
+  className,
 }: ElementListProps) {
   const [data, setData] = React.useState<string[]>();
 
@@ -53,23 +53,10 @@ export function ElementList({
   const title = `${PropertyGridManager.translate("element-list.title")} (${instanceKeys.length})`;
 
   return (
-    <div
-      className={classnames("property-grid-react-element-list", rootClassName)}
-    >
-      <div className="property-grid-react-element-list-header">
-        <IconButton
-          id="property-grid-react-element-list-back-btn"
-          styleType="borderless"
-          onClick={onBack}
-          onKeyDown={onBack}
-          title={PropertyGridManager.translate("header.back")}
-        >
-          <SvgProgressBackwardCircular />
-        </IconButton>
-        <div className="property-grid-react-element-list-title">
-          {title}
-        </div>
-      </div>
+    <div className={classnames("property-grid-react-element-list", className)}>
+      <Header onBackButtonClick={onBack}>
+        <Text className="property-grid-react-element-list-title" variant="leading">{title}</Text>
+      </Header>
       <div className="property-grid-react-element-list-container" role="list">
         {data?.map((label, index) => (
           <MenuItem

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -3,7 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import "./PropertyGrid.scss";
 import { useCallback } from "react";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
 import {

--- a/packages/itwin/property-grid/src/components/Header.scss
+++ b/packages/itwin/property-grid/src/components/Header.scss
@@ -3,10 +3,13 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-@import "~@itwin/core-react/lib/cjs/core-react/index";
+.property-grid-react-panel-header {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  height: calc(var(--iui-size-l) * 2);
 
-.property-grid-react-filtering-pg-label {
-  @include uicore-text;
-  text-align: center;
-  padding: 0 var(--iui-size-m);
+  .property-grid-react-header-back-button {
+    margin-right: var(--iui-size-xs);
+  }
 }

--- a/packages/itwin/property-grid/src/components/Header.tsx
+++ b/packages/itwin/property-grid/src/components/Header.tsx
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import "./Header.scss";
+import classnames from "classnames";
+import { SvgProgressBackwardCircular } from "@itwin/itwinui-icons-react";
+import { IconButton } from "@itwin/itwinui-react";
+import { PropertyGridManager } from "../PropertyGridManager";
+
+import type { PropsWithChildren } from "react";
+
+/** @internal */
+export interface HeaderProps {
+  className?: string;
+  onBackButtonClick?: () => void;
+}
+
+/** @internal */
+export function Header({ className, children, onBackButtonClick }: PropsWithChildren<HeaderProps>) {
+  return <div className={classnames("property-grid-react-panel-header", className)}>
+    {
+      onBackButtonClick
+        ? <IconButton
+          styleType="borderless"
+          onClick={onBackButtonClick}
+          onKeyDown={onBackButtonClick}
+          title={PropertyGridManager.translate("header.back")}
+          className="property-grid-react-header-back-button"
+        >
+          <SvgProgressBackwardCircular />
+        </IconButton>
+        : null
+    }
+    {children}
+  </div>;
+}

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.scss
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.scss
@@ -5,39 +5,32 @@
 
 .property-grid-react-transition-container {
   height: 100%;
-  width: auto;
   display: flex;
   position: relative;
-  padding-left: var(--iui-size-xs);
-  padding-bottom: var(--iui-size-xs);
+  padding: var(--iui-size-xs);
   box-sizing: border-box;
-}
 
-.property-grid-react-transition-container-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
+  .property-grid-react-transition-container-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 
-.property-grid-react-animated-tab {
-  transition: transform 400ms ease-out;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-}
+    .property-grid-react-animated-tab {
+      transition: transform 400ms ease-out;
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+    }
 
-.property-grid-react-animated-tab-animate-right {
-  transform: translate(100%, 0);
-}
+    .property-grid-react-animated-tab-animate-right {
+      transform: translate(100%, 0);
+    }
 
-.property-grid-react-animated-tab-animate-left {
-  transform: translate(-100%, 0);
-}
-
-.property-grid-react-multi-select-icon>svg {
-  width: 26px;
-  height: 26px;
+    .property-grid-react-animated-tab-animate-left {
+      transform: translate(-100%, 0);
+    }
+  }
 }

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -10,6 +10,7 @@ import { SvgArrowDown, SvgArrowUp, SvgPropertiesList } from "@itwin/itwinui-icon
 import { IconButton } from "@itwin/itwinui-react";
 import { Presentation } from "@itwin/presentation-frontend";
 import { useInstanceSelection } from "../hooks/UseInstanceSelection";
+import { NullValueSettingContext } from "../hooks/UseNullValuesSetting";
 import { PropertyGridManager } from "../PropertyGridManager";
 import { ElementList as ElementListComponent } from "./ElementList";
 import { PropertyGrid as PropertyGridComponent } from "./PropertyGrid";
@@ -102,15 +103,17 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
   return (
     <div className="property-grid-react-transition-container">
       <div className="property-grid-react-transition-container-inner">
-        {items.map((component, idx) => (
-          <div key={component.key} className={classnames({
-            "property-grid-react-animated-tab": true,
-            "property-grid-react-animated-tab-animate-right": idx > content,
-            "property-grid-react-animated-tab-animate-left": idx < content,
-          })} >
-            {component}
-          </div>
-        ))}
+        <NullValueSettingContext>
+          {items.map((component, idx) => (
+            <div key={component.key} className={classnames({
+              "property-grid-react-animated-tab": true,
+              "property-grid-react-animated-tab-animate-right": idx > content,
+              "property-grid-react-animated-tab-animate-left": idx < content,
+            })} >
+              {component}
+            </div>
+          ))}
+        </NullValueSettingContext>
       </div>
     </div>
   );

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -30,7 +30,7 @@ enum MultiElementPropertyContent {
  * Props for `MultiElementPropertyGrid` component.
  * @public
  */
-export type MultiElementPropertyGridProps = Omit<PropertyGridProps, "headerContent" | "onBackButton"> & AncestorNavigationProps;
+export type MultiElementPropertyGridProps = Omit<PropertyGridProps, "headerControls" | "onBackButton"> & AncestorNavigationProps;
 
 /**
  * Component that renders property grid for instances in `UnifiedSelection`.
@@ -57,7 +57,7 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
     });
   }, []);
 
-  const onInfoButton = () => {
+  const openElementList = () => {
     setContent(MultiElementPropertyContent.ElementList);
   };
 
@@ -65,21 +65,14 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
   const items = [
     <PropertyGridComponent
       {...props}
-      headerContent={
-        moreThanOneElement
-          ?
-          <IconButton
-            className="property-grid-react-multi-select-icon"
-            size="small"
-            styleType="borderless"
-            onClick={onInfoButton}
-            onKeyDown={onInfoButton}
-            title={PropertyGridManager.translate("element-list.title")}
-          >
-            <SvgPropertiesList />
-          </IconButton>
-          : <AncestryNavigation {...ancestorsNavigationProps} />
+      headerControls={
+        <HeaderControls
+          multipleElementsSelected={moreThanOneElement}
+          onElementListButtonClick={openElementList}
+          ancestorsNavigationProps={ancestorsNavigationProps}
+        />
       }
+      className={classnames("property-grid-react-property-grid", props.className)}
       key={"PropertyGrid"}
     />,
     <ElementListComponent
@@ -92,7 +85,7 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
         setContent(MultiElementPropertyContent.SingleElementPropertyGrid);
         focusInstance(instanceKey);
       }}
-      rootClassName={props.rootClassName}
+      className={classnames("property-grid-react-element-list", props.className)}
       key={"ElementList"}
     />,
     <SingleElementGrid
@@ -101,6 +94,7 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
       onBackButton={() => {
         setContent(MultiElementPropertyContent.ElementList);
       }}
+      className={classnames("property-grid-react-single-element-property-grid", props.className)}
       key={"SingleElementPropertyGrid"}
     />,
   ];
@@ -120,6 +114,33 @@ export function MultiElementPropertyGrid({ enableAncestorNavigation, ...props }:
       </div>
     </div>
   );
+}
+
+interface HeaderControlsProps {
+  multipleElementsSelected: boolean;
+  ancestorsNavigationProps: AncestorsNavigationProps;
+  onElementListButtonClick: () => void;
+}
+
+function HeaderControls({
+  multipleElementsSelected,
+  ancestorsNavigationProps,
+  onElementListButtonClick,
+}: HeaderControlsProps) {
+  if (!multipleElementsSelected) {
+    return <AncestryNavigation {...ancestorsNavigationProps} />;
+  }
+
+  return <IconButton
+    className="property-grid-react-multi-select-icon"
+    size="small"
+    styleType="borderless"
+    onClick={onElementListButtonClick}
+    onKeyDown={onElementListButtonClick}
+    title={PropertyGridManager.translate("element-list.title")}
+  >
+    <SvgPropertiesList />
+  </IconButton>;
 }
 
 function SingleElementGrid({ instanceKey, ...props }: Omit<SingleElementPropertyGridProps, "instanceKey"> & {instanceKey: InstanceKey | undefined}) {

--- a/packages/itwin/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGrid.tsx
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import "./PropertyGrid.scss";
 import { FillCentered } from "@itwin/core-react";
+import { Text } from "@itwin/itwinui-react";
 import { usePropertyDataProviderWithUnifiedSelection } from "@itwin/presentation-components";
 import { useDataProvider } from "../hooks/UseDataProvider";
 import { PropertyGridManager } from "../PropertyGridManager";
@@ -30,9 +30,7 @@ export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps
   if (isOverLimit) {
     return (
       <FillCentered style={{ flexDirection: "column" }}>
-        <div className="property-grid-react-filtering-pg-label">
-          {PropertyGridManager.translate("selection.too-many-elements-selected")}
-        </div>
+        <Text>{PropertyGridManager.translate("selection.too-many-elements-selected")}</Text>
       </FillCentered>
     );
   }

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.scss
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.scss
@@ -3,60 +3,20 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-@import "~@itwin/core-react/lib/cjs/core-react/index";
-
-$header-height: 50px;
-
 .property-grid-widget-container {
   height: 100%;
   width: 100%;
-  position: absolute;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.property-grid-container {
-  flex: 1;
-  overflow: hidden;
 }
 
 .property-grid-react-panel-label-and-class {
   flex: 1;
-  display: block;
   overflow: hidden;
-}
 
-.property-grid-react-panel-label {
-  @include uicore-text(leading);
-  padding: var(--iui-size-xs) 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.property-grid-react-panel-header {
-  display: flex;
-  align-items: center;
-  margin-right: 6px;
-  height: $header-height;
-  box-sizing: border-box;
-}
-
-.property-grid-react-panel-class {
-  @include uicore-text;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-#property-grid-react-element-list-back-btn {
-  margin-right: 2px;
-  padding: 0 4px;
-
-  > svg {
-    width: 22px;
-    height: 22px;
-    margin: 0;
+  & > * {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -11,7 +11,7 @@ import { ResizableContainerObserver } from "@itwin/core-react";
 import { Text } from "@itwin/itwinui-react";
 import { useContextMenu } from "../hooks/UseContextMenu";
 import { useLoadedInstanceInfo } from "../hooks/UseInstanceInfo";
-import { useNullValueSetting } from "../hooks/UseNullValuesSetting";
+import { useNullValueSettingContext } from "../hooks/UseNullValuesSetting";
 import { FilteringPropertyGrid, NonEmptyValuesPropertyDataFilterer, NoopPropertyDataFilterer } from "./FilteringPropertyGrid";
 import { Header } from "./Header";
 import { SettingsDropdownMenu } from "./SettingsDropdownMenu";
@@ -49,20 +49,20 @@ export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMen
 export function PropertyGridContent({
   dataProvider,
   imodel,
-  contextMenuItemProviders,
+  contextMenuItems,
   className,
   onBackButton,
   headerControls,
-  settingProviders,
+  settings,
   ...props
 }: PropertyGridContentProps) {
   const { item } = useLoadedInstanceInfo({ dataProvider });
-  const { showNullValues, setShowNullValues } = useNullValueSetting();
   const { renderContextMenu, onPropertyContextMenu } = useContextMenu({
     dataProvider,
     imodel,
-    contextMenuItemProviders,
+    contextMenuItems,
   });
+  const { showNullValues } = useNullValueSettingContext();
   const filterer = useFilterer({ showNullValues });
 
   const [{ width, height }, setSize] = useState({ width: 0, height: 0 });
@@ -71,9 +71,7 @@ export function PropertyGridContent({
   }, []);
 
   const settingsProps: SettingsDropdownMenuProps = {
-    settingProviders,
-    showNullValues,
-    setShowNullValues,
+    settings,
     dataProvider,
   };
 

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -16,7 +16,7 @@ import { FilteringPropertyGrid, NonEmptyValuesPropertyDataFilterer, NoopProperty
 import { Header } from "./Header";
 import { SettingsDropdownMenu } from "./SettingsDropdownMenu";
 
-import type { SettingsDropdownMenuProps, SettingsProps } from "./SettingsDropdownMenu";
+import type { SettingsDropdownMenuProps, SettingsMenuProps } from "./SettingsDropdownMenu";
 import type { ReactNode } from "react";
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -40,7 +40,7 @@ export interface PropertyGridContentBaseProps extends Omit<FilteringPropertyGrid
  * Props for `PropertyGridContent` component.
  * @public
  */
-export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & SettingsProps;
+export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & SettingsMenuProps;
 
 /**
  * Component that renders property grid with header and context menu.
@@ -53,7 +53,7 @@ export function PropertyGridContent({
   className,
   onBackButton,
   headerControls,
-  settings,
+  settingsMenuItems,
   ...props
 }: PropertyGridContentProps) {
   const { item } = useLoadedInstanceInfo({ dataProvider });
@@ -71,7 +71,7 @@ export function PropertyGridContent({
   }, []);
 
   const settingsProps: SettingsDropdownMenuProps = {
-    settings,
+    settingsMenuItems,
     dataProvider,
   };
 

--- a/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
+++ b/packages/itwin/property-grid/src/components/PropertyGridContent.tsx
@@ -8,21 +8,21 @@ import classnames from "classnames";
 import { useCallback, useState } from "react";
 import { PropertyValueRendererManager } from "@itwin/components-react";
 import { ResizableContainerObserver } from "@itwin/core-react";
-import { SvgProgressBackwardCircular } from "@itwin/itwinui-icons-react";
-import { IconButton } from "@itwin/itwinui-react";
+import { Text } from "@itwin/itwinui-react";
 import { useContextMenu } from "../hooks/UseContextMenu";
 import { useLoadedInstanceInfo } from "../hooks/UseInstanceInfo";
 import { useNullValueSetting } from "../hooks/UseNullValuesSetting";
-import { PropertyGridManager } from "../PropertyGridManager";
 import { FilteringPropertyGrid, NonEmptyValuesPropertyDataFilterer, NoopPropertyDataFilterer } from "./FilteringPropertyGrid";
+import { Header } from "./Header";
+import { SettingsDropdownMenu } from "./SettingsDropdownMenu";
 
+import type { SettingsDropdownMenuProps, SettingsProps } from "./SettingsDropdownMenu";
 import type { ReactNode } from "react";
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
 import type { FilteringPropertyGridProps } from "./FilteringPropertyGrid";
 import type { ContextMenuProps } from "../hooks/UseContextMenu";
-import type { NullValueSettingProps } from "../hooks/UseNullValuesSetting";
 
 /**
  * Base props for rendering `PropertyGridContent` component.
@@ -31,16 +31,16 @@ import type { NullValueSettingProps } from "../hooks/UseNullValuesSetting";
 export interface PropertyGridContentBaseProps extends Omit<FilteringPropertyGridProps, "dataProvider" | "filterer" | "isPropertyHoverEnabled" | "isPropertySelectionEnabled" | "onPropertyContextMenu" | "width" | "height"> {
   imodel: IModelConnection;
   dataProvider: IPresentationPropertyDataProvider;
-  rootClassName?: string;
+  className?: string;
   onBackButton?: () => void;
-  headerContent?: JSX.Element;
+  headerControls?: JSX.Element;
 }
 
 /**
  * Props for `PropertyGridContent` component.
  * @public
  */
-export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & NullValueSettingProps;
+export type PropertyGridContentProps = PropertyGridContentBaseProps & ContextMenuProps & SettingsProps;
 
 /**
  * Component that renders property grid with header and context menu.
@@ -50,14 +50,14 @@ export function PropertyGridContent({
   dataProvider,
   imodel,
   contextMenuItemProviders,
-  persistNullValueToggle,
-  rootClassName,
+  className,
   onBackButton,
-  headerContent,
+  headerControls,
+  settingProviders,
   ...props
 }: PropertyGridContentProps) {
   const { item } = useLoadedInstanceInfo({ dataProvider });
-  const { showNullValues } = useNullValueSetting({ persistNullValueToggle });
+  const { showNullValues, setShowNullValues } = useNullValueSetting();
   const { renderContextMenu, onPropertyContextMenu } = useContextMenu({
     dataProvider,
     imodel,
@@ -70,60 +70,56 @@ export function PropertyGridContent({
     setSize({ width: w, height: h });
   }, []);
 
+  const settingsProps: SettingsDropdownMenuProps = {
+    settingProviders,
+    showNullValues,
+    setShowNullValues,
+    dataProvider,
+  };
+
   return (
-    <div className={classnames("property-grid-widget-container", rootClassName)}>
-      <Header headerContent={headerContent} item={item} onBackButtonClick={onBackButton} />
-      <div className={"property-grid-container"}>
-        <ResizableContainerObserver onResize={handleResize}>
-          <FilteringPropertyGrid
-            {...props}
-            dataProvider={dataProvider}
-            filterer={filterer}
-            isPropertyHoverEnabled={true}
-            isPropertySelectionEnabled={true}
-            onPropertyContextMenu={onPropertyContextMenu}
-            width={width}
-            height={height}
-          />
-        </ResizableContainerObserver>
-      </div>
+    <div className={classnames("property-grid-widget-container", className)}>
+      <PropertyGridHeader controls={headerControls} item={item} onBackButtonClick={onBackButton} settingsProps={settingsProps} />
+      <ResizableContainerObserver onResize={handleResize}>
+        <FilteringPropertyGrid
+          {...props}
+          dataProvider={dataProvider}
+          filterer={filterer}
+          isPropertyHoverEnabled={true}
+          isPropertySelectionEnabled={true}
+          onPropertyContextMenu={onPropertyContextMenu}
+          width={width}
+          height={height}
+        />
+      </ResizableContainerObserver>
       {renderContextMenu()}
     </div>
   );
 }
 
-interface HeaderProps {
-  headerContent?: ReactNode;
+interface PropertyGridHeaderProps {
+  controls?: ReactNode;
   item?: { className: string, label: PropertyRecord };
   onBackButtonClick?: () => void;
+  settingsProps: SettingsDropdownMenuProps;
 }
 
-function Header({ item, headerContent, onBackButtonClick }: HeaderProps) {
+function PropertyGridHeader({ item, controls, settingsProps, onBackButtonClick }: PropertyGridHeaderProps) {
   if (!item) {
     return null;
   }
 
   return (
-    <div className="property-grid-react-panel-header">
-      {onBackButtonClick !== undefined && (
-        <IconButton
-          id="property-grid-react-element-list-back-btn"
-          styleType="borderless"
-          onClick={onBackButtonClick}
-          onKeyDown={onBackButtonClick}
-          title={PropertyGridManager.translate("header.back")}
-        >
-          <SvgProgressBackwardCircular />
-        </IconButton>
-      )}
+    <Header onBackButtonClick={onBackButtonClick}>
       <div className="property-grid-react-panel-label-and-class">
-        <div className="property-grid-react-panel-label">
-          {item.label && PropertyValueRendererManager.defaultManager.render(item.label)}
-        </div>
-        <div className="property-grid-react-panel-class">{item.className}</div>
+        <Text variant="leading">
+          {PropertyValueRendererManager.defaultManager.render(item.label)}
+        </Text>
+        <Text>{item.className}</Text>
       </div>
-      {headerContent}
-    </div>
+      {controls}
+      <SettingsDropdownMenu {...settingsProps}/>
+    </Header>
   );
 }
 
@@ -137,8 +133,6 @@ function useFilterer({ showNullValues }: UseFiltererProps) {
     nonEmpty: new NonEmptyValuesPropertyDataFilterer(),
   }));
 
-  // TODO: figure out a way to toggle this. https://github.com/iTwin/viewer-components-react/issues/499
-  // istanbul ignore if
   if (!showNullValues) {
     return defaultFilterers.nonEmpty;
   }

--- a/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
+++ b/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
@@ -89,7 +89,7 @@ export function SettingsDropdownMenu({ settingProviders, dataProvider, showNullV
   ));
 
   return <DropdownMenu menuItems={menuItems}>
-    <IconButton styleType="borderless" title={PropertyGridManager.translate("settings.label")}>
+    <IconButton styleType="borderless" size="small" title={PropertyGridManager.translate("settings.label")}>
       <SvgMoreVertical />
     </IconButton>
   </DropdownMenu>;

--- a/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
+++ b/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { useMemo } from "react";
+import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
+import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
+import { PropertyGridManager } from "../PropertyGridManager";
+
+import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
+import type { NullValueSetting } from "../hooks/UseNullValuesSetting";
+
+/**
+ * Type definition for settings provider.
+ * @public
+ */
+export type SettingsProvider = (context: SettingContext) => SettingDefinition[];
+
+/**
+ * Context provided to `SettingsProvider`.
+ * @public
+ */
+export interface SettingContext {
+  /** Data provider used by property grid. */
+  dataProvider: IPresentationPropertyDataProvider;
+  /** State of `null` values setting. */
+  nullValueSetting: NullValueSetting;
+}
+
+/**
+ * Definition of single settings item that should be shown in dropdown menu.
+ * @public
+ */
+export interface SettingDefinition {
+  /** Unique id. */
+  id: string;
+  /** Label that is shown in dropdown menu. */
+  label: string;
+  /** Description that is shown while hovering over setting. */
+  description?: string;
+  /** Action that should be performed when setting is clicked. */
+  action: () => Promise<void>;
+}
+
+/**
+ * Props for configuring settings available in property grid header dropdown menu.
+ * @public
+ */
+export interface SettingsProps {
+  /** List of providers used to populate settings dropdown. */
+  settingProviders?: SettingsProvider[];
+}
+
+/**
+ * Props for `SettingsDropdownMenu`.
+ * @internal
+ */
+export interface SettingsDropdownMenuProps extends SettingsProps {
+  dataProvider: IPresentationPropertyDataProvider;
+  showNullValues: boolean;
+  setShowNullValues: (value: boolean) => Promise<void>;
+}
+
+/**
+ * Component that renders dropdown menu with provided settings.
+ * @internal
+ */
+export function SettingsDropdownMenu({ settingProviders, dataProvider, showNullValues, setShowNullValues }: SettingsDropdownMenuProps) {
+  const itemDefinitions = useMemo(() => {
+    return (settingProviders ?? []).flatMap((provider) => provider({ dataProvider, nullValueSetting: { showNullValues, setShowNullValues } }));
+  }, [settingProviders, dataProvider, showNullValues, setShowNullValues]);
+
+  if (itemDefinitions.length === 0) {
+    return null;
+  }
+
+  const menuItems = (close: () => void) => itemDefinitions.map((definition) => (
+    <MenuItem
+      key={definition.id}
+      onClick={() => {
+        void definition.action();
+        close();
+      }}
+      title={definition.description}
+    >
+      {definition.label}
+    </MenuItem>
+  ));
+
+  return <DropdownMenu menuItems={menuItems}>
+    <IconButton styleType="borderless" title={PropertyGridManager.translate("settings.label")}>
+      <SvgMoreVertical />
+    </IconButton>
+  </DropdownMenu>;
+}
+
+/**
+ * Creates provider for `Show/Hide Empty Values` setting.
+ * @public
+ */
+export function createShowNullValuesSettingProvider(persist?: boolean) {
+  return ({ nullValueSetting }: SettingContext) => {
+    const { showNullValues, setShowNullValues } = nullValueSetting;
+    const label = showNullValues ? PropertyGridManager.translate("settings.hide-null.label") : PropertyGridManager.translate("settings.show-null.label");
+    const description = showNullValues ? PropertyGridManager.translate("settings.hide-null.description") : PropertyGridManager.translate("settings.show-null.description");
+    return [{
+      id: "show-hide-null-values",
+      label,
+      description,
+      action: async () => setShowNullValues(!showNullValues, { persist }),
+    }];
+  };
+}

--- a/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
+++ b/packages/itwin/property-grid/src/components/SettingsDropdownMenu.tsx
@@ -13,10 +13,10 @@ import type { PropsWithChildren, ReactNode } from "react";
 import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
 
 /**
- * Props for single setting renderer.
+ * Props for single settings menu item renderer.
  * @public
  */
-export interface SettingProps {
+export interface SettingsMenuItemProps {
   /** Data provider used by property grid. */
   dataProvider: IPresentationPropertyDataProvider;
   /** Callback that closes dropdown menu. */
@@ -27,16 +27,16 @@ export interface SettingProps {
  * Props for configuring settings available in property grid header dropdown menu.
  * @public
  */
-export interface SettingsProps {
-  /** List of settings to render in dropdown menu. For consistent style recommend using `PropertyGridSetting` component. */
-  settings?: Array<(props: SettingProps) => ReactNode>;
+export interface SettingsMenuProps {
+  /** List of settings to render in dropdown menu. For consistent style recommend using `PropertyGridSettingsMenuItem` component. */
+  settingsMenuItems?: Array<(props: SettingsMenuItemProps) => ReactNode>;
 }
 
 /**
- * Props for `PropertyGridSetting` component.
+ * Props for `PropertyGridSettingsMenuItem` component.
  * @public
  */
-export interface PropertyGridSettingProps {
+export interface PropertyGridSettingsMenuItemProps {
   /** Unique setting id. */
   id: string;
   /** Setting click event handler. */
@@ -49,7 +49,7 @@ export interface PropertyGridSettingProps {
  * Component for rendering single item in settings dropdown.
  * @public
  */
-export function PropertyGridSetting({ id, onClick, title, children }: PropsWithChildren<PropertyGridSettingProps>) {
+export function PropertyGridSettingsMenuItem({ id, onClick, title, children }: PropsWithChildren<PropertyGridSettingsMenuItemProps>) {
   return <MenuItem
     key={id}
     onClick={onClick}
@@ -60,10 +60,10 @@ export function PropertyGridSetting({ id, onClick, title, children }: PropsWithC
 }
 
 /**
- * Props for `ShowHideNullValuesSetting`.
+ * Props for `ShowHideNullValuesSettingsMenuItem`.
  * @public
  */
-export interface ShowHideNullValuesSettingProps extends SettingProps {
+export interface ShowHideNullValuesSettingsMenuItemProps extends SettingsMenuItemProps {
   /** Specifies whether setting value should be persisted on change. */
   persist?: boolean;
 }
@@ -72,14 +72,14 @@ export interface ShowHideNullValuesSettingProps extends SettingProps {
  * Renders `Show/Hide Empty Values` setting.
  * @public
  */
-export function ShowHideNullValuesSetting({ close, persist }: ShowHideNullValuesSettingProps) {
+export function ShowHideNullValuesSettingsMenuItem({ close, persist }: ShowHideNullValuesSettingsMenuItemProps) {
   const { showNullValues, setShowNullValues } = useNullValueSettingContext();
 
   const label = showNullValues ? PropertyGridManager.translate("settings.hide-null.label") : PropertyGridManager.translate("settings.show-null.label");
   const description = showNullValues ? PropertyGridManager.translate("settings.hide-null.description") : PropertyGridManager.translate("settings.show-null.description");
 
   return (
-    <PropertyGridSetting
+    <PropertyGridSettingsMenuItem
       id="show-hide-null-values"
       title={description}
       onClick={() => {
@@ -88,7 +88,7 @@ export function ShowHideNullValuesSetting({ close, persist }: ShowHideNullValues
       }}
     >
       {label}
-    </PropertyGridSetting>
+    </PropertyGridSettingsMenuItem>
   );
 }
 
@@ -96,7 +96,7 @@ export function ShowHideNullValuesSetting({ close, persist }: ShowHideNullValues
  * Props for `SettingsDropdownMenu`.
  * @internal
  */
-export interface SettingsDropdownMenuProps extends SettingsProps {
+export interface SettingsDropdownMenuProps extends SettingsMenuProps {
   dataProvider: IPresentationPropertyDataProvider;
 }
 
@@ -104,16 +104,12 @@ export interface SettingsDropdownMenuProps extends SettingsProps {
  * Component that renders dropdown menu with provided settings.
  * @internal
  */
-export function SettingsDropdownMenu({ settings, dataProvider }: SettingsDropdownMenuProps) {
-  if (!settings || settings.length === 0) {
+export function SettingsDropdownMenu({ settingsMenuItems, dataProvider }: SettingsDropdownMenuProps) {
+  if (!settingsMenuItems || settingsMenuItems.length === 0) {
     return null;
   }
 
-  return <SettingsDropdown settings={settings} dataProvider={dataProvider} />;
-}
-
-function SettingsDropdown({ settings, dataProvider }: SettingsDropdownMenuProps & {settings: Array<(props: SettingProps) => ReactNode>}) {
-  const menuItems = (close: () => void) => settings.map((setting, index) => <Fragment key={index}>{setting({ dataProvider, close })}</Fragment>);
+  const menuItems = (close: () => void) => settingsMenuItems.map((item, index) => <Fragment key={index}>{item({ dataProvider, close })}</Fragment>);
 
   return <DropdownMenu menuItems={menuItems}>
     <IconButton styleType="borderless" size="small" title={PropertyGridManager.translate("settings.label")}>

--- a/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
+++ b/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { assert } from "@itwin/core-bentley";
 import { ContextMenuItem as CoreContextMenuItem, GlobalContextMenu } from "@itwin/core-react";
 import { FavoritePropertiesScope, Presentation } from "@itwin/presentation-frontend";
@@ -170,16 +170,12 @@ export function useContextMenu({ dataProvider, imodel, contextMenuItems }: UseCo
     }
 
     const field = await dataProvider.getFieldByPropertyDescription(args.propertyRecord.property);
-    const items = contextMenuItems.map((item) => item({ imodel, dataProvider, record: args.propertyRecord, field })).filter((item) => !!item);
+    const items = contextMenuItems.map((item, index) => <Fragment key={index}>{item({ imodel, dataProvider, record: args.propertyRecord, field })}</Fragment>);
 
-    setContextMenu(
-      items.length > 0
-        ? {
-          position: { x: args.event.clientX, y: args.event.clientY },
-          menuItems: items,
-        }
-        : undefined
-    );
+    setContextMenu({
+      position: { x: args.event.clientX, y: args.event.clientY },
+      menuItems: items,
+    });
   };
 
   const renderContextMenu = () => {

--- a/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
+++ b/packages/itwin/property-grid/src/hooks/UseContextMenu.tsx
@@ -70,6 +70,7 @@ export function PropertyGridContextMenuItem({ id, children, title, onSelect }: P
 
 /**
  * Props for `Add/Remove` favorite properties context menu items.
+ * @public
  */
 export interface FavoritePropertiesContextMenuItemProps extends ContextMenuItemProps {
   /** Scope in which favorite property should be stored. Defaults to `FavoritePropertiesScope.IModel`. */
@@ -80,7 +81,7 @@ export interface FavoritePropertiesContextMenuItemProps extends ContextMenuItemP
  * Renders `Add to Favorite` context menu item if property field is not favorite. Otherwise renders nothing.
  * @public
  */
-export function AddFavoritePropertyMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps) {
+export function AddFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps) {
   const currentScope = scope ?? FavoritePropertiesScope.IModel;
   if (!field || Presentation.favoriteProperties.has(field, imodel, currentScope)) {
     return null;
@@ -104,7 +105,7 @@ export function AddFavoritePropertyMenuItem({ field, imodel, scope }: FavoritePr
  * Renders `Remove from Favorite` context menu item if property field is favorite. Otherwise renders nothing.
  * @public
  */
-export function RemoveFavoritePropertyMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps) {
+export function RemoveFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps) {
   const currentScope = scope ?? FavoritePropertiesScope.IModel;
   if (!field || !Presentation.favoriteProperties.has(field, imodel, currentScope)) {
     return null;
@@ -128,7 +129,7 @@ export function RemoveFavoritePropertyMenuItem({ field, imodel, scope }: Favorit
  * Renders `Copy Text` context menu item.
  * @public
  */
-export function CopyPropertyTextMenuItem({ record }: ContextMenuItemProps) {
+export function CopyPropertyTextContextMenuItem({ record }: ContextMenuItemProps) {
   return (
     <PropertyGridContextMenuItem
       id="copy-text"

--- a/packages/itwin/property-grid/src/hooks/UseNullValuesSetting.ts
+++ b/packages/itwin/property-grid/src/hooks/UseNullValuesSetting.ts
@@ -7,43 +7,41 @@ import { useCallback, useEffect, useState } from "react";
 import { usePreferencesContext } from "../PropertyGridPreferencesContext";
 
 /**
- * Props for `useNullValueSetting` hook.
+ * Definition of `null` values setting state.
  * @public
  */
-export interface NullValueSettingProps {
-  /** Specifies whether setting for showing/hiding null values in property grid should be persisted. */
-  persistNullValueToggle?: boolean;
+export interface NullValueSetting {
+  /** Specifies whether `null` values are shown. */
+  showNullValues: boolean;
+  /** Callback for changing `showNullValues` values. */
+  setShowNullValues: (value: boolean, options?: { persist?: boolean }) => Promise<void>;
 }
 
 /**
  * Custom hook for tracking of "show/hide null values" setting in property grid.
  * @internal
  */
-export function useNullValueSetting({ persistNullValueToggle }: NullValueSettingProps) {
+export function useNullValueSetting(): NullValueSetting {
   const [showNullValues, setShowNullValues] = useState(true);
   const { getShowNullValuesPreference, setShowNullValuesPreference } = useNullValueStorage();
 
-  // If persisting hide/show empty values, get the preference
+  // Get value from preferences storage
   useEffect(() => {
-    const setDefaultShowNullValues = async () => {
-      if (persistNullValueToggle) {
-        const res = await getShowNullValuesPreference();
-        setShowNullValues(res);
-      }
-    };
+    void (async () => {
+      const res = await getShowNullValuesPreference();
+      setShowNullValues(res);
+    })();
+  }, [getShowNullValuesPreference]);
 
-    void setDefaultShowNullValues();
-  }, [persistNullValueToggle, getShowNullValuesPreference]);
-
-  // Fcn for updating toggle for Hide / Show Empty Fields menu options
-  const updateShowNullValues = useCallback(async (value: boolean) => {
+  // Function for updating Hide / Show Empty Fields setting
+  const updateShowNullValues = useCallback(async (value: boolean, options?: { persist?: boolean }) => {
     setShowNullValues(value);
 
     // Persist hide/show value
-    if (persistNullValueToggle) {
+    if (options?.persist) {
       await setShowNullValuesPreference(value);
     }
-  }, [persistNullValueToggle, setShowNullValuesPreference]);
+  }, [setShowNullValuesPreference]);
 
   return {
     showNullValues,

--- a/packages/itwin/property-grid/src/hooks/UseNullValuesSetting.tsx
+++ b/packages/itwin/property-grid/src/hooks/UseNullValuesSetting.tsx
@@ -37,11 +37,11 @@ export function useNullValueSetting() {
   }, [getShowNullValuesPreference]);
 
   // Function for updating Hide / Show Empty Fields setting
-  const updateShowNullValues = useCallback(async (value: boolean, options: { persist?: boolean }) => {
+  const updateShowNullValues = useCallback(async (value: boolean, options?: { persist?: boolean }) => {
     setShowNullValues(value);
 
     // Persist hide/show value
-    if (options.persist) {
+    if (options && options.persist) {
       await setShowNullValuesPreference(value);
     }
   }, [setShowNullValuesPreference]);
@@ -80,7 +80,7 @@ function useNullValueStorage() {
 /** @internal */
 export interface NullValueSettingContextValue {
   showNullValues: boolean;
-  setShowNullValues: (value: boolean, options: { persist?: boolean }) => Promise<void>;
+  setShowNullValues: (value: boolean, options?: { persist?: boolean }) => Promise<void>;
 }
 
 // istanbul ignore next

--- a/packages/itwin/property-grid/src/property-grid-react.ts
+++ b/packages/itwin/property-grid/src/property-grid-react.ts
@@ -11,6 +11,7 @@ export * from "./components/PropertyGridContent";
 export * from "./components/PropertyGrid";
 export * from "./components/SingleElementPropertyGrid";
 export * from "./components/MultiElementPropertyGrid";
+export * from "./components/SettingsDropdownMenu";
 export * from "./hooks/UseContextMenu";
 export * from "./hooks/UseDataProvider";
 export * from "./hooks/UseInstanceSelection";

--- a/packages/itwin/property-grid/src/test/components/MultiElementPropertyGrid.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/MultiElementPropertyGrid.test.tsx
@@ -166,16 +166,17 @@ describe("<MultiElementPropertGrid />", () => {
     await waitFor(() => getByText("Test-Value-2"));
 
     // navigate back to element list
-    const propertyGridBackButton = container.querySelector<HTMLButtonElement>(".property-grid-react-panel-header #property-grid-react-element-list-back-btn");
-    expect(propertyGridBackButton).to.not.be.null;
-    await userEvents.click(propertyGridBackButton!);
+    const singleElementGrid = container.querySelector<HTMLButtonElement>(".property-grid-react-single-element-property-grid");
+    expect(singleElementGrid).to.not.be.null;
+    const singleElementBackButton = getByRoleRTL(singleElementGrid!, "button", { name: "header.back"  });
+    await userEvents.click(singleElementBackButton);
     await waitFor(() => getByText(expectedLabels[0]));
 
     // navigate back to multi instances properties grid
     const elementList = container.querySelector<HTMLDivElement>(".property-grid-react-element-list");
     expect(element).to.not.be.null;
-    const singleElementBackButton = getByRoleRTL(elementList!, "button", { name: "header.back"  });
-    await userEvents.click(singleElementBackButton);
+    const elementListBackButton = getByRoleRTL(elementList!, "button", { name: "header.back"  });
+    await userEvents.click(elementListBackButton);
     await waitFor(() => getByText("MultiInstances"));
   });
 

--- a/packages/itwin/property-grid/src/test/components/PropertyGridContent.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/PropertyGridContent.test.tsx
@@ -10,7 +10,7 @@ import { PropertyDataChangeEvent } from "@itwin/components-react";
 import { render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
 import { PropertyGridContent } from "../../components/PropertyGridContent";
-import { PropertyGridSetting, ShowHideNullValuesSetting } from "../../components/SettingsDropdownMenu";
+import { PropertyGridSettingsMenuItem, ShowHideNullValuesSettingsMenuItem } from "../../components/SettingsDropdownMenu";
 import { NullValueSettingContext } from "../../hooks/UseNullValuesSetting";
 import { PropertyGridManager } from "../../PropertyGridManager";
 import { createPropertyRecord, stubSelectionManager } from "../TestUtils";
@@ -96,8 +96,8 @@ describe("<PropertyGridContent />", () => {
       <PropertyGridContent
         dataProvider={provider}
         imodel={imodel}
-        settings={[
-          () => <PropertyGridSetting id="testSetting" onClick={spy}>Test Setting</PropertyGridSetting>,
+        settingsMenuItems={[
+          () => <PropertyGridSettingsMenuItem id="testSetting" onClick={spy}>Test Setting</PropertyGridSettingsMenuItem>,
         ]}
       />
     );
@@ -118,8 +118,8 @@ describe("<PropertyGridContent />", () => {
       <PropertyGridContent
         dataProvider={provider}
         imodel={imodel}
-        settings={[
-          (props) => <ShowHideNullValuesSetting {...props} />,
+        settingsMenuItems={[
+          (props) => <ShowHideNullValuesSettingsMenuItem {...props} />,
         ]}
       />
     );

--- a/packages/itwin/property-grid/src/test/components/SettingsDropdownMenu.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/SettingsDropdownMenu.test.tsx
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
-import { SettingsDropdownMenu, ShowHideNullValuesSetting } from "../../components/SettingsDropdownMenu";
+import { SettingsDropdownMenu, ShowHideNullValuesSettingsMenuItem } from "../../components/SettingsDropdownMenu";
 import { NullValueSettingContext, SHOWNULL_KEY } from "../../hooks/UseNullValuesSetting";
 import { PropertyGridManager } from "../../PropertyGridManager";
 import { PreferencesContextProvider } from "../../PropertyGridPreferencesContext";
@@ -36,7 +36,7 @@ describe("<SettingsDropdownMenu />", () => {
     const { getByRole, queryByText } = render(
       <SettingsDropdownMenu
         dataProvider={{} as IPresentationPropertyDataProvider}
-        settings={[
+        settingsMenuItems={[
           ({ close }) => <button
             onClick={() => {
               spy();
@@ -60,7 +60,7 @@ describe("<SettingsDropdownMenu />", () => {
     const { getByRole, getByText, queryByText } = render(
       <SettingsDropdownMenu
         dataProvider={{} as IPresentationPropertyDataProvider}
-        settings={[
+        settingsMenuItems={[
           ({ close }) => <button
             onClick={() => {
               spy();
@@ -125,12 +125,12 @@ describe("Default settings", () => {
     });
 
     it("renders", async () => {
-      const { queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps}/>);
+      const { queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps}/>);
       await waitFor(() => expect(queryByText("settings.hide-null.label")).to.not.be.null);
     });
 
     it("does not persist new value by default", async () => {
-      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps}/>);
+      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps}/>);
       const item = await waitFor(() => getByText("settings.hide-null.label"));
       await userEvents.click(item);
 
@@ -140,7 +140,7 @@ describe("Default settings", () => {
     });
 
     it("persist new value", async () => {
-      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps} persist={true} />);
+      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps} persist={true} />);
       const item = await waitFor(() => getByText("settings.hide-null.label"));
       await userEvents.click(item);
 
@@ -156,12 +156,12 @@ describe("Default settings", () => {
     });
 
     it("renders", async () => {
-      const { queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps}/>);
+      const { queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps}/>);
       await waitFor(() => expect(queryByText("settings.show-null.label")).to.not.be.null);
     });
 
     it("does not persist new value by default", async () => {
-      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps}/>);
+      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps}/>);
       const item = await waitFor(() => getByText("settings.show-null.label"));
       await userEvents.click(item);
 
@@ -171,7 +171,7 @@ describe("Default settings", () => {
     });
 
     it("persist new value", async () => {
-      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSetting {...settingProps} persist={true} />);
+      const { getByText, queryByText } = renderWithContext(<ShowHideNullValuesSettingsMenuItem {...settingProps} persist={true} />);
       const item = await waitFor(() => getByText("settings.show-null.label"));
       await userEvents.click(item);
 

--- a/packages/itwin/property-grid/src/test/components/SettingsDropdownMenu.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/SettingsDropdownMenu.test.tsx
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import sinon from "sinon";
+import { render, waitFor } from "@testing-library/react";
+import userEvents from "@testing-library/user-event";
+import { createShowNullValuesSettingProvider, PropertyGridManager, SettingsDropdownMenu } from "../../property-grid-react";
+
+import type { IPresentationPropertyDataProvider } from "@itwin/presentation-components";
+
+describe("<SettingsDropdownMenu />", () => {
+  before(() => {
+    sinon.stub(PropertyGridManager, "translate").callsFake((key) => key);
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
+  it("renders nothing if no settings provided", async () => {
+    const { container } = render(<SettingsDropdownMenu dataProvider={{} as IPresentationPropertyDataProvider} showNullValues={true} setShowNullValues={async () => {}} />);
+    expect(container.children).to.have.lengthOf(0);
+  });
+
+  it("renders provided settings", async () => {
+    const spy = sinon.spy();
+    const { getByRole, getByText } = render(
+      <SettingsDropdownMenu
+        dataProvider={{} as IPresentationPropertyDataProvider}
+        showNullValues={true}
+        setShowNullValues={async () => {}}
+        settingProviders={[
+          () => [{ id: "test-setting", label: "Test Setting", action: spy }],
+        ]}
+      />
+    );
+
+    const dropdownButton = getByRole("button", { name: "settings.label" });
+    await userEvents.click(dropdownButton);
+
+    const setting = await waitFor(() => getByText("Test Setting"));
+    await userEvents.click(setting);
+
+    await waitFor(() => expect(spy).to.be.calledOnce);
+  });
+
+  describe("'hide null value' setting", () => {
+    [true, false].map((persist) => {
+      it(`calls 'setShowNullValues' with 'options.persist: ${persist}'`, async () => {
+        const spy = sinon.spy();
+        const { getByRole, getByText } = render(
+          <SettingsDropdownMenu
+            dataProvider={{} as IPresentationPropertyDataProvider}
+            showNullValues={true}
+            setShowNullValues={spy}
+            settingProviders={[
+              createShowNullValuesSettingProvider(persist),
+            ]}
+          />
+        );
+
+        const dropdownButton = getByRole("button", { name: "settings.label" });
+        await userEvents.click(dropdownButton);
+
+        const setting = await waitFor(() => getByText("settings.hide-null.label"));
+        await userEvents.click(setting);
+
+        await waitFor(() => expect(spy).to.be.calledOnceWith(false, sinon.match((options) => options.persist === persist)));
+      });
+    });
+  });
+
+  describe("'show null value' setting", () => {
+    [true, false].map((persist) => {
+      it(`calls 'setShowNullValues' with 'options.persist: ${persist}'`, async () => {
+        const spy = sinon.spy();
+        const { getByRole, getByText } = render(
+          <SettingsDropdownMenu
+            dataProvider={{} as IPresentationPropertyDataProvider}
+            showNullValues={false}
+            setShowNullValues={spy}
+            settingProviders={[
+              createShowNullValuesSettingProvider(persist),
+            ]}
+          />
+        );
+
+        const dropdownButton = getByRole("button", { name: "settings.label" });
+        await userEvents.click(dropdownButton);
+
+        const setting = await waitFor(() => getByText("settings.show-null.label"));
+        await userEvents.click(setting);
+
+        await waitFor(() => expect(spy).to.be.calledOnceWith(true, sinon.match((options) => options.persist === persist)));
+      });
+    });
+  });
+});

--- a/packages/itwin/property-grid/src/test/hooks/UseContextMenu.test.tsx
+++ b/packages/itwin/property-grid/src/test/hooks/UseContextMenu.test.tsx
@@ -12,7 +12,9 @@ import { render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
 import * as webUtilities from "../../api/WebUtilities";
 import {
-  AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridContextMenuItem, RemoveFavoritePropertyMenuItem, useContextMenu,
+  AddFavoritePropertyContextMenuItem,
+  CopyPropertyTextContextMenuItem,
+  PropertyGridContextMenuItem, RemoveFavoritePropertyContextMenuItem, useContextMenu,
 } from "../../hooks/UseContextMenu";
 import { PropertyGridManager } from "../../PropertyGridManager";
 import { createFunctionStub, createPropertyRecord, stubFavoriteProperties } from "../TestUtils";
@@ -58,21 +60,6 @@ describe("useContextMenu", () => {
       <TestComponent
         imodel={imodel}
         dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-      />
-    );
-
-    const openButton = await waitFor(() => getByText("Open Menu"));
-    await userEvents.click(openButton);
-
-    expect(queryByRole("menu")).to.be.null;
-  });
-
-  it("doesn't open context menu if there are no items with content", async () => {
-    const { getByText, queryByRole } = render(
-      <TestComponent
-        imodel={imodel}
-        dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-        contextMenuItems={[() => null]}
       />
     );
 
@@ -184,22 +171,22 @@ describe("Default context menu items", () => {
     favoritesManager.has.reset();
   });
 
-  describe("AddFavoritePropertyMenuItem", () => {
+  describe("AddFavoritePropertyContextMenuItem", () => {
     it("renders item with non-favorite property", () => {
       favoritesManager.has.returns(false);
-      const { queryByText } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      const { queryByText } = render(<AddFavoritePropertyContextMenuItem {...itemProps}/>);
       expect(queryByText("context-menu.add-favorite.label"));
     });
 
     it("renders nothing if property is favorite", () => {
       favoritesManager.has.returns(true);
-      const { container } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      const { container } = render(<AddFavoritePropertyContextMenuItem {...itemProps}/>);
       expect(container.children).to.have.lengthOf(0);
     });
 
     it("calls 'Presentation.favorites.add' with default scope", async () => {
       favoritesManager.has.returns(false);
-      const { getByText } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      const { getByText } = render(<AddFavoritePropertyContextMenuItem {...itemProps}/>);
       const item = getByText("context-menu.add-favorite.label");
       await userEvents.click(item);
 
@@ -208,7 +195,7 @@ describe("Default context menu items", () => {
 
     it("calls 'Presentation.favorites.add' with specified scope", async () => {
       favoritesManager.has.returns(false);
-      const { getByText } = render(<AddFavoritePropertyMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
+      const { getByText } = render(<AddFavoritePropertyContextMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
       const item = getByText("context-menu.add-favorite.label");
       await userEvents.click(item);
 
@@ -216,22 +203,22 @@ describe("Default context menu items", () => {
     });
   });
 
-  describe("RemoveFavoritePropertyMenuItem", () => {
+  describe("RemoveFavoritePropertyContextMenuItem", () => {
     it("renders item with favorite property", () => {
       favoritesManager.has.returns(true);
-      const { queryByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      const { queryByText } = render(<RemoveFavoritePropertyContextMenuItem {...itemProps}/>);
       expect(queryByText("context-menu.remove-favorite.label"));
     });
 
     it("renders nothing if property is not favorite", () => {
       favoritesManager.has.returns(false);
-      const { container } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      const { container } = render(<RemoveFavoritePropertyContextMenuItem {...itemProps}/>);
       expect(container.children).to.have.lengthOf(0);
     });
 
     it("calls 'Presentation.favorites.remove' with default scope", async () => {
       favoritesManager.has.returns(true);
-      const { getByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      const { getByText } = render(<RemoveFavoritePropertyContextMenuItem {...itemProps}/>);
       const item = getByText("context-menu.remove-favorite.label");
       await userEvents.click(item);
 
@@ -240,7 +227,7 @@ describe("Default context menu items", () => {
 
     it("calls 'Presentation.favorites.remove' with specified scope", async () => {
       favoritesManager.has.returns(true);
-      const { getByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
+      const { getByText } = render(<RemoveFavoritePropertyContextMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
       const item = getByText("context-menu.remove-favorite.label");
       await userEvents.click(item);
 
@@ -248,15 +235,15 @@ describe("Default context menu items", () => {
     });
   });
 
-  describe("CopyPropertyTextMenuItem", () => {
+  describe("CopyPropertyTextContextMenuItem", () => {
     it("renders item", () => {
-      const { queryByText } = render(<CopyPropertyTextMenuItem {...itemProps} />);
+      const { queryByText } = render(<CopyPropertyTextContextMenuItem {...itemProps} />);
       expect(queryByText("context-menu.copy-text.label"));
     });
 
     it("copies text when clicked", async () => {
       const copyStub = sinon.stub(webUtilities, "copyToClipboard");
-      const { getByText } = render(<CopyPropertyTextMenuItem {...itemProps} />);
+      const { getByText } = render(<CopyPropertyTextContextMenuItem {...itemProps} />);
       const item = getByText("context-menu.copy-text.label");
 
       await userEvents.click(item);

--- a/packages/itwin/property-grid/src/test/hooks/UseContextMenu.test.tsx
+++ b/packages/itwin/property-grid/src/test/hooks/UseContextMenu.test.tsx
@@ -12,7 +12,7 @@ import { render, waitFor } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
 import * as webUtilities from "../../api/WebUtilities";
 import {
-  createAddFavoritePropertyItemProvider, createCopyPropertyTextItemProvider, createRemoveFavoritePropertyItemProvider, useContextMenu,
+  AddFavoritePropertyMenuItem, CopyPropertyTextMenuItem, PropertyGridContextMenuItem, RemoveFavoritePropertyMenuItem, useContextMenu,
 } from "../../hooks/UseContextMenu";
 import { PropertyGridManager } from "../../PropertyGridManager";
 import { createFunctionStub, createPropertyRecord, stubFavoriteProperties } from "../TestUtils";
@@ -20,7 +20,7 @@ import { createFunctionStub, createPropertyRecord, stubFavoriteProperties } from
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { IPresentationPropertyDataProvider, PresentationPropertyDataProvider } from "@itwin/presentation-components";
 import type { MouseEvent } from "react";
-import type { ContextMenuItemDefinition, UseContentMenuProps } from "../../hooks/UseContextMenu";
+import type { ContextMenuItemProps, UseContentMenuProps } from "../../hooks/UseContextMenu";
 
 describe("useContextMenu", () => {
   const imodel = {} as IModelConnection;
@@ -39,17 +39,11 @@ describe("useContextMenu", () => {
   }
 
   it("opens context menu", async () => {
-    const contextMenuItem: ContextMenuItemDefinition = {
-      key: "test-item",
-      label: "Test Item",
-      execute: async () => {},
-    };
-
     const { getByText } = render(
       <TestComponent
         imodel={imodel}
         dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-        contextMenuItemProviders={[() => contextMenuItem]}
+        contextMenuItems={[() => <div>Test Item</div>]}
       />
     );
 
@@ -73,19 +67,28 @@ describe("useContextMenu", () => {
     expect(queryByRole("menu")).to.be.null;
   });
 
-  it("closes context menu when item is clicked", async () => {
-    const executeStub = sinon.stub();
-    const contextMenuItem: ContextMenuItemDefinition = {
-      key: "test-item",
-      label: "Test Item",
-      execute: executeStub,
-    };
+  it("doesn't open context menu if there are no items with content", async () => {
+    const { getByText, queryByRole } = render(
+      <TestComponent
+        imodel={imodel}
+        dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
+        contextMenuItems={[() => null]}
+      />
+    );
 
+    const openButton = await waitFor(() => getByText("Open Menu"));
+    await userEvents.click(openButton);
+
+    expect(queryByRole("menu")).to.be.null;
+  });
+
+  it("closes context menu when item is clicked", async () => {
+    const selectStub = sinon.stub();
     const { getByText, queryByText } = render(
       <TestComponent
         imodel={imodel}
         dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-        contextMenuItemProviders={[() => contextMenuItem]}
+        contextMenuItems={[() => <PropertyGridContextMenuItem id="test-item" onSelect={selectStub}>Test Item</PropertyGridContextMenuItem>]}
       />
     );
 
@@ -101,21 +104,15 @@ describe("useContextMenu", () => {
 
     // wait for item to disappear
     await waitFor(() => expect(queryByText("Test Item")).to.be.null);
-    expect(executeStub).to.be.calledOnce;
+    expect(selectStub).to.be.calledOnce;
   });
 
   it("closes context menu when `Esc` is clicked", async () => {
-    const contextMenuItem: ContextMenuItemDefinition = {
-      key: "test-item",
-      label: "Test Item",
-      execute: async () => {},
-    };
-
     const { getByText, queryByText } = render(
       <TestComponent
         imodel={imodel}
         dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-        contextMenuItemProviders={[() => contextMenuItem]}
+        contextMenuItems={[() => <div>Test Item</div>]}
       />
     );
 
@@ -134,17 +131,11 @@ describe("useContextMenu", () => {
   });
 
   it("closes context menu when outside element is clicked", async () => {
-    const contextMenuItem: ContextMenuItemDefinition = {
-      key: "test-item",
-      label: "Test Item",
-      execute: async () => {},
-    };
-
     const { getByText, queryByText } = render(
       <TestComponent
         imodel={imodel}
         dataProvider={dataProvider as unknown as IPresentationPropertyDataProvider}
-        contextMenuItemProviders={[() => contextMenuItem]}
+        contextMenuItems={[() => <div>Test Item</div>]}
       />
     );
 
@@ -164,13 +155,19 @@ describe("useContextMenu", () => {
   });
 });
 
-describe("Default context menu item providers", () => {
+describe("Default context menu items", () => {
   const imodel = {} as IModelConnection;
   const dataProvider = {} as IPresentationPropertyDataProvider;
   const record = createRecord();
   const field: Field = createField();
 
   let favoritesManager: ReturnType<typeof stubFavoriteProperties>;
+  const itemProps: ContextMenuItemProps = {
+    imodel,
+    dataProvider,
+    record,
+    field,
+  };
 
   before(() => {
     sinon.stub(PropertyGridManager, "translate").callsFake((key) => key);
@@ -187,76 +184,87 @@ describe("Default context menu item providers", () => {
     favoritesManager.has.reset();
   });
 
-  [undefined, FavoritePropertiesScope.ITwin].map((scope) => {
-    describe("createAddFavoritePropertyItemProvider", () => {
-      it(`creates definiton for non-favorite property with ${getScopeName(scope)} scope`, async () => {
-        favoritesManager.has.returns(false);
-
-        const item = createAddFavoritePropertyItemProvider(scope)({ field, imodel, dataProvider, record });
-        expect(item.hidden).to.be.false;
-        expect(item.label).to.be.eq("context-menu.add-favorite.label");
-        expect(item.title).to.be.eq("context-menu.add-favorite.description");
-
-        await item.execute();
-        expect(favoritesManager.add).to.be.calledOnceWith(field, imodel, scope ?? FavoritePropertiesScope.IModel);
-      });
-
-      it(`creates definiton for favorite property with ${getScopeName(scope)} scope`, async () => {
-        favoritesManager.has.returns(true);
-
-        const item = createAddFavoritePropertyItemProvider(scope)({ field, imodel, dataProvider, record });
-        expect(item.hidden).to.be.true;
-        expect(item.label).to.be.eq("context-menu.add-favorite.label");
-        expect(item.title).to.be.eq("context-menu.add-favorite.description");
-      });
+  describe("AddFavoritePropertyMenuItem", () => {
+    it("renders item with non-favorite property", () => {
+      favoritesManager.has.returns(false);
+      const { queryByText } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      expect(queryByText("context-menu.add-favorite.label"));
     });
 
-    describe("createRemoveFavoritePropertyItemProvider", () => {
-      it(`creates definiton for non-favorite property with ${getScopeName(scope)} scope`, async () => {
-        favoritesManager.has.returns(false);
+    it("renders nothing if property is favorite", () => {
+      favoritesManager.has.returns(true);
+      const { container } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      expect(container.children).to.have.lengthOf(0);
+    });
 
-        const item = createRemoveFavoritePropertyItemProvider(scope)({ field, imodel, dataProvider, record });
-        expect(item.hidden).to.be.true;
-        expect(item.label).to.be.eq("context-menu.remove-favorite.label");
-        expect(item.title).to.be.eq("context-menu.remove-favorite.description");
-      });
+    it("calls 'Presentation.favorites.add' with default scope", async () => {
+      favoritesManager.has.returns(false);
+      const { getByText } = render(<AddFavoritePropertyMenuItem {...itemProps}/>);
+      const item = getByText("context-menu.add-favorite.label");
+      await userEvents.click(item);
 
-      it(`creates definiton for favorite property with ${getScopeName(scope)} scope`, async () => {
-        favoritesManager.has.returns(true);
+      await waitFor(() => expect(favoritesManager.add).to.be.calledOnceWith(field, imodel,  FavoritePropertiesScope.IModel));
+    });
 
-        const item = createRemoveFavoritePropertyItemProvider(scope)({ field, imodel, dataProvider, record });
-        expect(item.hidden).to.be.false;
-        expect(item.label).to.be.eq("context-menu.remove-favorite.label");
-        expect(item.title).to.be.eq("context-menu.remove-favorite.description");
+    it("calls 'Presentation.favorites.add' with specified scope", async () => {
+      favoritesManager.has.returns(false);
+      const { getByText } = render(<AddFavoritePropertyMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
+      const item = getByText("context-menu.add-favorite.label");
+      await userEvents.click(item);
 
-        await item.execute();
-        expect(favoritesManager.remove).to.be.calledOnceWith(field, imodel, scope ?? FavoritePropertiesScope.IModel);
-      });
+      await waitFor(() => expect(favoritesManager.add).to.be.calledOnceWith(field, imodel,  FavoritePropertiesScope.ITwin));
     });
   });
 
-  describe("createCopyPropertyTextItemProvider", () => {
-    it(`creates definiton`, async () => {
+  describe("RemoveFavoritePropertyMenuItem", () => {
+    it("renders item with favorite property", () => {
+      favoritesManager.has.returns(true);
+      const { queryByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      expect(queryByText("context-menu.remove-favorite.label"));
+    });
+
+    it("renders nothing if property is not favorite", () => {
+      favoritesManager.has.returns(false);
+      const { container } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      expect(container.children).to.have.lengthOf(0);
+    });
+
+    it("calls 'Presentation.favorites.remove' with default scope", async () => {
+      favoritesManager.has.returns(true);
+      const { getByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps}/>);
+      const item = getByText("context-menu.remove-favorite.label");
+      await userEvents.click(item);
+
+      await waitFor(() => expect(favoritesManager.remove).to.be.calledOnceWith(field, imodel,  FavoritePropertiesScope.IModel));
+    });
+
+    it("calls 'Presentation.favorites.remove' with specified scope", async () => {
+      favoritesManager.has.returns(true);
+      const { getByText } = render(<RemoveFavoritePropertyMenuItem {...itemProps} scope={FavoritePropertiesScope.ITwin}/>);
+      const item = getByText("context-menu.remove-favorite.label");
+      await userEvents.click(item);
+
+      await waitFor(() => expect(favoritesManager.remove).to.be.calledOnceWith(field, imodel,  FavoritePropertiesScope.ITwin));
+    });
+  });
+
+  describe("CopyPropertyTextMenuItem", () => {
+    it("renders item", () => {
+      const { queryByText } = render(<CopyPropertyTextMenuItem {...itemProps} />);
+      expect(queryByText("context-menu.copy-text.label"));
+    });
+
+    it("copies text when clicked", async () => {
       const copyStub = sinon.stub(webUtilities, "copyToClipboard");
+      const { getByText } = render(<CopyPropertyTextMenuItem {...itemProps} />);
+      const item = getByText("context-menu.copy-text.label");
 
-      const item = createCopyPropertyTextItemProvider()({ field, imodel, dataProvider, record });
-      expect(item.hidden).to.be.undefined;
-      expect(item.label).to.be.eq("context-menu.copy-text.label");
-      expect(item.title).to.be.eq("context-menu.copy-text.description");
-
-      await item.execute();
+      await userEvents.click(item);
 
       expect(copyStub).to.be.calledOnceWithExactly(record.description);
     });
   });
 });
-
-function getScopeName(scope: undefined | FavoritePropertiesScope) {
-  if (scope === undefined) {
-    return "default";
-  }
-  return "custom";
-}
 
 function createField() {
   return new Field(

--- a/packages/itwin/property-grid/src/test/hooks/UseNullValuesSetting.test.tsx
+++ b/packages/itwin/property-grid/src/test/hooks/UseNullValuesSetting.test.tsx
@@ -11,7 +11,6 @@ import { PreferencesContextProvider } from "../../PropertyGridPreferencesContext
 import { createFunctionStub } from "../TestUtils";
 
 import type { PreferencesContextProviderProps } from "../../PropertyGridPreferencesContext";
-import type { NullValueSettingProps } from "../../hooks/UseNullValuesSetting";
 import type { PreferencesStorage } from "../../property-grid-react";
 
 function renderWithContext(element: JSX.Element, contextProps: Partial<PreferencesContextProviderProps>) {
@@ -20,11 +19,11 @@ function renderWithContext(element: JSX.Element, contextProps: Partial<Preferenc
   </PreferencesContextProvider>);
 }
 
-function TestComponent(useNullValueSettingProps: NullValueSettingProps) {
-  const { showNullValues, setShowNullValues } = useNullValueSetting(useNullValueSettingProps);
+function TestComponent({ persistOnClick }: { persistOnClick?: boolean }) {
+  const { showNullValues, setShowNullValues } = useNullValueSetting();
 
   const toggleShowNullValues = async () => {
-    await setShowNullValues(!showNullValues);
+    await setShowNullValues(!showNullValues, { persist: persistOnClick });
   };
 
   return <button onClick={toggleShowNullValues}>
@@ -69,7 +68,7 @@ describe("useNullValuesSetting", () => {
       storage.get.resolves(JSON.stringify(false));
 
       const { getByRole } = renderWithContext(
-        <TestComponent persistNullValueToggle={true} />,
+        <TestComponent />,
         { storage }
       );
 
@@ -80,7 +79,7 @@ describe("useNullValuesSetting", () => {
       storage.get.resolves(undefined);
 
       const { getByRole } = renderWithContext(
-        <TestComponent persistNullValueToggle={true} />,
+        <TestComponent />,
         { storage }
       );
 
@@ -91,7 +90,7 @@ describe("useNullValuesSetting", () => {
       storage.get.resolves(JSON.stringify(false));
 
       const { getByRole } = renderWithContext(
-        <TestComponent persistNullValueToggle={true} />,
+        <TestComponent persistOnClick={true} />,
         { storage }
       );
 

--- a/packages/itwin/property-grid/src/test/setup.ts
+++ b/packages/itwin/property-grid/src/test/setup.ts
@@ -33,3 +33,31 @@ global.DOMRect = class DOMRect {
     return JSON.stringify(this);
   }
 };
+
+const raf = global.requestAnimationFrame;
+const caf = global.cancelAnimationFrame;
+before(() => {
+  Object.defineProperty(global, "requestAnimationFrame", {
+    writable: true,
+    value: (cb: FrameRequestCallback) => {
+      return setTimeout(cb, 0);
+    },
+  });
+  Object.defineProperty(global, "cancelAnimationFrame", {
+    writable: true,
+    value: (handle: number) => {
+      clearTimeout(handle);
+    },
+  });
+});
+
+after(() => {
+  Object.defineProperty(global, "requestAnimationFrame", {
+    writable: true,
+    value: raf,
+  });
+  Object.defineProperty(global, "cancelAnimationFrame", {
+    writable: true,
+    value: caf,
+  });
+});

--- a/packages/itwin/property-grid/tsconfig.json
+++ b/packages/itwin/property-grid/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "noImplicitOverride": false,
     "resolveJsonModule": true,
-    "lib": ["DOM"]
+    "lib": ["DOM", "ES2019"]
   },
   "include": ["src"],
 }


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/499

* Added settings dropdown to header.
* Moved `Show/Hide Empty Values` setting from context menu to settings dropdown.
* Unified PropertyGrid and ElementList headers.
* Cleaned up styles.

Settings dropdown:
![image](https://github.com/iTwin/viewer-components-react/assets/24278440/5a1f9938-5978-48a2-bb90-639bbc29db62)
