### PR TITLE
[EC3] Modified toolbar layout to be consistent with G&M widget

### DIFF
--- a/common/changes/@itwin/ec3-widget-react/uyen-ec3w-toolbar-layout_2023-08-03-21-51.json
+++ b/common/changes/@itwin/ec3-widget-react/uyen-ec3w-toolbar-layout_2023-08-03-21-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ec3-widget-react",
+      "comment": "modified toolbar layout in EC3 widget to be consistent with G&M widget.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/ec3-widget-react"
+}

--- a/packages/itwin/ec3-widget/src/components/Templates.scss
+++ b/packages/itwin/ec3-widget/src/components/Templates.scss
@@ -59,6 +59,9 @@
     flex-basis: $iui-3xl;
     flex-shrink: 1;
     flex-grow: 1;
+    .ec3w-search-button {
+      display: flex;
+    }
   }
 
   .ec3w-templates-list {

--- a/packages/itwin/ec3-widget/src/components/Templates.tsx
+++ b/packages/itwin/ec3-widget/src/components/Templates.tsx
@@ -110,8 +110,9 @@ export const Templates = ({ onClickCreate, onClickTemplateTitle }: TemplateProps
               startIcon={<SvgAdd />}
               onClick={onClickCreate}
               styleType="high-visibility"
+              title="New Template"
             >
-              Create Template
+              New
             </Button>
             <Button
               data-testid="ec3-export-button"
@@ -121,17 +122,17 @@ export const Templates = ({ onClickCreate, onClickTemplateTitle }: TemplateProps
             >
               Export
             </Button>
-            <IconButton
-              title="Refresh"
-              onClick={refresh}
-              disabled={isLoading}
-              styleType="borderless"
-            >
-              <SvgRefresh />
-            </IconButton>
           </div>
           <div className="ec3w-search-bar-container" data-testid="ec3-search-bar">
             <div className="ec3w-search-button">
+              <IconButton
+                title="Refresh"
+                onClick={refresh}
+                disabled={isLoading}
+                styleType="borderless"
+              >
+                <SvgRefresh />
+              </IconButton>
               <SearchBar
                 searchValue={searchValue}
                 setSearchValue={setSearchValue}


### PR DESCRIPTION
Changed button name from "Create Template" to "New" with tooltip. Group Refresh and Search together so these can be on the right end of the flexbox.
![image](https://github.com/iTwin/viewer-components-react/assets/56598021/c2fb24f4-bdb1-46ae-88f8-99cee5c1179e)
