### PR TITLE
Added allowActions on Measurement base class. Replaced internal APIs

### DIFF
--- a/common/changes/@itwin/measure-tools-react/bugfix-allow-actions-internal-api-usage_2023-07-24-15-54.json
+++ b/common/changes/@itwin/measure-tools-react/bugfix-allow-actions-internal-api-usage_2023-07-24-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "Added allowActions property to Measurement base class to let measurements to opt out of the popup action toolbar. Fixed up internal usage of currentInputState with (soon to be) public APIs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/packages/itwin/measure-tools/package.json
+++ b/packages/itwin/measure-tools/package.json
@@ -127,6 +127,16 @@
     ],
     "extends": "plugin:@itwin/ui",
     "rules": {
+      "@itwin/no-internal": [
+        "warn",
+        {
+          "tag": [
+            "internal",
+            "alpha",
+            "beta"
+          ]
+        }
+      ],
       "@typescript-eslint/unbound-method": "off",
       "no-duplicate-imports": "off",
       "@typescript-eslint/consistent-type-imports": "error"

--- a/packages/itwin/measure-tools/src/api/Measurement.ts
+++ b/packages/itwin/measure-tools/src/api/Measurement.ts
@@ -6,7 +6,7 @@
 import { UiFramework } from "@itwin/appui-react";
 import type { Id64String } from "@itwin/core-bentley";
 import type { GeometryStreamProps } from "@itwin/core-common";
-import type { DecorateContext, HitDetail} from "@itwin/core-frontend";
+import type { DecorateContext, HitDetail } from "@itwin/core-frontend";
 import { BeButton, BeButtonEvent, IModelApp } from "@itwin/core-frontend";
 import type { Point3d } from "@itwin/core-geometry";
 import type { FormatterSpec } from "@itwin/core-quantity";
@@ -187,7 +187,7 @@ export class MeasurementPickContext {
   public static create(hitDetail: HitDetail, ev?: BeButtonEvent): MeasurementPickContext {
     if (!ev) {
       ev = new BeButtonEvent();
-      IModelApp.toolAdmin.currentInputState.toEventFromLastDataPoint(ev);
+      IModelApp.toolAdmin.fillEventFromLastDataButton(ev);
     }
 
     return new MeasurementPickContext(hitDetail.sourceId, hitDetail, ev);
@@ -201,7 +201,7 @@ export class MeasurementPickContext {
   public static createFromSourceId(geomId: string, ev?: BeButtonEvent): MeasurementPickContext {
     if (!ev) {
       ev = new BeButtonEvent();
-      IModelApp.toolAdmin.currentInputState.toEventFromLastDataPoint(ev);
+      IModelApp.toolAdmin.fillEventFromLastDataButton(ev);
     }
 
     return new MeasurementPickContext(geomId, undefined, ev);
@@ -398,6 +398,9 @@ export abstract class Measurement {
       this.onDisplayLabelsToggled();
     }
   }
+
+  /** Communicates to the action toolbar this measurement wants to participate in actions. */
+  public get allowActions(): boolean { return true; }
 
   /** Protected constructor */
   protected constructor() {

--- a/packages/itwin/measure-tools/src/test/measure-tools/Measurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/Measurement.test.ts
@@ -11,6 +11,8 @@ import { MeasurementPreferences } from "../../api/MeasurementPreferences";
 import type { DistanceMeasurementProps } from "../../measurements/DistanceMeasurement";
 import { DistanceMeasurement } from "../../measurements/DistanceMeasurement";
 import { DistanceMeasurementSubClass } from "./MeasurementSerialization.test";
+import { MeasurementActionToolbar } from "../../widgets/MeasurementActionToolbar";
+import { Point2d } from "@itwin/core-geometry";
 
 describe("Measurement tests", () => {
   it("Test equality, type mismatch", () => {
@@ -212,6 +214,18 @@ describe("Measurement tests", () => {
 
     assert.isTrue(test.cleanupCalled);
   });
+
+  it("Test measurement allowActions", () => {
+    MeasurementActionToolbar.setDefaultActionProvider();
+    const didOpen = MeasurementActionToolbar.openToolbar([new NoParticipateMeasurement()], Point2d.create(0, 0));
+    assert.isFalse(didOpen);
+
+    const reallyDidOpen = MeasurementActionToolbar.openToolbar([new DistanceMeasurement()], Point2d.create(0, 0));
+    assert.isTrue(reallyDidOpen);
+
+    MeasurementActionToolbar.closeToolbar();
+    MeasurementActionToolbar.clearActionProviders();
+  });
 });
 
 class CleanupDistanceMeasurement extends DistanceMeasurement {
@@ -220,4 +234,8 @@ class CleanupDistanceMeasurement extends DistanceMeasurement {
   public override onCleanup() {
     this.cleanupCalled = true;
   }
+}
+
+class NoParticipateMeasurement extends DistanceMeasurement {
+  public override get allowActions() { return false; }
 }

--- a/packages/itwin/measure-tools/src/widgets/MeasurementActionToolbar.tsx
+++ b/packages/itwin/measure-tools/src/widgets/MeasurementActionToolbar.tsx
@@ -319,11 +319,15 @@ export class MeasurementActionToolbar {
     // Ensure a previous toolbar was closed out
     this.closeToolbar(false);
 
-    if (this._filterHandler && !this._filterHandler(measurements))
+    const measurementsForActions = measurements.filter((m) => m.allowActions);
+    if (measurementsForActions.length === 0)
+      return false;
+
+    if (this._filterHandler && !this._filterHandler(measurementsForActions))
       return false;
 
     // Query all action items...if have none, do not show the toolbar
-    const itemList = this.buildActionList(measurements);
+    const itemList = this.buildActionList(measurementsForActions);
     if (itemList.length === 0)
       return false;
 
@@ -334,7 +338,7 @@ export class MeasurementActionToolbar {
     // Show toolbar
     const realOffset = (offset !== undefined) ? offset : Point2d.createZero();
     const realRelPosition = (relativePosition !== undefined) ? relativePosition : RelativePosition.Top;
-    CursorPopupManager.open(this._lastPopupId, this.buildToolbar(measurements, itemList), screenPoint, realOffset, realRelPosition);
+    CursorPopupManager.open(this._lastPopupId, this.buildToolbar(measurementsForActions, itemList), screenPoint, realOffset, realRelPosition);
 
     FeatureTracking.notifyFeature(MeasureToolsFeatures.MeasurementActionsToolbar_Open);
 


### PR DESCRIPTION
- `allowActions` is now a property getter that can be overridden on `Measurement`. The measurement action toolbar now filters first any measurements who return `false`.
- Investigated cause of non-measurement action items being pulled into the toolbar, filed an [issue](https://github.com/iTwin/appui/issues/424) with AppUi.
- Added lint rule for internal usage APIs and reviewed usage:
  - `currentInputState` should not be used and replaced the button event filling with (soon to be) public APIs
  - Other internal usage are all soon-to-be promoted APIs
  - TODO: ` IModelConnection.requestSnap` will need to be replaced with `AccuSnap.doSnapRequest` when the itwin version is updated