### PR TITLE
Inject custom props into globalThis

### DIFF
--- a/apps/test-viewer/src/index.tsx
+++ b/apps/test-viewer/src/index.tsx
@@ -9,6 +9,16 @@ import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./components/App";
 
+// Set custom global variables
+if (process.env.IMJS_GLOBAL_PROPS) {
+  try {
+    const json = JSON.parse(process.env.IMJS_GLOBAL_PROPS);
+    Object.entries(json).forEach(([key, value]) => {Object.defineProperty(globalThis, key, {value}) });
+  } catch {
+    console.log(`Could not read 'IMJS_GLOBAL_PROPS'`);
+  }
+}
+
 if (!process.env.IMJS_AUTH_CLIENT_CLIENT_ID) {
   throw new Error(
     "Please add a valid OIDC client id to the .env file and restart the application. See the README for more information."


### PR DESCRIPTION
The goal of this PR is to avoid making code change when we want to switch to QA environment. 

In your .env you can have something like: 
`IMJS_GLOBAL_PROPS = {"IMJS_URL_PREFIX": "qa-"}`
which will be the equivalent of
`globalThis.IMJS_URL_PREFIX="qa-"`

This give us an internal backdoor, but still being generic enough to avoid exposing our internal stuff to third parties.  
