### PR TITLE
Tree widget: Update rulesets

### DIFF
--- a/common/api/summary/tree-widget-react.exports.csv
+++ b/common/api/summary/tree-widget-react.exports.csv
@@ -19,6 +19,7 @@ internal;createSearchRuleset(props: CreateSearchRulesetProps): Ruleset
 internal;CreateSearchRulesetProps = Omit
 public;createVisibilityTreeNodeRenderer({ levelOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled }: VisibilityTreeNodeRendererProps): (treeNodeProps: TreeNodeRendererProps) => JSX.Element
 public;createVisibilityTreeRenderer({ nodeRendererProps }: VisibilityTreeRendererProps): (props: TreeRendererProps) => JSX.Element
+internal;customizeModelsTreeNodeItem(item: Partial
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element
 alpha;ExternalSourcesTreeComponent:
 alpha;ExternalSourcesTreeProps = BaseTreeProps

--- a/common/api/tree-widget-react.api.md
+++ b/common/api/tree-widget-react.api.md
@@ -8,6 +8,7 @@
 
 import type { AbstractTreeNodeLoaderWithProvider } from '@itwin/components-react';
 import { BeEvent } from '@itwin/core-bentley';
+import type { DelayLoadedTreeNodeItem } from '@itwin/components-react';
 import type { ECClassGroupingNodeKey } from '@itwin/presentation-common';
 import { HighlightableTreeProps } from '@itwin/components-react';
 import type { Id64String } from '@itwin/core-bentley';
@@ -17,6 +18,7 @@ import type { IModelConnection } from '@itwin/core-frontend';
 import type { IPresentationTreeDataProvider } from '@itwin/presentation-components';
 import type { Localization } from '@itwin/core-common';
 import type { LocalizationOptions } from '@itwin/core-i18n';
+import type { Node as Node_2 } from '@itwin/presentation-common';
 import type { NodeCheckboxRenderProps } from '@itwin/core-react';
 import { NodeKey } from '@itwin/presentation-common';
 import type { Ruleset } from '@itwin/presentation-common';
@@ -170,6 +172,9 @@ export function createVisibilityTreeNodeRenderer({ levelOffset, disableRootNodeC
 
 // @public
 export function createVisibilityTreeRenderer({ nodeRendererProps }: VisibilityTreeRendererProps): (props: TreeRendererProps) => JSX.Element;
+
+// @internal (undocumented)
+export function customizeModelsTreeNodeItem(item: Partial<DelayLoadedTreeNodeItem>, node: Partial<Node_2>): void;
 
 // @alpha
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element;

--- a/common/changes/@itwin/tree-widget-react/tree_widget_update_rulesets_2023-07-18-13-05.json
+++ b/common/changes/@itwin/tree-widget-react/tree_widget_update_rulesets_2023-07-18-13-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "`ModelsTree`: Refactor ruleset to not use deprecated `ImageIdOverride` rule. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/changes/@itwin/tree-widget-react/tree_widget_update_rulesets_2023-07-18-13-06.json
+++ b/common/changes/@itwin/tree-widget-react/tree_widget_update_rulesets_2023-07-18-13-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "`ModelsTree`: Always render checkbox to avoid UI shifting when checkbox appear.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/packages/itwin/tree-widget/src/components/trees/category-tree/Categories.json
+++ b/packages/itwin/tree-widget/src/components/trees/category-tree/Categories.json
@@ -13,12 +13,10 @@
               "classes": [
                 {
                   "schemaName": "BisCore",
-                  "classNames": [
-                    "SpatialCategory"
-                  ]
+                  "classNames": ["SpatialCategory"],
+                  "arePolymorphic": true
                 }
               ],
-              "arePolymorphic": true,
               "relatedInstances": [
                 {
                   "relationshipPath": {
@@ -46,12 +44,10 @@
               "classes": [
                 {
                   "schemaName": "BisCore",
-                  "classNames": [
-                    "DrawingCategory"
-                  ]
+                  "classNames": ["DrawingCategory"],
+                  "arePolymorphic": true
                 }
               ],
-              "arePolymorphic": true,
               "relatedInstances": [
                 {
                   "relationshipPath": {

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -13,7 +13,7 @@ import { ClassGroupingOption } from "../Common";
 import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
 import { createVisibilityTreeRenderer, useVisibilityTreeFiltering, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
 import { ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
-import { createRuleset, createSearchRuleset } from "./Utils";
+import { createRuleset, createSearchRuleset, customizeModelsTreeNodeItem } from "./Utils";
 
 import type { IModelConnection, Viewport } from "@itwin/core-frontend";
 import type { SingleSchemaClassSpecification } from "@itwin/presentation-common";
@@ -151,12 +151,14 @@ function useModelsTreeNodeLoader(props: ModelsTreeProps) {
     appendChildrenCountForGroupingNodes: (props.hierarchyConfig?.enableElementsClassGrouping === ClassGroupingOption.YesWithCounts),
     pagingSize: PAGING_SIZE,
     enableHierarchyAutoUpdate: props.enableHierarchyAutoUpdate,
+    customizeTreeNodeItem: customizeModelsTreeNodeItem,
   });
   const { nodeLoader: searchNodeLoader, onItemsRendered: onSearchItemsRendered } = usePresentationTreeNodeLoader({
     imodel: props.iModel,
     ruleset: rulesets.search,
     pagingSize: PAGING_SIZE,
     enableHierarchyAutoUpdate: props.enableHierarchyAutoUpdate,
+    customizeTreeNodeItem: customizeModelsTreeNodeItem,
   });
 
   const activeNodeLoader = props.filterInfo?.filter ? searchNodeLoader : nodeLoader;

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
@@ -3,8 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { NodeKey } from "@itwin/presentation-common";
+
 import type { Id64String } from "@itwin/core-bentley";
-import type { Ruleset } from "@itwin/presentation-common";
+import type { DelayLoadedTreeNodeItem } from "@itwin/components-react";
+import type { Node, Ruleset } from "@itwin/presentation-common";
 import type { ModelsTreeHierarchyConfiguration } from "./ModelsTree";
 
 /** @internal */
@@ -68,6 +71,7 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isSubject: "true",
+              icon: "\"icon-imodel-hollow-2\"",
             },
           },
         ],
@@ -122,6 +126,7 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isSubject: "true",
+              icon: "\"icon-folder\"",
             },
           },
         ],
@@ -200,6 +205,7 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isModel: "true",
+              icon: "\"icon-model\"",
             },
           },
         ],
@@ -230,6 +236,7 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isModel: "true",
+              icon: "\"icon-model\"",
             },
           },
         ],
@@ -272,6 +279,7 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             items: {
               isCategory: "true",
               modelId: "ParentNode.InstanceId",
+              icon: "\"icon-layers\"",
             },
           },
         ],
@@ -303,6 +311,8 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             items: {
               modelId: "this.Model.Id",
               categoryId: "this.Category.Id",
+              icon: "\"icon-item\"",
+              groupIcon: "\"icon-ec-class\"",
             },
           },
         ],
@@ -333,6 +343,8 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             items: {
               modelId: "this.Model.Id",
               categoryId: "this.Category.Id",
+              icon: "\"icon-item\"",
+              groupIcon: "\"icon-ec-class\"",
             },
           },
         ],
@@ -362,31 +374,6 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
             applicationStage: "PostProcess",
           },
         ],
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass("Subject", "BisCore")`,
-        imageIdExpression: `IIF(this.Parent.Id = NULL, "icon-imodel-hollow-2", "icon-folder")`,
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass("Model", "BisCore")`,
-        imageIdExpression: `"icon-model"`,
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass("Category", "BisCore")`,
-        imageIdExpression: `"icon-layers"`,
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass("Element", "BisCore")`,
-        imageIdExpression: `"icon-item"`,
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsClassGroupingNode`,
-        imageIdExpression: `"icon-ec-class"`,
       },
       {
         ruleType: "Content",
@@ -447,6 +434,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isSubject: "true",
+              icon: "\"icon-imodel-hollow-2\"",
             },
           },
         ],
@@ -501,6 +489,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isSubject: "true",
+              icon: "\"icon-folder\"",
             },
           },
           {
@@ -558,6 +547,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isModel: "true",
+              icon: "\"icon-model\"",
             },
           },
         ],
@@ -609,6 +599,7 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isModel: "true",
+              icon: "\"icon-model\"",
             },
           },
         ],
@@ -642,20 +633,24 @@ export function createSearchRuleset(props: CreateSearchRulesetProps): Ruleset {
             ruleType: "ExtendedData",
             items: {
               isModel: "true",
+              icon: "\"icon-model\"",
             },
           },
         ],
       },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsOfClass("Subject", "BisCore")`,
-        imageIdExpression: `IIF(this.Parent.Id = NULL, "icon-imodel-hollow-2", "icon-folder")`,
-      },
-      {
-        ruleType: "ImageIdOverride",
-        condition: `ThisNode.IsOfClass("Model", "BisCore")`,
-        imageIdExpression: `"icon-model"`,
-      },
     ],
   };
+}
+
+/** @internal */
+export function customizeModelsTreeNodeItem(item: Partial<DelayLoadedTreeNodeItem>, node: Partial<Node>) {
+  item.isCheckboxVisible = true;
+  item.isCheckboxDisabled = true;
+  item.icon = getIcon(node);
+}
+
+function getIcon(node: Partial<Node>) {
+  return node.key && NodeKey.isClassGroupingNodeKey(node.key)
+    ? node.extendedData?.groupIcon
+    : node.extendedData?.icon;
 }

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTree.test.snap
@@ -12,12 +12,13 @@ Array [
               Object {
                 "extendedData": Object {
                   "categoryId": "0x13",
+                  "groupIcon": "icon-ec-class",
+                  "icon": "icon-item",
                   "modelId": "0x11",
                 },
                 "filtering": Object {
                   "descriptor": [Function],
                 },
-                "icon": "icon-item",
                 "label": PropertyRecord {
                   "property": Object {
                     "displayLabel": "Label",
@@ -33,11 +34,11 @@ Array [
               },
             ],
             "extendedData": Object {
+              "icon": "icon-layers",
               "isCategory": true,
               "modelId": "0x11",
             },
             "hasChildren": true,
-            "icon": "icon-layers",
             "label": PropertyRecord {
               "property": Object {
                 "displayLabel": "Label",
@@ -53,13 +54,13 @@ Array [
           },
         ],
         "extendedData": Object {
+          "icon": "icon-model",
           "isModel": true,
         },
         "filtering": Object {
           "descriptor": [Function],
         },
         "hasChildren": true,
-        "icon": "icon-model",
         "label": PropertyRecord {
           "property": Object {
             "displayLabel": "Label",
@@ -75,10 +76,10 @@ Array [
       },
     ],
     "extendedData": Object {
+      "icon": "icon-imodel-hollow-2",
       "isSubject": true,
     },
     "hasChildren": true,
-    "icon": "icon-imodel-hollow-2",
     "label": PropertyRecord {
       "property": Object {
         "displayLabel": "Label",
@@ -109,12 +110,13 @@ Array [
                   Object {
                     "extendedData": Object {
                       "categoryId": "0x12",
+                      "groupIcon": "icon-ec-class",
+                      "icon": "icon-item",
                       "modelId": "0x11",
                     },
                     "filtering": Object {
                       "descriptor": [Function],
                     },
-                    "icon": "icon-item",
                     "label": PropertyRecord {
                       "property": Object {
                         "displayLabel": "Label",
@@ -130,8 +132,11 @@ Array [
                   },
                 ],
                 "description": "The generic:PhysicalObject class is used for bis:PhysicalElements which cannot be further classified. More-specific bis:PhysicalElement subclasses should be used wherever possible.",
+                "extendedData": Object {
+                  "groupIcon": "icon-ec-class",
+                  "icon": "icon-item",
+                },
                 "hasChildren": true,
-                "icon": "icon-ec-class",
                 "label": PropertyRecord {
                   "property": Object {
                     "displayLabel": "Label",
@@ -147,11 +152,11 @@ Array [
               },
             ],
             "extendedData": Object {
+              "icon": "icon-layers",
               "isCategory": true,
               "modelId": "0x11",
             },
             "hasChildren": true,
-            "icon": "icon-layers",
             "label": PropertyRecord {
               "property": Object {
                 "displayLabel": "Label",
@@ -167,13 +172,13 @@ Array [
           },
         ],
         "extendedData": Object {
+          "icon": "icon-model",
           "isModel": true,
         },
         "filtering": Object {
           "descriptor": [Function],
         },
         "hasChildren": true,
-        "icon": "icon-model",
         "label": PropertyRecord {
           "property": Object {
             "displayLabel": "Label",
@@ -189,10 +194,10 @@ Array [
       },
     ],
     "extendedData": Object {
+      "icon": "icon-imodel-hollow-2",
       "isSubject": true,
     },
     "hasChildren": true,
-    "icon": "icon-imodel-hollow-2",
     "label": PropertyRecord {
       "property": Object {
         "displayLabel": "Label",
@@ -221,12 +226,13 @@ Array [
               Object {
                 "extendedData": Object {
                   "categoryId": "0x12",
+                  "groupIcon": "icon-ec-class",
+                  "icon": "icon-item",
                   "modelId": "0x11",
                 },
                 "filtering": Object {
                   "descriptor": [Function],
                 },
-                "icon": "icon-item",
                 "label": PropertyRecord {
                   "property": Object {
                     "displayLabel": "Label",
@@ -242,11 +248,11 @@ Array [
               },
             ],
             "extendedData": Object {
+              "icon": "icon-layers",
               "isCategory": true,
               "modelId": "0x11",
             },
             "hasChildren": true,
-            "icon": "icon-layers",
             "label": PropertyRecord {
               "property": Object {
                 "displayLabel": "Label",
@@ -262,13 +268,13 @@ Array [
           },
         ],
         "extendedData": Object {
+          "icon": "icon-model",
           "isModel": true,
         },
         "filtering": Object {
           "descriptor": [Function],
         },
         "hasChildren": true,
-        "icon": "icon-model",
         "label": PropertyRecord {
           "property": Object {
             "displayLabel": "Label",
@@ -284,10 +290,10 @@ Array [
       },
     ],
     "extendedData": Object {
+      "icon": "icon-imodel-hollow-2",
       "isSubject": true,
     },
     "hasChildren": true,
-    "icon": "icon-imodel-hollow-2",
     "label": PropertyRecord {
       "property": Object {
         "displayLabel": "Label",

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { StandardNodeTypes } from "@itwin/presentation-common";
+import { customizeModelsTreeNodeItem } from "../../../tree-widget-react";
+
+import type { DelayLoadedTreeNodeItem } from "@itwin/components-react";
+import type { Node } from "@itwin/presentation-common";
+
+describe("customizeModelsTreeNodeItem", () => {
+  it("sets icon from extended data", () => {
+    const item: Partial<DelayLoadedTreeNodeItem> = {};
+    const node: Partial<Node> = {
+      extendedData: {
+        icon: "test-icon",
+      },
+    };
+    customizeModelsTreeNodeItem(item, node);
+    expect(item.icon).to.be.eq("test-icon");
+  });
+
+  it("sets icon from extended data for grouping nodes", () => {
+    const item: Partial<DelayLoadedTreeNodeItem> = {};
+    const node: Partial<Node> = {
+      key: {
+        type: StandardNodeTypes.ECClassGroupingNode,
+        className: "TestClass",
+        groupedInstancesCount: 5,
+        pathFromRoot: [],
+        version: 2,
+      },
+      extendedData: {
+        icon: "test-icon",
+        groupIcon: "test-group-icon",
+      },
+    };
+    customizeModelsTreeNodeItem(item, node);
+    expect(item.icon).to.be.eq("test-group-icon");
+  });
+
+  it("sets checkbox to be visible and disabled", () => {
+    const item: Partial<DelayLoadedTreeNodeItem> = {};
+    const node: Partial<Node> = {};
+    customizeModelsTreeNodeItem(item, node);
+    expect(item.isCheckboxVisible).to.be.true;
+    expect(item.isCheckboxDisabled).to.be.true;
+  });
+});


### PR DESCRIPTION
* Refactored `ModelsTree` ruleset to move away from deprecated `ImageIdOverride` rule. 
* Made checkboxes in `ModelsTree` always visible to avoid shifting UI.
* Moved `arePolymorphic` attribute to correct place in `CategoryTree`.