### PR TITLE
[G&M] Custom calculation formula hint

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/custom-calculation-formula-hint_2023-07-18-16-40.json
+++ b/common/changes/@itwin/grouping-mapping-widget/custom-calculation-formula-hint_2023-07-18-16-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Adds an informational icon that the user can hover over to learn about custom calculation formulas. Also adds a placeholder to the formula Textarea with an example formula.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.scss
@@ -11,5 +11,10 @@
     display: flex;
     flex-direction: column;
     gap: var(--iui-size-s);
+
+    .gmw-formula-information-icon {
+      display: flex;
+      justify-content: space-between;
+    }
   }
 }

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.scss
@@ -11,10 +11,5 @@
     display: flex;
     flex-direction: column;
     gap: var(--iui-size-s);
-
-    .gmw-formula-information-icon {
-      display: flex;
-      justify-content: space-between;
-    }
   }
 }

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
@@ -229,7 +229,7 @@ export const CustomCalculationAction = ({
           <Alert
             type='informational'
             clickableText='Click here.'
-            clickableTextProps={{ href: 'https://developer.bentley.com/apis/insights/operations/create-customcalculation/', target: '_blank', rel: 'noreferrer' }}
+            clickableTextProps={{ href: "https://developer.bentley.com/apis/insights/operations/create-customcalculation/", target: "_blank", rel: "noreferrer" }}
           >
             To learn more about creating custom calculation formulas, view the documentation.
           </Alert>

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
@@ -3,14 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
+  Alert,
   Fieldset,
-  Icon,
-  Label,
   LabeledInput,
   LabeledSelect,
   LabeledTextarea,
   Text,
-  Tooltip,
 } from "@itwin/itwinui-react";
 import React, { useCallback, useEffect, useState } from "react";
 import ActionPanel from "./ActionPanel";
@@ -26,7 +24,6 @@ import { useGroupingMappingApiConfig } from "./context/GroupingApiConfigContext"
 import type { CalculatedProperty, CustomCalculation, GroupProperty } from "@itwin/insights-client";
 import { QuantityType } from "@itwin/insights-client";
 import { usePropertiesContext } from "./context/PropertiesContext";
-import { SvgInfoCircular } from "@itwin/itwinui-icons-react";
 
 export interface CustomCalculationActionProps {
   mappingId: string;
@@ -229,27 +226,18 @@ export const CustomCalculationAction = ({
               validator.showMessageFor("name");
             }}
           />
+          <Alert
+            type='informational'
+            clickableText='Click here.'
+            clickableTextProps={{ href: 'https://developer.bentley.com/apis/insights/operations/create-customcalculation/', target: '_blank', rel: 'noreferrer' }}
+          >
+            To learn more about creating custom calculation formulas, view the documentation.
+          </Alert>
           <LabeledTextarea
             value={formula}
+            required
             name='formula'
-            label={
-              <div className='gmw-formula-information-icon'>
-                <Label required>
-                  Formula
-                </Label>
-                <Tooltip
-                  content=' Formulas can be used to create calculated properties based on already
-                  existing properties. Data types supported are numbers, booleans, and strings.
-                  Formulas can be created using many common logical operators, mathematical operators,
-                  constants, and functions.'
-                  placement='top'
-                >
-                  <Icon fill='informational'>
-                    <SvgInfoCircular />
-                  </Icon>
-                </Tooltip>
-              </div>
-            }
+            label='Formula'
             disabled={isLoading}
             onChange={(event) => {
               setFormula(event.target.value);

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/CustomCalculationAction.tsx
@@ -4,10 +4,13 @@
 *--------------------------------------------------------------------------------------------*/
 import {
   Fieldset,
+  Icon,
+  Label,
   LabeledInput,
   LabeledSelect,
   LabeledTextarea,
   Text,
+  Tooltip,
 } from "@itwin/itwinui-react";
 import React, { useCallback, useEffect, useState } from "react";
 import ActionPanel from "./ActionPanel";
@@ -23,6 +26,7 @@ import { useGroupingMappingApiConfig } from "./context/GroupingApiConfigContext"
 import type { CalculatedProperty, CustomCalculation, GroupProperty } from "@itwin/insights-client";
 import { QuantityType } from "@itwin/insights-client";
 import { usePropertiesContext } from "./context/PropertiesContext";
+import { SvgInfoCircular } from "@itwin/itwinui-icons-react";
 
 export interface CustomCalculationActionProps {
   mappingId: string;
@@ -227,9 +231,25 @@ export const CustomCalculationAction = ({
           />
           <LabeledTextarea
             value={formula}
-            required
             name='formula'
-            label='Formula'
+            label={
+              <div className='gmw-formula-information-icon'>
+                <Label required>
+                  Formula
+                </Label>
+                <Tooltip
+                  content=' Formulas can be used to create calculated properties based on already
+                  existing properties. Data types supported are numbers, booleans, and strings.
+                  Formulas can be created using many common logical operators, mathematical operators,
+                  constants, and functions.'
+                  placement='top'
+                >
+                  <Icon fill='informational'>
+                    <SvgInfoCircular />
+                  </Icon>
+                </Tooltip>
+              </div>
+            }
             disabled={isLoading}
             onChange={(event) => {
               setFormula(event.target.value);


### PR DESCRIPTION
Adds an informational icon that the user can hover over to learn about custom calculation formulas. Also adds a placeholder to the formula Textarea with an example formula.

Here is what the UI changes look like:
https://github.com/iTwin/viewer-components-react/assets/22688247/fe658dc4-bcdc-4f76-99a9-cb774afcbc21

