### PR TITLE
[G&M] Added a dropdown arrow to the Add Group button.

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/add-arrow_2023-07-12-16-13.json
+++ b/common/changes/@itwin/grouping-mapping-widget/add-arrow_2023-07-12-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Added a dropdown arrow for the Add Group button.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsAddButton.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsAddButton.tsx
@@ -6,6 +6,7 @@ import { Button, DropdownMenu, MenuItem, Text } from "@itwin/itwinui-react";
 import React from "react";
 import type { GroupingCustomUI } from "./customUI/GroupingMappingCustomUI";
 import "./GroupsAddButton.scss";
+import { SvgCaretDownSmall } from "@itwin/itwinui-icons-react";
 
 export interface GroupsDropdownMenuProps {
   disabled?: boolean;
@@ -38,6 +39,7 @@ export const GroupsAddButton = ({
       data-testid="gmw-add-group-button"
       styleType="high-visibility"
       disabled={disabled}
+      endIcon={<SvgCaretDownSmall />}
     >
       <Text>Add Group</Text>
     </Button>


### PR DESCRIPTION
Added a dropdown arrow to the Add Group button.

Here is what the button looks like after the change: 
https://github.com/iTwin/viewer-components-react/assets/22688247/15ef63a4-326a-42b4-93f4-280fa7fbb92a
