### PR TITLE
[G&M] Fixed Enable Extraction Button

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/master_2023-07-11-17-59.json
+++ b/common/changes/@itwin/grouping-mapping-widget/master_2023-07-11-17-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Fixed Enable/Disable Extraction bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/Mapping.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/Mapping.tsx
@@ -79,7 +79,7 @@ const toggleExtraction = async (
   mapping: Mapping
 ) => {
   try {
-    const newState = mapping.extractionEnabled;
+    const newState = !mapping.extractionEnabled;
     const accessToken = await getAccessToken();
     await mappingsClient.updateMapping(accessToken, iModelId, mapping.id, {
       extractionEnabled: newState,


### PR DESCRIPTION
Fixed the bug of Enable/Disable Extraction Button. Now, when you click on 3 dots next to the mapping name and click on Enable/Disable Extraction, it works as intended.