### PR TITLE
Property Widget: Improve keyboard navigation

### DIFF
--- a/common/changes/@itwin/property-grid-react/property_grid_keyboard_navigation_2023-06-14-12-05.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_keyboard_navigation_2023-06-14-12-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Improved keyboard navigation when navigating from Property Grid to Element List.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { StagePanelLocation, StagePanelSection, StageUsage, WidgetState } from "@itwin/appui-react";
+import { SvgInfoCircular } from "@itwin/itwinui-icons-react";
 import { PropertyGridComponent, PropertyGridComponentId } from "./PropertyGridComponent";
 import { PropertyGridManager } from "./PropertyGridManager";
 
@@ -48,7 +49,7 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
       label: PropertyGridManager.translate("widget-label"),
       content: <PropertyGridComponent {...propertyGridProps} />,
       defaultState: WidgetState.Hidden,
-      icon: "icon-info",
+      icon: <SvgInfoCircular />,
       priority: defaultPanelWidgetPriority,
     }];
   }

--- a/packages/itwin/property-grid/src/components/Header.tsx
+++ b/packages/itwin/property-grid/src/components/Header.tsx
@@ -25,7 +25,6 @@ export function Header({ className, children, onBackButtonClick }: PropsWithChil
         ? <IconButton
           styleType="borderless"
           onClick={onBackButtonClick}
-          onKeyDown={onBackButtonClick}
           title={PropertyGridManager.translate("header.back")}
           className="property-grid-react-header-back-button"
         >

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.scss
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.scss
@@ -17,7 +17,7 @@
     overflow: hidden;
 
     .property-grid-react-animated-tab {
-      transition: transform 400ms ease-out;
+      transition: all 400ms ease-out;
       position: absolute;
       top: 0;
       left: 0;
@@ -27,10 +27,12 @@
 
     .property-grid-react-animated-tab-animate-right {
       transform: translate(100%, 0);
+      visibility: hidden;
     }
 
     .property-grid-react-animated-tab-animate-left {
       transform: translate(-100%, 0);
+      visibility: hidden;
     }
   }
 }

--- a/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/MultiElementPropertyGrid.tsx
@@ -191,7 +191,6 @@ function HeaderControls({
     size="small"
     styleType="borderless"
     onClick={onElementListButtonClick}
-    onKeyDown={onElementListButtonClick}
     title={PropertyGridManager.translate("element-list.title")}
   >
     <SvgPropertiesList />


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/537

Removed `onKeyDown` handlers from buttons as those were fired when navigating through buttons with TAB.
Made Element List and Property Grid hidden when they are pushed to side. Previously they were always visible but pushed outside of container's visible part. This caused some issues when pressing button to show Element List because focused element was still in Property Grid.