### PR TITLE
Property grid: Fix empty values filterer

### DIFF
--- a/common/changes/@itwin/property-grid-react/property_grid_fix_empty_values_filterer_2023-06-12-14-55.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_fix_empty_values_filterer_2023-06-12-14-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Fixed property grid not hiding empty struct and array properties.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -3,7 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import "./PropertyGrid.scss";
 import { useCallback } from "react";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
 import {
@@ -83,23 +82,16 @@ export class NonEmptyValuesPropertyDataFilterer extends PropertyRecordDataFilter
   public async recordMatchesFilter(
     node: PropertyRecord
   ): Promise<PropertyDataFilterResult> {
-    switch(node.value.valueFormat) {
-      case PropertyValueFormat.Primitive:
-        return {
-          filteredTypes: [FilteredType.Value],
-          matchesFilter: !!node.value.displayValue,
-        };
-      case PropertyValueFormat.Array:
-        return {
-          filteredTypes: [FilteredType.Value],
-          matchesFilter: node.value.items.length > 0,
-        };
-      case PropertyValueFormat.Struct:
-        return {
-          filteredTypes: [FilteredType.Value],
-          matchesFilter: Object.keys(node.value.members).length > 0,
-        };
+    if (node.value.valueFormat !== PropertyValueFormat.Primitive) {
+      return {
+        matchesFilter: false,
+      };
     }
+
+    return {
+      filteredTypes: [FilteredType.Value],
+      matchesFilter: !!node.value.displayValue,
+    };
   }
 }
 

--- a/packages/itwin/property-grid/src/test/components/FilteringPropertyGrid.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/FilteringPropertyGrid.test.tsx
@@ -128,15 +128,15 @@ describe("<FilteringPropertyGrid />", () => {
                     valueFormat: PropertyValueFormat.Array,
                     itemsTypeName: "string",
                     items: [
-                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1" }, { name: "item-prop-1", displayLabel: "Item Prop 1" }),
-                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2" }, { name: "item-prop-2", displayLabel: "Item Prop 2" }),
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1", displayValue: "Item 1" }, { name: "item-prop-1", displayLabel: "Non-Empty Item 1" }),
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2", displayValue: "Item 2" }, { name: "item-prop-2", displayLabel: "Non-Empty Item 2" }),
                     ],
                   },
-                  { name: "test-prop1", displayLabel: "Non-null Prop" }
+                  { name: "test-prop1", displayLabel: "Non-Empty Array Prop" }
                 ),
                 createPropertyRecord(
                   { valueFormat: PropertyValueFormat.Array, itemsTypeName: "string", items: [] },
-                  { name: "test-prop2", displayLabel: "Empty Prop" }
+                  { name: "test-prop2", displayLabel: "Empty Array Prop" }
                 ),
               ],
             },
@@ -153,8 +153,63 @@ describe("<FilteringPropertyGrid />", () => {
         />
       );
 
-      await waitFor(() => getByText("Non-null Prop"));
-      expect(queryByText("Empty Prop")).to.be.null;
+      await waitFor(() => getByText(/^Non-Empty Array Prop/));
+      expect(queryByText(/^Empty Array Prop/)).to.be.null;
+    });
+
+    it("filters out array properties with empty items", async () => {
+      const filterer = new NonEmptyValuesPropertyDataFilterer();
+      const dataProvider = {
+        onDataChanged: new PropertyDataChangeEvent(),
+        getData: async () => {
+          return {
+            categories: [{
+              expand: true,
+              label: "Test Category",
+              name: "test-category",
+            }],
+            label: PropertyRecord.fromString("Test Instance"),
+            records: {
+              ["test-category"]: [
+                createPropertyRecord(
+                  {
+                    valueFormat: PropertyValueFormat.Array,
+                    itemsTypeName: "string",
+                    items: [
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1", displayValue: "Item 1" }, { name: "item-prop-1", displayLabel: "Non-Empty Item 1" }),
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2", displayValue: "Item 2" }, { name: "item-prop-2", displayLabel: "Non-Empty Item 2" }),
+                    ],
+                  },
+                  { name: "test-prop1", displayLabel: "Non-Empty Array Prop" }
+                ),
+                createPropertyRecord(
+                  {
+                    valueFormat: PropertyValueFormat.Array,
+                    itemsTypeName: "string",
+                    items: [
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive }, { name: "item-prop-1", displayLabel: "Empty Item 1" }),
+                      createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive }, { name: "item-prop-2", displayLabel: "Empty Item 2" }),
+                    ],
+                  },
+                  { name: "test-prop2", displayLabel: "Empty Array Prop" }
+                ),
+              ],
+            },
+          };
+        },
+      } as IPropertyDataProvider;
+
+      const { getByText, queryByText } = render(
+        <FilteringPropertyGrid
+          height={100}
+          width={100}
+          filterer={filterer}
+          dataProvider={dataProvider}
+        />
+      );
+
+      await waitFor(() => getByText(/^Non-Empty Array Prop/));
+      expect(queryByText(/^Empty Array Prop/)).to.be.null;
     });
 
     it("filters out empty struct properties", async () => {
@@ -175,15 +230,15 @@ describe("<FilteringPropertyGrid />", () => {
                   {
                     valueFormat: PropertyValueFormat.Struct,
                     members: {
-                      member1: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1" }, { name: "item-prop-1", displayLabel: "Item Prop 1" }),
-                      member2: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2" }, { name: "item-prop-2", displayLabel: "Item Prop 2" }),
+                      member1: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1", displayValue: "Item 1" }, { name: "item-prop-1", displayLabel: "Member Prop 1" }),
+                      member2: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2", displayValue: "Item 2" }, { name: "item-prop-2", displayLabel: "Member Prop 2" }),
                     },
                   },
-                  { name: "test-prop1", displayLabel: "Non-null Prop" }
+                  { name: "test-prop1", displayLabel: "Non-Empty Struct Prop" }
                 ),
                 createPropertyRecord(
                   { valueFormat: PropertyValueFormat.Struct, members: {} },
-                  { name: "test-prop2", displayLabel: "Empty Prop" }
+                  { name: "test-prop2", displayLabel: "Empty Struct Prop" }
                 ),
               ],
             },
@@ -200,8 +255,61 @@ describe("<FilteringPropertyGrid />", () => {
         />
       );
 
-      await waitFor(() => getByText("Non-null Prop"));
-      expect(queryByText("Empty Prop")).to.be.null;
+      await waitFor(() => getByText("Non-Empty Struct Prop"));
+      expect(queryByText("Empty Struct Prop")).to.be.null;
+    });
+
+    it("filters out struct properties with empty members", async () => {
+      const filterer = new NonEmptyValuesPropertyDataFilterer();
+      const dataProvider = {
+        onDataChanged: new PropertyDataChangeEvent(),
+        getData: async () => {
+          return {
+            categories: [{
+              expand: true,
+              label: "Test Category",
+              name: "test-category",
+            }],
+            label: PropertyRecord.fromString("Test Instance"),
+            records: {
+              ["test-category"]: [
+                createPropertyRecord(
+                  {
+                    valueFormat: PropertyValueFormat.Struct,
+                    members: {
+                      member1: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 1", displayValue: "Item 1" }, { name: "item-prop-1", displayLabel: "Member Prop 1" }),
+                      member2: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive, value: "Item 2", displayValue: "Item 2" }, { name: "item-prop-2", displayLabel: "Member Prop 2" }),
+                    },
+                  },
+                  { name: "test-prop1", displayLabel: "Non-Empty Struct Prop" }
+                ),
+                createPropertyRecord(
+                  {
+                    valueFormat: PropertyValueFormat.Struct,
+                    members: {
+                      emptyMember1: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive }, { name: "empty-prop-1", displayLabel: "Empty Member 1" }),
+                      emptyMember2: createPropertyRecord({ valueFormat: PropertyValueFormat.Primitive }, { name: "empty-prop-2", displayLabel: "Empty Member 2" }),
+                    },
+                  },
+                  { name: "test-prop2", displayLabel: "Empty Struct Prop" }
+                ),
+              ],
+            },
+          };
+        },
+      } as IPropertyDataProvider;
+
+      const { getByText, queryByText } = render(
+        <FilteringPropertyGrid
+          height={100}
+          width={100}
+          filterer={filterer}
+          dataProvider={dataProvider}
+        />
+      );
+
+      await waitFor(() => getByText("Non-Empty Struct Prop"));
+      expect(queryByText("Empty Struct Prop")).to.be.null;
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/529

Fixed empty values filterer to correctly filter out struct properties with empty members and array properties with empty items.