### PR TITLE
Tree widget: Remove itwinui-variables dependency

### DIFF
--- a/common/changes/@itwin/tree-widget-react/tree_widget_remove_itwinui_variables_2023-08-07-12-28.json
+++ b/common/changes/@itwin/tree-widget-react/tree_widget_remove_itwinui_variables_2023-08-07-12-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/tree-widget-react",
+      "comment": "Removed `@itwin/itwinui-variables` from dependencies.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/tree-widget-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       '@itwin/appui-abstract': 4.0.6_@itwin+core-bentley@4.0.6
       '@itwin/appui-layout-react': 4.3.0_a15530b1b218cc32d3ec6ade15225a27
       '@itwin/appui-react': 4.3.0_95010a99ad239167390c73a26ef3edcc
-      '@itwin/breakdown-trees-react': file:../../packages/itwin/breakdown-trees_065db99a892ecdf2d2aa4e3c2a0a5654
+      '@itwin/breakdown-trees-react': file:../../packages/itwin/breakdown-trees_c8d1880a3dfbfaf90f7998cb5612f14a
       '@itwin/browser-authorization': 0.8.0_@itwin+core-bentley@4.0.6
       '@itwin/components-react': 4.3.0_a15530b1b218cc32d3ec6ade15225a27
       '@itwin/core-bentley': 4.0.6
@@ -1270,7 +1270,6 @@ importers:
       '@itwin/itwinui-icons-react': ^2.1.0
       '@itwin/itwinui-illustrations-react': ^2.1.0
       '@itwin/itwinui-react': ^2.11.0
-      '@itwin/itwinui-variables': ^2.0.0
       '@itwin/presentation-backend': ^4.0.0
       '@itwin/presentation-common': ^4.0.0
       '@itwin/presentation-components': ^4.0.0
@@ -1326,7 +1325,6 @@ importers:
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-illustrations-react': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-react': 2.11.2_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-variables': 2.0.0
       classnames: 2.3.1
       i18next: 10.6.0
       react-error-boundary: 4.0.10_react@17.0.2
@@ -25465,11 +25463,11 @@ packages:
       react: 17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2
 
-  file:../../packages/itwin/breakdown-trees_065db99a892ecdf2d2aa4e3c2a0a5654:
+  file:../../packages/itwin/breakdown-trees_c8d1880a3dfbfaf90f7998cb5612f14a:
     resolution: {directory: ../../packages/itwin/breakdown-trees, type: directory}
     id: file:../../packages/itwin/breakdown-trees
     name: '@itwin/breakdown-trees-react'
-    version: 0.6.2
+    version: 0.6.3
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-layout-react': ^4.3.0
@@ -25484,7 +25482,7 @@ packages:
       '@itwin/presentation-common': ^4.0.0
       '@itwin/presentation-components': ^4.0.0
       '@itwin/presentation-frontend': ^4.0.0
-      '@itwin/tree-widget-react': workspace:^1.0.0-dev.6
+      '@itwin/tree-widget-react': workspace:^1.0.0
       react: ^17.0.0
       react-dom: ^17.0.0
       react-redux: 7.2.6
@@ -25550,15 +25548,15 @@ packages:
     resolution: {directory: ../../packages/itwin/map-layers, type: directory}
     id: file:../../packages/itwin/map-layers
     name: '@itwin/map-layers'
-    version: 5.0.0
+    version: 5.1.1
     peerDependencies:
-      '@itwin/appui-abstract': ^4.0.6
+      '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-layout-react': ^4.0.0
       '@itwin/appui-react': ^4.0.0
       '@itwin/components-react': ^4.0.0
-      '@itwin/core-bentley': ^4.0.6
-      '@itwin/core-common': ^4.0.6
-      '@itwin/core-frontend': ^4.0.6
+      '@itwin/core-bentley': ^4.0.0
+      '@itwin/core-common': ^4.0.0
+      '@itwin/core-frontend': ^4.0.0
       '@itwin/core-react': ^4.0.0
       '@itwin/imodel-components-react': ^4.0.0
       react: ^17.0.0
@@ -25621,7 +25619,7 @@ packages:
     resolution: {directory: ../../packages/itwin/property-grid, type: directory}
     id: file:../../packages/itwin/property-grid
     name: '@itwin/property-grid-react'
-    version: 1.0.0-dev.3
+    version: 1.0.1
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0
@@ -25657,7 +25655,7 @@ packages:
     resolution: {directory: ../../packages/itwin/tree-widget, type: directory}
     id: file:../../packages/itwin/tree-widget
     name: '@itwin/tree-widget-react'
-    version: 1.0.0-dev.6
+    version: 1.0.0
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -43,7 +43,6 @@
     "@itwin/itwinui-icons-react": "^2.1.0",
     "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@itwin/itwinui-react": "^2.11.0",
-    "@itwin/itwinui-variables": "^2.0.0",
     "classnames": "^2.3.1",
     "i18next": "^10.2.2",
     "react-error-boundary": "^4.0.10",

--- a/packages/itwin/tree-widget/src/components/SelectableTree.scss
+++ b/packages/itwin/tree-widget/src/components/SelectableTree.scss
@@ -2,7 +2,6 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/itwinui-variables";
 
 .tree-widget-selectable-tree {
   padding: var(--iui-size-xs);


### PR DESCRIPTION
Removed `@itwin/itwinui-variables` dependency. 

`@import "~@itwin/itwinui-variables";` with `~` throws error if app is built with `react-scripts` and `USE_FAST_SASS=false`. If `~` is removed it builds successfully but fails with `USE_FAST_SASS=true`. To avoid these problems removed import and dependency on `itwinui-variables` as it should be enough to have dependency on `itwinui-react`: https://github.com/iTwin/iTwinUI/wiki/Version-conflicts#general-guidelines