### PR TITLE
[measure-tools] Add listeners for unit system changes in startup

### DIFF
--- a/common/changes/@itwin/measure-tools-react/fix-measure-tools-unit-changes_2023-07-19-18-19.json
+++ b/common/changes/@itwin/measure-tools-react/fix-measure-tools-unit-changes_2023-07-19-18-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Add listeners for unit system changes when starting decorator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/packages/itwin/measure-tools/src/api/MeasurementManager.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementManager.ts
@@ -452,11 +452,12 @@ export class MeasurementManager implements Decorator {
     this._dropDecoratorCallback = IModelApp.viewManager.addDecorator(this);
 
     if (undefined === this._dropQuantityFormatterListeners) {
-      this._dropQuantityFormatterListeners = () =>{
-        IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(this.onActiveUnitSystemChanged, this);
-        IModelApp.quantityFormatter.onQuantityFormatsChanged.addListener(this.onActiveUnitSystemChanged, this);
-        IModelApp.quantityFormatter.onUnitsProviderChanged.addListener(this.onActiveUnitSystemChanged, this);
-      };
+      const unsubscribers = [IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(this.onActiveUnitSystemChanged, this),
+        IModelApp.quantityFormatter.onQuantityFormatsChanged.addListener(this.onActiveUnitSystemChanged, this),
+        IModelApp.quantityFormatter.onUnitsProviderChanged.addListener(this.onActiveUnitSystemChanged, this)]
+      this._dropQuantityFormatterListeners = () => unsubscribers.forEach((unsubscriber) => {
+        unsubscriber()
+      });
 
     } else {
       this.onActiveUnitSystemChanged();

--- a/packages/itwin/measure-tools/src/api/MeasurementManager.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementManager.ts
@@ -454,9 +454,9 @@ export class MeasurementManager implements Decorator {
     if (undefined === this._dropQuantityFormatterListeners) {
       const unsubscribers = [IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(this.onActiveUnitSystemChanged, this),
         IModelApp.quantityFormatter.onQuantityFormatsChanged.addListener(this.onActiveUnitSystemChanged, this),
-        IModelApp.quantityFormatter.onUnitsProviderChanged.addListener(this.onActiveUnitSystemChanged, this)]
+        IModelApp.quantityFormatter.onUnitsProviderChanged.addListener(this.onActiveUnitSystemChanged, this)];
       this._dropQuantityFormatterListeners = () => unsubscribers.forEach((unsubscriber) => {
-        unsubscriber()
+        unsubscriber();
       });
 
     } else {


### PR DESCRIPTION
Made changes to how the addListeners for unit system changes were being called since it doesn't actually trigger the addListener functions before these changes.

Related bug:
https://bentleycs.visualstudio.com/beconnect/_boards/board/t/Pineapple%20-%20iMVF/Backlog%20items/?workitem=1220088