### PR TITLE
Property grid: Ignore transient instances

### DIFF
--- a/common/api/property-grid-react.api.md
+++ b/common/api/property-grid-react.api.md
@@ -144,9 +144,6 @@ export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps
 export function PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null;
 
 // @public
-export const PropertyGridComponentId = "vcr:PropertyGridComponent";
-
-// @public
 export interface PropertyGridComponentProps extends Omit<MultiElementPropertyGridProps, "imodel"> {
     preferencesStorage?: PreferencesStorage;
 }
@@ -219,6 +216,9 @@ export interface PropertyGridUiItemsProviderProps {
     defaultPanelWidgetPriority?: number;
     propertyGridProps?: PropertyGridComponentProps;
 }
+
+// @public
+export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
 
 // @public
 export function RemoveFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null;

--- a/common/api/summary/property-grid-react.exports.csv
+++ b/common/api/summary/property-grid-react.exports.csv
@@ -21,7 +21,6 @@ internal;NullValueSettingContextValue
 public;PreferencesStorage
 public;PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element
 public;PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null
-public;PropertyGridComponentId = "vcr:PropertyGridComponent"
 public;PropertyGridComponentProps 
 internal;PropertyGridContent({ dataProvider, imodel, contextMenuItems, className, onBackButton, headerControls, settingsMenuItems, ...props }: PropertyGridContentProps): JSX.Element
 public;PropertyGridContentBaseProps 
@@ -34,6 +33,7 @@ public;PropertyGridSettingsMenuItem({ id, onClick, title, children }: PropsWithC
 public;PropertyGridSettingsMenuItemProps
 public;PropertyGridUiItemsProvider 
 public;PropertyGridUiItemsProviderProps
+public;PropertyGridWidgetId = "vcr:PropertyGridComponent"
 public;RemoveFavoritePropertyContextMenuItem({ field, imodel, scope }: FavoritePropertiesContextMenuItemProps): JSX.Element | null
 internal;SettingsDropdownMenu({ settingsMenuItems, dataProvider }: SettingsDropdownMenuProps): JSX.Element | null
 internal;SettingsDropdownMenuProps 

--- a/common/changes/@itwin/property-grid-react/property_grid_ignore_transient_instances_2023-07-14-14-29.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_ignore_transient_instances_2023-07-14-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Do not open property grid widget when transient instance is selected.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/PropertyGridComponent.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridComponent.tsx
@@ -3,20 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { useEffect } from "react";
-import { useActiveIModelConnection, useSpecificWidgetDef, WidgetState } from "@itwin/appui-react";
-import { Presentation } from "@itwin/presentation-frontend";
+import { useActiveIModelConnection } from "@itwin/appui-react";
 import { MultiElementPropertyGrid } from "./components/MultiElementPropertyGrid";
 import { PreferencesContextProvider } from "./PropertyGridPreferencesContext";
 
 import type { MultiElementPropertyGridProps } from "./components/MultiElementPropertyGrid";
 import type { PreferencesStorage } from "./api/PreferencesStorage";
-
-/**
- * Id of the property grid widget created by `PropertyGridUiItemsProvider`.
- * @public
- */
-export const PropertyGridComponentId = "vcr:PropertyGridComponent";
 
 /**
  * Props for `PropertyGridComponent`.
@@ -41,24 +33,6 @@ export function PropertyGridComponent({ preferencesStorage, ...props }: Property
   }
 
   return <PreferencesContextProvider storage={preferencesStorage}>
-    <PropertyGridComponentContent {...props} imodel={imodel} />
+    <MultiElementPropertyGrid {...props} imodel={imodel} />
   </PreferencesContextProvider>;
-}
-
-/** Component that renders `MultiElementPropertyGrid` an hides/shows widget based on `UnifiedSelection`. */
-function PropertyGridComponentContent(props: MultiElementPropertyGridProps) {
-  const widgetDef = useSpecificWidgetDef(PropertyGridComponentId);
-
-  useEffect(() => {
-    if (!widgetDef) {
-      return;
-    }
-
-    return Presentation.selection.selectionChange.addListener((args) => {
-      const keys = Presentation.selection.getSelection(args.imodel);
-      widgetDef.setWidgetState(keys.isEmpty ? WidgetState.Hidden : WidgetState.Open);
-    });
-  }, [widgetDef]);
-
-  return <MultiElementPropertyGrid {...props} />;
 }

--- a/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/PropertyGridUiItemsProvider.tsx
@@ -3,13 +3,23 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { StagePanelLocation, StagePanelSection, StageUsage, WidgetState } from "@itwin/appui-react";
+import { useEffect } from "react";
+import { StagePanelLocation, StagePanelSection, StageUsage, useSpecificWidgetDef, WidgetState } from "@itwin/appui-react";
+import { Id64 } from "@itwin/core-bentley";
 import { SvgInfoCircular } from "@itwin/itwinui-icons-react";
-import { PropertyGridComponent, PropertyGridComponentId } from "./PropertyGridComponent";
+import { Key } from "@itwin/presentation-common";
+import { Presentation } from "@itwin/presentation-frontend";
+import { PropertyGridComponent } from "./PropertyGridComponent";
 import { PropertyGridManager } from "./PropertyGridManager";
 
 import type { UiItemsProvider, Widget } from "@itwin/appui-react";
 import type { PropertyGridComponentProps } from "./PropertyGridComponent";
+
+/**
+ * Id of the property grid widget created by `PropertyGridUiItemsProvider`.
+ * @public
+ */
+export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
 
 /**
  * Props for creating `PropertyGridUiItemsProvider`.
@@ -45,9 +55,9 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
     }
 
     return [{
-      id: PropertyGridComponentId,
+      id: PropertyGridWidgetId,
       label: PropertyGridManager.translate("widget-label"),
-      content: <PropertyGridComponent {...propertyGridProps} />,
+      content: <PropertyGridWidget {...propertyGridProps} />,
       defaultState: WidgetState.Hidden,
       icon: <SvgInfoCircular />,
       priority: defaultPanelWidgetPriority,
@@ -55,3 +65,22 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
   }
 }
 
+/** Component that renders `PropertyGridComponent` an hides/shows widget based on `UnifiedSelection`. */
+function PropertyGridWidget(props: PropertyGridComponentProps) {
+  const widgetDef = useSpecificWidgetDef(PropertyGridWidgetId);
+
+  useEffect(() => {
+    if (!widgetDef) {
+      return;
+    }
+
+    return Presentation.selection.selectionChange.addListener((args) => {
+      const selection = Presentation.selection.getSelection(args.imodel);
+      // show property grid widget if there are at least one node or valid instance selected.
+      const show = selection.nodeKeysCount !== 0 || selection.some((key) => Key.isInstanceKey(key) && !Id64.isTransient(key.id));
+      widgetDef.setWidgetState(show ? WidgetState.Open : WidgetState.Hidden);
+    });
+  }, [widgetDef]);
+
+  return <PropertyGridComponent {...props} />;
+}

--- a/packages/itwin/property-grid/src/hooks/UseInstanceSelection.ts
+++ b/packages/itwin/property-grid/src/hooks/UseInstanceSelection.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useState } from "react";
 import { UiFramework } from "@itwin/appui-react";
+import { Id64 } from "@itwin/core-bentley";
 import { Presentation } from "@itwin/presentation-frontend";
 
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -179,10 +180,12 @@ function getInstanceKeys(keys: Readonly<KeySet>) {
   keys.instanceKeys.forEach(
     (ids: Set<string>, className: string) => {
       ids.forEach((id: string) => {
-        selectedInstanceKeys.push({
-          id,
-          className,
-        });
+        if (!Id64.isTransient(id)) {
+          selectedInstanceKeys.push({
+            id,
+            className,
+          });
+        }
       });
     }
   );

--- a/packages/itwin/property-grid/src/test/PropertyGridComponent.test.tsx
+++ b/packages/itwin/property-grid/src/test/PropertyGridComponent.test.tsx
@@ -5,17 +5,13 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { UiFramework, WidgetState } from "@itwin/appui-react";
+import { UiFramework } from "@itwin/appui-react";
 import { BeEvent } from "@itwin/core-bentley";
-import { KeySet } from "@itwin/presentation-common";
 import { render, waitFor } from "@testing-library/react";
 import * as multiElementPropertyGrid from "../components/MultiElementPropertyGrid";
-import { PropertyGridComponent, PropertyGridComponentId } from "../PropertyGridComponent";
-import { stubSelectionManager } from "./TestUtils";
+import { PropertyGridComponent } from "../PropertyGridComponent";
 
-import type { WidgetDef } from "@itwin/appui-react";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { ISelectionProvider, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
 
 describe("PropertyGridComponent", () => {
   const imodel = {
@@ -45,52 +41,5 @@ describe("PropertyGridComponent", () => {
     UiFramework.setIModelConnection(imodel);
     const { getByText } = render(<PropertyGridComponent />);
     await waitFor(() => getByText("MultiElementPropertyGrid"));
-  });
-
-  describe("widget state", () => {
-    const widgetDef = {
-      id: PropertyGridComponentId,
-      setWidgetState: sinon.stub<Parameters<WidgetDef["setWidgetState"]>, ReturnType<WidgetDef["setWidgetState"]>>(),
-    };
-    const frontstageDef = {
-      findWidgetDef: (id: string) => id === widgetDef.id ? widgetDef : undefined,
-    };
-
-    let selectionManager: ReturnType<typeof stubSelectionManager>;
-
-    before(() => {
-      selectionManager = stubSelectionManager();
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => frontstageDef);
-      UiFramework.setIModelConnection(imodel);
-    });
-
-    beforeEach(() => {
-      selectionManager.getSelection.reset();
-      widgetDef.setWidgetState.reset();
-    });
-
-    it("hides widget if `UnifiedSelection` changes to empty", async () => {
-      render(<PropertyGridComponent />);
-
-      selectionManager.getSelection.returns(new KeySet());
-      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
-
-      await waitFor(() => {
-        expect(widgetDef.setWidgetState).to.be.called;
-        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Hidden);
-      });
-    });
-
-    it("opens widget if `UnifiedSelection` changes to non-empty", async () => {
-      render(<PropertyGridComponent />);
-
-      selectionManager.getSelection.returns(new KeySet([{ id: "0x1", className: "TestClass" }]));
-      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
-
-      await waitFor(() => {
-        expect(widgetDef.setWidgetState).to.be.called;
-        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Open);
-      });
-    });
   });
 });

--- a/packages/itwin/property-grid/src/test/PropertyGridUiItemsProvider.test.tsx
+++ b/packages/itwin/property-grid/src/test/PropertyGridUiItemsProvider.test.tsx
@@ -5,15 +5,24 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { StagePanelLocation, StagePanelSection, StageUsage } from "@itwin/appui-react";
-import { render } from "@testing-library/react";
+import { StagePanelLocation, StagePanelSection, StageUsage, UiFramework, WidgetState } from "@itwin/appui-react";
+import { KeySet, StandardNodeTypes } from "@itwin/presentation-common";
+import { render, waitFor } from "@testing-library/react";
 import * as propertyGridComponent from "../PropertyGridComponent";
 import { PropertyGridManager } from "../PropertyGridManager";
-import { PropertyGridUiItemsProvider } from "../PropertyGridUiItemsProvider";
+import { PropertyGridUiItemsProvider, PropertyGridWidgetId } from "../PropertyGridUiItemsProvider";
+import { stubSelectionManager } from "./TestUtils";
+
+import type { WidgetDef } from "@itwin/appui-react";
+import type { ECClassGroupingNodeKey } from "@itwin/presentation-common";
+import type { ISelectionProvider, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
 
 describe("PropertyGridUiItemsProvider", () => {
+  let propertyGridComponentStub: sinon.SinonStub<Parameters<typeof propertyGridComponent["PropertyGridComponent"]>, ReturnType<typeof propertyGridComponent["PropertyGridComponent"]>>;
+
   before(() => {
     sinon.stub(PropertyGridManager, "translate").callsFake((key) => key);
+    propertyGridComponentStub = sinon.stub(propertyGridComponent, "PropertyGridComponent").returns(<></>);
   });
 
   after(() => {
@@ -40,11 +49,94 @@ describe("PropertyGridUiItemsProvider", () => {
   });
 
   it("renders property grid component", () => {
-    const propertyGridComponentStub = sinon.stub(propertyGridComponent, "PropertyGridComponent").returns(<></>);
+    propertyGridComponentStub.resetHistory();
     const provider = new PropertyGridUiItemsProvider();
     const [widget] = provider.provideWidgets("", StageUsage.General, StagePanelLocation.Right, StagePanelSection.End);
     render(<>{widget.content}</>);
 
     expect(propertyGridComponentStub).to.be.called;
+  });
+
+  describe("widget state", () => {
+    const widgetDef = {
+      id: PropertyGridWidgetId,
+      setWidgetState: sinon.stub<Parameters<WidgetDef["setWidgetState"]>, ReturnType<WidgetDef["setWidgetState"]>>(),
+    };
+    const frontstageDef = {
+      findWidgetDef: (id: string) => id === widgetDef.id ? widgetDef : undefined,
+    };
+
+    let selectionManager: ReturnType<typeof stubSelectionManager>;
+
+    before(() => {
+      selectionManager = stubSelectionManager();
+      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => frontstageDef);
+    });
+
+    beforeEach(() => {
+      selectionManager.getSelection.reset();
+      widgetDef.setWidgetState.reset();
+    });
+
+    function renderWidget() {
+      const provider = new PropertyGridUiItemsProvider();
+      const [widget] = provider.provideWidgets("", StageUsage.General, StagePanelLocation.Right, StagePanelSection.End);
+      render(<>{widget.content}</>);
+    }
+
+    it("hides widget if `UnifiedSelection` changes to empty", async () => {
+      renderWidget();
+
+      selectionManager.getSelection.returns(new KeySet());
+      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
+
+      await waitFor(() => {
+        expect(widgetDef.setWidgetState).to.be.called;
+        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Hidden);
+      });
+    });
+
+    it("hides widget if `UnifiedSelection` has only transient instance keys", async () => {
+      renderWidget();
+
+      selectionManager.getSelection.returns(new KeySet([{ id: "0xffffff0000000001", className: "Transient" }]));
+      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
+
+      await waitFor(() => {
+        expect(widgetDef.setWidgetState).to.be.called;
+        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Hidden);
+      });
+    });
+
+    it("opens widget if `UnifiedSelection` changes to non-empty", async () => {
+      renderWidget();
+
+      selectionManager.getSelection.returns(new KeySet([{ id: "0x1", className: "TestClass" }]));
+      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
+
+      await waitFor(() => {
+        expect(widgetDef.setWidgetState).to.be.called;
+        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Open);
+      });
+    });
+
+    it("opens widget if `UnifiedSelection` has node keys", async () => {
+      renderWidget();
+
+      const key: ECClassGroupingNodeKey = {
+        className: "TestClass",
+        groupedInstancesCount: 5,
+        pathFromRoot: [],
+        type: StandardNodeTypes.ECClassGroupingNode,
+        version: 2,
+      };
+      selectionManager.getSelection.returns(new KeySet([key]));
+      selectionManager.selectionChange.raiseEvent({} as SelectionChangeEventArgs, {} as ISelectionProvider);
+
+      await waitFor(() => {
+        expect(widgetDef.setWidgetState).to.be.called;
+        expect(widgetDef.setWidgetState).to.be.calledWith(WidgetState.Open);
+      });
+    });
   });
 });

--- a/packages/itwin/property-grid/src/test/hooks/UseInstanceSelection.test.ts
+++ b/packages/itwin/property-grid/src/test/hooks/UseInstanceSelection.test.ts
@@ -59,6 +59,16 @@ describe("useInstanceSelection", () => {
     });
   });
 
+  it("ignores transient instance keys", async () => {
+    const transientKey: InstanceKey = { id: "0xffffff0000000001", className: "Transient" };
+    selectionManager.getSelection.returns(new KeySet([noParentKey, transientKey]));
+    const { result } = renderHook(useInstanceSelection, { initialProps: { imodel } });
+
+    await waitFor(() => {
+      expect(result.current.selectedKeys).to.have.lengthOf(1);
+    });
+  });
+
   it("reacts to selection changes", async () => {
     const otherKey: InstanceKey = { id: "0x5", className: "OtherClass" };
     selectionManager.getSelection.returns(new KeySet([noParentKey]));


### PR DESCRIPTION
Do not open property grid when transient instance is selected. Also do not add transient instances to selected instances count when multiple instances are selected (some valid and some transient)