### PR TITLE
[G&M] Changed "Color by group" to get info about overlapped elements. 

### DIFF
--- a/common/changes/@itwin/grouping-mapping-widget/color_by_group_2023-08-11-17-01.json
+++ b/common/changes/@itwin/grouping-mapping-widget/color_by_group_2023-08-11-17-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Major Change for Color by Group",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupItem.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupItem.tsx
@@ -8,25 +8,43 @@ import { HorizontalTile } from "./HorizontalTile";
 import type { ContextCustomUI, GroupingCustomUI } from "./customUI/GroupingMappingCustomUI";
 import type { GroupingProps } from "./Grouping";
 import { GroupMenuActions } from "./GroupMenuActions";
+import { useGroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
 
 export interface GroupItemProps extends Omit<GroupingProps, "onClickAddGroup"> {
   group: Group;
   groupUIs: GroupingCustomUI[];
   contextUIs: ContextCustomUI[];
   setShowDeleteModal: (showDeleteModal: Group) => void;
+  setIsOverlappedElementsInfoPanelOpen: (isOverlappedElementsInfoPanelOpen: Group) => void;
 }
 
 export const GroupItem = ({
   onClickGroupTitle,
   disableActions,
   group,
+  isVisualizing,
   ...rest
 }: GroupItemProps) => {
+
+  const {groupElementsInfo, overlappedElementsInfo, showGroupColor} = useGroupHilitedElementsContext();
 
   const onTitleClick = () => {
     if (onClickGroupTitle) {
       onClickGroupTitle(group);
     }
+  };
+
+  const elementsInfoString = () => {
+    const groupId = group.id;
+    const numberOfElementsInGroup = groupElementsInfo.get(groupId);
+    const overlappedInfo = overlappedElementsInfo.get(groupId);
+    var numberOfOverlappedElementsInGroup = 0;
+    if (overlappedInfo){
+      overlappedInfo.forEach((array) => {
+        numberOfOverlappedElementsInGroup+=array.elements.length;
+      })
+    }
+    return `${numberOfOverlappedElementsInGroup}/${numberOfElementsInGroup} overlaps`;
   };
 
   return (
@@ -40,6 +58,9 @@ export const GroupItem = ({
           {...rest}
         />
       }
+      elementsInfo = {elementsInfoString()}
+      showGroupColor = {showGroupColor}
+      isVisualizing = {isVisualizing}
       onClickTitle={onClickGroupTitle && !disableActions ? onTitleClick : undefined}
     />
   );

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupItem.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupItem.tsx
@@ -38,11 +38,11 @@ export const GroupItem = ({
     const groupId = group.id;
     const numberOfElementsInGroup = groupElementsInfo.get(groupId);
     const overlappedInfo = overlappedElementsInfo.get(groupId);
-    var numberOfOverlappedElementsInGroup = 0;
+    let numberOfOverlappedElementsInGroup = 0;
     if (overlappedInfo){
       overlappedInfo.forEach((array) => {
         numberOfOverlappedElementsInGroup+=array.elements.length;
-      })
+      });
     }
     return `${numberOfOverlappedElementsInGroup}/${numberOfElementsInGroup} overlaps`;
   };

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupMenuActions.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupMenuActions.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import type { Group } from "@itwin/insights-client";
-import { SvgDelete, SvgEdit, SvgMore, SvgInfo } from "@itwin/itwinui-icons-react";
+import { SvgDelete, SvgEdit, SvgInfo, SvgMore } from "@itwin/itwinui-icons-react";
 import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
 import React, { useCallback } from "react";
 import type { ContextCustomUI, GroupingCustomUI } from "./customUI/GroupingMappingCustomUI";
@@ -119,11 +119,11 @@ export const GroupMenuActions = ({
           data-testid="gmw-context-menu-item"
         >
           Overlap Info
-        </MenuItem>)
-    };
+        </MenuItem>);
+    }
 
     return menuItems;
-  }, [ groupUIs, onClickGroupModify, contextUIs, onClickRenderContextCustomUI, mapping, iModelId, showGroupColor ]);
+  }, [ groupUIs, disableActions, group, contextUIs, mapping, iModelId, showGroupColor, onModify, setIsOverlappedElementsInfoPanelOpen, setShowDeleteModal,onClickGroupModify, onClickRenderContextCustomUI ]);
 
   return (
     <div className="gmw-actions">

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupMenuActions.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupMenuActions.tsx
@@ -3,19 +3,21 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import type { Group } from "@itwin/insights-client";
-import { SvgDelete, SvgEdit, SvgMore } from "@itwin/itwinui-icons-react";
+import { SvgDelete, SvgEdit, SvgMore, SvgInfo } from "@itwin/itwinui-icons-react";
 import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
 import React, { useCallback } from "react";
 import type { ContextCustomUI, GroupingCustomUI } from "./customUI/GroupingMappingCustomUI";
 import type { GroupingProps } from "./Grouping";
 import { useGroupingMappingApiConfig } from "./context/GroupingApiConfigContext";
 import "./GroupMenuActions.scss";
+import { useGroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
 
 export interface GroupMenuActionsProps extends Omit<GroupingProps, "onClickAddGroup" | "onClickGroupTitle"> {
   group: Group;
   groupUIs: GroupingCustomUI[];
   contextUIs: ContextCustomUI[];
   setShowDeleteModal: (showDeleteModal: Group) => void;
+  setIsOverlappedElementsInfoPanelOpen: (isOverlappedElementsInfoPanelOpen: Group) => void;
 }
 
 export const GroupMenuActions = ({
@@ -28,13 +30,100 @@ export const GroupMenuActions = ({
   contextUIs,
   disableActions,
   setShowDeleteModal,
+  setIsOverlappedElementsInfoPanelOpen,
 }: GroupMenuActionsProps) => {
   const { iModelId } = useGroupingMappingApiConfig();
-
+  const { showGroupColor } = useGroupHilitedElementsContext();
   const onModify = useCallback(async (group: Group, type: string) => {
     if (!onClickGroupModify) return;
     onClickGroupModify(group, type);
   }, [onClickGroupModify]);
+
+  const createMenuItems = useCallback((close: () => void) => {
+    const menuItems = [
+      ...(groupUIs.length > 0 && onClickGroupModify
+        ? [
+          <MenuItem
+            key={0}
+            icon={<SvgEdit />}
+            disabled={disableActions}
+            data-testid="gmw-context-menu-item"
+            subMenuItems={groupUIs.map((p, index) => (
+              <MenuItem
+                key={p.name}
+                className="gmw-menu-item"
+                data-testid={`gmw-edit-${index}`}
+                onClick={async () => {
+                  await onModify(group, p.name);
+                  close();
+                }}
+                icon={p.icon}
+              >
+                {p.displayLabel}
+              </MenuItem>
+            ))}
+          >
+            Edit
+          </MenuItem>,
+        ]
+        : []),
+      ...contextUIs.map((p) => {
+        return (
+          <MenuItem
+            key={p.name}
+            onClick={async () => {
+              if (
+                p.uiComponent &&
+                onClickRenderContextCustomUI
+              ) {
+                onClickRenderContextCustomUI(
+                  p.uiComponent,
+                  group,
+                  p.displayLabel
+                );
+              }
+              if (p.onClick) {
+                p.onClick(group, mapping, iModelId);
+              }
+              close();
+            }}
+            icon={p.icon}
+            data-testid="gmw-context-menu-item"
+          >
+            {p.displayLabel}
+          </MenuItem>
+        );
+      }),
+      <MenuItem
+        key={2}
+        onClick={() => {
+          setShowDeleteModal(group);
+          close();
+        }}
+        icon={<SvgDelete />}
+        data-testid="gmw-context-menu-item"
+      >
+        Remove
+      </MenuItem>,
+    ];
+
+    if (showGroupColor) {
+      menuItems.push(
+        <MenuItem
+          key={3}
+          onClick={() => {
+            setIsOverlappedElementsInfoPanelOpen(group);
+            close();
+          }}
+          icon={<SvgInfo />}
+          data-testid="gmw-context-menu-item"
+        >
+          Overlap Info
+        </MenuItem>)
+    };
+
+    return menuItems;
+  }, [ groupUIs, onClickGroupModify, contextUIs, onClickRenderContextCustomUI, mapping, iModelId, showGroupColor ]);
 
   return (
     <div className="gmw-actions">
@@ -45,78 +134,12 @@ export const GroupMenuActions = ({
       <DropdownMenu
         className="gmw-action-dropdown"
         disabled={disableActions}
-        menuItems={(close: () => void) => [
-          ...(groupUIs.length > 0 && onClickGroupModify
-            ? [
-              <MenuItem
-                key={0}
-                icon={<SvgEdit />}
-                disabled={disableActions}
-                data-testid="gmw-context-menu-item"
-                subMenuItems={groupUIs.map((p, index) => (
-                  <MenuItem
-                    key={p.name}
-                    className="gmw-menu-item"
-                    data-testid={`gmw-edit-${index}`}
-                    onClick={async () => {
-                      await onModify(group, p.name);
-                      close();
-                    }}
-                    icon={p.icon}
-                  >
-                    {p.displayLabel}
-                  </MenuItem>
-                ))}
-              >
-                Edit
-              </MenuItem>,
-            ]
-            : []),
-          ...contextUIs.map((p) => {
-            return (
-              <MenuItem
-                key={p.name}
-                onClick={async () => {
-                  if (
-                    p.uiComponent &&
-                    onClickRenderContextCustomUI
-                  ) {
-                    onClickRenderContextCustomUI(
-                      p.uiComponent,
-                      group,
-                      p.displayLabel
-                    );
-                  }
-                  if (p.onClick) {
-                    p.onClick(group, mapping, iModelId);
-                  }
-                  close();
-                }}
-                icon={p.icon}
-                data-testid="gmw-context-menu-item"
-              >
-                {p.displayLabel}
-              </MenuItem>
-            );
-          }),
-          <MenuItem
-            key={2}
-            onClick={() => {
-              setShowDeleteModal(group);
-              close();
-            }}
-            icon={<SvgDelete />}
-            data-testid="gmw-context-menu-item"
-          >
-            Remove
-          </MenuItem>,
-        ]}
+        menuItems= {createMenuItems}
       >
         <IconButton
           disabled={disableActions}
           styleType="borderless"
           data-testid="gmw-more-button"
-          title='Group Options'
         >
           <SvgMore />
         </IconButton>

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.scss
@@ -32,6 +32,10 @@
     height: 1px;
   }
 
+  .gmw-overlap-alert{
+    font-size: small;
+  }
+
   .gmw-group-list {
     display: flex;
     flex-direction: column;

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/Grouping.tsx
@@ -5,11 +5,11 @@
 import React, { useCallback, useEffect, useState } from "react";
 import type { CreateTypeFromInterface } from "../utils";
 import {
+  Alert,
   ButtonGroup,
   IconButton,
+  InformationPanelWrapper,
   ProgressLinear,
-  Alert,
-  InformationPanelWrapper
 } from "@itwin/itwinui-react";
 import {
   SvgRefresh,
@@ -178,20 +178,20 @@ export const Groupings = ({
           <>
             {overlappedElementsInfo.size > 0 && isAlertClosed && showGroupColor && !isVisualizing &&
             <Alert
-            onClose={() => setIsAlertClosed(false)}
-            clickableText={isAlertExpanded ? 'Less Details' : 'More Details'}
-            clickableTextProps={{ onClick: () => setIsAlertExpanded(!isAlertExpanded) }}
-            > 
+              onClose={() => setIsAlertClosed(false)}
+              clickableText={isAlertExpanded ? "Less Details" : "More Details"}
+              clickableTextProps={{ onClick: () => setIsAlertExpanded(!isAlertExpanded) }}
+            >
               {isAlertExpanded ? (
-              <>
+                <>
                 Overlapped elements are colored in red in the viewer. <br />
-                To get overlap info in details, click the "Overlap Info" in the menu icon adjacent to the groups. 
-              </>
+                To get overlap info in details, click the &ldquo;Overlap Info&rdquo; in the menu icon adjacent to the groups.
+                </>
               ) : (
-              <>
+                <>
                 Overlapped elements are colored in red in the viewer.
-              </>
-              )}            
+                </>
+              )}
             </Alert>}
 
             <div className="gmw-group-list">

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMappingContext.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMappingContext.tsx
@@ -20,7 +20,7 @@ import type { CalculatedProperty, CustomCalculation, Group, GroupProperty, IMapp
 import { createGroupingMappingCustomUI, GroupingMappingCustomUIContext } from "./context/GroupingMappingCustomUIContext";
 import type { GroupingMappingCustomUI } from "./customUI/GroupingMappingCustomUI";
 import type { QueryCacheItem } from "./context/GroupHilitedElementsContext";
-import { GroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
+import { GroupHilitedElementsContext, OverlappedInfo } from "./context/GroupHilitedElementsContext";
 import { PropertiesContext } from "./context/PropertiesContext";
 import { useActiveIModelConnection } from "@itwin/appui-react";
 
@@ -77,6 +77,10 @@ export const GroupingMappingContext = (props: GroupingMappingContextProps) => {
   const [calculatedProperties, setCalculatedProperties] = useState<CalculatedProperty[]>([]);
   const [customCalculationProperties, setCustomCalculationProperties] = useState<CustomCalculation[]>([]);
   const [numberOfVisualizedGroups, setNumberOfVisualizedGroups] = useState(0);
+  const [overlappedElementsInfo, setOverlappedElementsInfo] = useState<Map<string, OverlappedInfo[]>>(new Map());
+  const [groupElementsInfo, setGroupElementsInfo] = useState<Map<string, number>>(new Map());
+  const [isOverlappedColored, setIsOverlappedColored] = useState<boolean>(false);
+  const [totalNumberOfVisualization, setTotalNumberOfVisualization] = useState<number>(1);
 
   useEffect(() => {
     setApiConfig(() => ({
@@ -106,8 +110,16 @@ export const GroupingMappingContext = (props: GroupingMappingContextProps) => {
       setGroups,
       numberOfVisualizedGroups,
       setNumberOfVisualizedGroups,
+      overlappedElementsInfo,
+      setOverlappedElementsInfo,
+      groupElementsInfo,
+      setGroupElementsInfo,
+      isOverlappedColored,
+      setIsOverlappedColored,
+      totalNumberOfVisualization,
+      setTotalNumberOfVisualization,
     }),
-    [groups, hiddenGroupsIds, showGroupColor, numberOfVisualizedGroups]
+    [groups, hiddenGroupsIds, showGroupColor, numberOfVisualizedGroups, overlappedElementsInfo, groupElementsInfo, isOverlappedColored, totalNumberOfVisualization]
   );
 
   const propertiesContextValue = useMemo(

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMappingContext.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupingMappingContext.tsx
@@ -19,8 +19,8 @@ import {
 import type { CalculatedProperty, CustomCalculation, Group, GroupProperty, IMappingsClient } from "@itwin/insights-client";
 import { createGroupingMappingCustomUI, GroupingMappingCustomUIContext } from "./context/GroupingMappingCustomUIContext";
 import type { GroupingMappingCustomUI } from "./customUI/GroupingMappingCustomUI";
-import type { QueryCacheItem } from "./context/GroupHilitedElementsContext";
-import { GroupHilitedElementsContext, OverlappedInfo } from "./context/GroupHilitedElementsContext";
+import type { OverlappedInfo , QueryCacheItem } from "./context/GroupHilitedElementsContext";
+import { GroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
 import { PropertiesContext } from "./context/PropertiesContext";
 import { useActiveIModelConnection } from "@itwin/appui-react";
 

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsVisualization.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsVisualization.tsx
@@ -101,6 +101,7 @@ export const GroupsVisualization = ({
       setNumberOfVisualizedGroups,
       setOverlappedElementsInfo,
       setGroupElementsInfo,
+      setTotalNumberOfVisualization,
     ]
   );
 
@@ -116,7 +117,7 @@ export const GroupsVisualization = ({
         } else {
           clearEmphasizedOverriddenElements();
         }
-      } 
+      }
     };
     void visualize();
   }, [groups, showGroupColor, visualizeGroupColorsWrapper, isOverlappedColored]);

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsVisualization.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/GroupsVisualization.tsx
@@ -50,8 +50,12 @@ export const GroupsVisualization = ({
     groups,
     hiddenGroupsIds,
     showGroupColor,
+    isOverlappedColored,
     setHiddenGroupsIds,
     setNumberOfVisualizedGroups,
+    setOverlappedElementsInfo,
+    setGroupElementsInfo,
+    setTotalNumberOfVisualization,
   } = useGroupHilitedElementsContext();
 
   const getHiliteIdsFromGroupsWrapper = useCallback(
@@ -77,6 +81,9 @@ export const GroupsVisualization = ({
         hiddenGroupsIds,
         hilitedElementsQueryCache,
         setNumberOfVisualizedGroups,
+        setOverlappedElementsInfo,
+        setGroupElementsInfo,
+        setTotalNumberOfVisualization,
         emphasizeElements,
       );
       isNonEmphasizedSelectable && clearEmphasizedElements();
@@ -92,6 +99,8 @@ export const GroupsVisualization = ({
       emphasizeElements,
       isNonEmphasizedSelectable,
       setNumberOfVisualizedGroups,
+      setOverlappedElementsInfo,
+      setGroupElementsInfo,
     ]
   );
 
@@ -101,14 +110,16 @@ export const GroupsVisualization = ({
         firstUpdate.current = false;
         return;
       }
-      if (groups.length > 0 && showGroupColor) {
-        await visualizeGroupColorsWrapper();
-      } else {
-        clearEmphasizedOverriddenElements();
-      }
+      if(isOverlappedColored === false) {
+        if (groups.length > 0 && showGroupColor) {
+          await visualizeGroupColorsWrapper();
+        } else {
+          clearEmphasizedOverriddenElements();
+        }
+      } 
     };
     void visualize();
-  }, [groups, showGroupColor, visualizeGroupColorsWrapper]);
+  }, [groups, showGroupColor, visualizeGroupColorsWrapper, isOverlappedColored]);
 
   const hideAllGroups = useCallback(
     async () => {

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.scss
@@ -10,6 +10,12 @@
     border-radius: 5px;
     background-color: var(--iui-color-background-backdrop);
     min-height: calc(var(--iui-size-s) * 5);
+    padding: 5.5px var(--iui-size-xs);
+    padding-bottom: 2px var(--iui-size-xs);
+    padding-top: 2px var(--iui-size-xs);
+    &.text-visible{
+      min-height: calc(var(--iui-size-s) * 6)
+    }
 
     .gmw-body-container {
       display: flex;
@@ -37,10 +43,6 @@
       display: flex;
       align-items: center;
       position: relative;
-
-      &.text-visible{
-        min-height: calc(var(--iui-size-s) * 6)
-      }
       
       .gmw-action-button {
         margin-left: 0;

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.scss
@@ -10,7 +10,6 @@
     border-radius: 5px;
     background-color: var(--iui-color-background-backdrop);
     min-height: calc(var(--iui-size-s) * 5);
-    padding: 5.5px var(--iui-size-xs);
 
     .gmw-body-container {
       display: flex;
@@ -33,12 +32,33 @@
         }
       }
     }
-    .gmw-action-button {
-      margin-left: 0;
-      align-self: center;
-      min-width: 36px;
-      margin-right: var(--iui-size-2xs);
-      flex-shrink: 0;
+  
+    .gmw-action-container{ 
+      display: flex;
+      align-items: center;
+      position: relative;
+
+      &.text-visible{
+        min-height: calc(var(--iui-size-s) * 6)
+      }
+      
+      .gmw-action-button {
+        margin-left: 0;
+        align-self: center;
+        min-width: 36px;
+        margin-right: var(--iui-size-2xs);
+        flex-shrink: 0;
+
+        &-text {
+          align-self: flex-end;
+          font-size:smaller;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          position: absolute;
+          bottom: 0;
+        }
+      }
     }
   }
 

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
@@ -26,7 +26,7 @@ export interface HorizontalTileProps {
 export const HorizontalTile = (props: HorizontalTileProps) => {
 
   return (
-    <div className={classNames("gmw-horizontal-tile-container", { "gmw-horizontal-tile-selected": props.selected })} onClick={props.onClick} data-testid="gmw-horizontal-tile">
+    <div className={classNames(`gmw-horizontal-tile-container ${props.showGroupColor &&  !props.isVisualizing && props.elementsInfo ? "text-visible" : ""}`, { "gmw-horizontal-tile-selected": props.selected })} onClick={props.onClick} data-testid="gmw-horizontal-tile">
       <div className="gmw-body-container">
         {props.dragHandle}
         <div className="gmw-body">
@@ -39,7 +39,7 @@ export const HorizontalTile = (props: HorizontalTileProps) => {
           {props.subText && <Text className="gmw-body-text" isMuted={true} title={props.subtextToolTip} variant="small">{props.subText}</Text>}
         </div>
       </div>
-      <div className={`gmw-action-container ${props.showGroupColor &&  !props.isVisualizing && props.elementsInfo ? "text-visible" : ""}`}>
+      <div className="gmw-action-container">
         <div className="gmw-action-button" data-testid="tile-action-button">
           {props.actionGroup}
           {props.showGroupColor &&  !props.isVisualizing && props.elementsInfo &&

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
@@ -42,7 +42,7 @@ export const HorizontalTile = (props: HorizontalTileProps) => {
       <div className={`gmw-action-container ${props.showGroupColor &&  !props.isVisualizing && props.elementsInfo ? "text-visible" : ""}`}>
         <div className="gmw-action-button" data-testid="tile-action-button">
           {props.actionGroup}
-          {props.showGroupColor &&  !props.isVisualizing && props.elementsInfo && 
+          {props.showGroupColor &&  !props.isVisualizing && props.elementsInfo &&
           <Text className="gmw-action-button-text" isMuted={true} title={"Elems-info"} variant="small">{props.elementsInfo}</Text>}
         </div>
       </div>

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/HorizontalTile.tsx
@@ -18,6 +18,9 @@ export interface HorizontalTileProps {
   subtextToolTip?: string;
   selected?: boolean;
   dragHandle?: ReactNode;
+  elementsInfo?: string;
+  showGroupColor?: boolean;
+  isVisualizing?: boolean;
 }
 
 export const HorizontalTile = (props: HorizontalTileProps) => {
@@ -36,8 +39,12 @@ export const HorizontalTile = (props: HorizontalTileProps) => {
           {props.subText && <Text className="gmw-body-text" isMuted={true} title={props.subtextToolTip} variant="small">{props.subText}</Text>}
         </div>
       </div>
-      <div className="gmw-action-button" data-testid="tile-action-button">
-        {props.actionGroup}
+      <div className={`gmw-action-container ${props.showGroupColor &&  !props.isVisualizing && props.elementsInfo ? "text-visible" : ""}`}>
+        <div className="gmw-action-button" data-testid="tile-action-button">
+          {props.actionGroup}
+          {props.showGroupColor &&  !props.isVisualizing && props.elementsInfo && 
+          <Text className="gmw-action-button-text" isMuted={true} title={"Elems-info"} variant="small">{props.elementsInfo}</Text>}
+        </div>
       </div>
     </div>
   );

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.scss
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.gmw-overlap-information {
+  display: flex;
+  flex-direction: column;
+  gap: var(--iui-size-s);
+  flex-grow: 1;
+
+  .gmw-information-body {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.scss
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.scss
@@ -4,13 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 
 .gmw-overlap-information {
-  display: flex;
-  flex-direction: column;
-  gap: var(--iui-size-s);
-  flex-grow: 1;
-
-  .gmw-information-body {
-    display: flex;
-    justify-content: space-between;
+    max-width: 100%;
+    width: 100%;
+    .gmw-information-body {
+      textarea {
+        resize: vertical;
+      }
+    }
   }
-}

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.tsx
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import React from "react";
+import { useMemo, useState } from "react";
+import { CreateTypeFromInterface } from "../utils";
+import { InformationPanel, InformationPanelBody, InformationPanelHeader, Table, Text } from "@itwin/itwinui-react";
+import "./OverlappedElementsInformationPanel.scss";
+import { Group } from "@itwin/insights-client";
+import { OverlappedInfo } from "./context/GroupHilitedElementsContext";
+import { CellProps } from 'react-table'
+import { OverlappedElementsRadioButton } from "./OverlappedElementsRadioButton";
+import { useGroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
+
+export interface OverlappedElementsInformationPanelProps {
+  group?: Group;
+  onClose: () => void;
+  overlappedElementsInfo: Map<string, OverlappedInfo[]>;
+  groups: Group[];
+}
+
+export interface OverlappedElementsDisplayProps {
+  numberOfElements: string;
+  groups: string[];
+  elementsIds: string[]
+}
+type OverlappedTyped = CreateTypeFromInterface<OverlappedElementsDisplayProps>;
+
+export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedElementsInfo, groups }: OverlappedElementsInformationPanelProps) => {
+  const [isOverlappedInfoLoading, setIsOverlappedInfoLoading] = useState<boolean>(false);
+  const { isOverlappedColored, setIsOverlappedColored } = useGroupHilitedElementsContext();
+  const [activeToggleIndex, setActiveToggleIndex] = useState<number>(-1);
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: "Table",
+        columns: [
+          {
+            id: 'number',
+            Header: 'Number of Overlapped elements',
+            accessor: 'numberOfElements',
+          },
+          {
+            id: 'groups',
+            Header: 'Groups',
+            accessor: 'groups',
+            Cell: (value: CellProps<OverlappedTyped>) => {
+              return (
+                <div>
+                  {value.row.original.groups.map((groupName, index) => (
+                    <div key={index}>{groupName}</div>
+                  ))}
+                </div>);
+            },
+          },
+          {
+            id: "radio",
+            width: 80,
+            accessor: 'elementsIds',
+            Cell: ({ value, row }: CellProps<OverlappedTyped>) => {
+
+              const isToggleActive = activeToggleIndex === row.index;
+
+              return (<OverlappedElementsRadioButton
+                color={"red"}
+                ids={value}
+                showOverlappedColor={isToggleActive}
+                setShowOverlappedColor={() => {
+                  setActiveToggleIndex(row.index);
+                }}
+
+                labelPosition="left" />);
+            }
+          }
+        ],
+      },
+    ],
+    [activeToggleIndex, isOverlappedColored]
+  );
+  const key = group ? group.id : "";
+  const overlappedInfo = overlappedElementsInfo.get(key);
+
+  const arr: OverlappedElementsDisplayProps[] = useMemo(() => {
+    setIsOverlappedInfoLoading(true);
+    const result: OverlappedElementsDisplayProps[] = []
+    if (overlappedInfo) {
+      setIsOverlappedColored(true);
+      overlappedInfo.forEach((array) => {
+        var groupNames: string[] = [];
+        array.groupIds.forEach((groupId) => {
+          const group = groups.find((group) => group.id === groupId);
+          if (group) {
+            groupNames.push(group.groupName);
+          }
+        });
+        result.push({ numberOfElements: array.elements.length.toString(), groups: groupNames, elementsIds: array.elements });
+      });
+    }
+    setIsOverlappedInfoLoading(false);
+    return result;
+  }, [overlappedInfo, groups]);
+
+  const handleClose = () => {
+    setActiveToggleIndex(-1);
+    setIsOverlappedColored(false);
+    onClose();
+  };
+
+  return (
+    <InformationPanel isOpen={!!group} className="gmw-overlap-information">
+      <InformationPanelHeader onClose={handleClose}>
+        <Text variant="leading">{`${group?.groupName} Overlap Info`}</Text>
+      </InformationPanelHeader>
+      <InformationPanelBody className="gmw-information-body">
+        <Table<OverlappedTyped>
+          columns={columns}
+          data={arr}
+          emptyTableContent='No Overlaps.'
+          isLoading={isOverlappedInfoLoading}
+          isSortable={true}
+        />
+      </InformationPanelBody>
+    </InformationPanel>
+  );
+};

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsInformationPanel.tsx
@@ -4,12 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 import React from "react";
 import { useMemo, useState } from "react";
-import { CreateTypeFromInterface } from "../utils";
+import type { CreateTypeFromInterface } from "../utils";
 import { InformationPanel, InformationPanelBody, InformationPanelHeader, Table, Text } from "@itwin/itwinui-react";
 import "./OverlappedElementsInformationPanel.scss";
-import { Group } from "@itwin/insights-client";
-import { OverlappedInfo } from "./context/GroupHilitedElementsContext";
-import { CellProps } from 'react-table'
+import type { Group } from "@itwin/insights-client";
+import type { OverlappedInfo } from "./context/GroupHilitedElementsContext";
+import type { CellProps } from "react-table";
 import { OverlappedElementsRadioButton } from "./OverlappedElementsRadioButton";
 import { useGroupHilitedElementsContext } from "./context/GroupHilitedElementsContext";
 
@@ -23,13 +23,13 @@ export interface OverlappedElementsInformationPanelProps {
 export interface OverlappedElementsDisplayProps {
   numberOfElements: string;
   groups: string[];
-  elementsIds: string[]
+  elementsIds: string[];
 }
 type OverlappedTyped = CreateTypeFromInterface<OverlappedElementsDisplayProps>;
 
 export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedElementsInfo, groups }: OverlappedElementsInformationPanelProps) => {
   const [isOverlappedInfoLoading, setIsOverlappedInfoLoading] = useState<boolean>(false);
-  const { isOverlappedColored, setIsOverlappedColored } = useGroupHilitedElementsContext();
+  const { setIsOverlappedColored } = useGroupHilitedElementsContext();
   const [activeToggleIndex, setActiveToggleIndex] = useState<number>(-1);
 
   const columns = useMemo(
@@ -38,14 +38,14 @@ export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedE
         Header: "Table",
         columns: [
           {
-            id: 'number',
-            Header: 'Number of Overlapped elements',
-            accessor: 'numberOfElements',
+            id: "number",
+            Header: "Number of Overlapped elements",
+            accessor: "numberOfElements",
           },
           {
-            id: 'groups',
-            Header: 'Groups',
-            accessor: 'groups',
+            id: "groups",
+            Header: "Groups",
+            accessor: "groups",
             Cell: (value: CellProps<OverlappedTyped>) => {
               return (
                 <div>
@@ -58,7 +58,7 @@ export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedE
           {
             id: "radio",
             width: 80,
-            accessor: 'elementsIds',
+            accessor: "elementsIds",
             Cell: ({ value, row }: CellProps<OverlappedTyped>) => {
 
               const isToggleActive = activeToggleIndex === row.index;
@@ -72,23 +72,23 @@ export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedE
                 }}
 
                 labelPosition="left" />);
-            }
-          }
+            },
+          },
         ],
       },
     ],
-    [activeToggleIndex, isOverlappedColored]
+    [activeToggleIndex]
   );
   const key = group ? group.id : "";
   const overlappedInfo = overlappedElementsInfo.get(key);
 
   const arr: OverlappedElementsDisplayProps[] = useMemo(() => {
     setIsOverlappedInfoLoading(true);
-    const result: OverlappedElementsDisplayProps[] = []
+    const result: OverlappedElementsDisplayProps[] = [];
     if (overlappedInfo) {
       setIsOverlappedColored(true);
       overlappedInfo.forEach((array) => {
-        var groupNames: string[] = [];
+        const groupNames: string[] = [];
         array.groupIds.forEach((groupId) => {
           const group = groups.find((group) => group.id === groupId);
           if (group) {
@@ -100,7 +100,7 @@ export const OverlappedElementsInformationPanel = ({ group, onClose, overlappedE
     }
     setIsOverlappedInfoLoading(false);
     return result;
-  }, [overlappedInfo, groups]);
+  }, [overlappedInfo, groups, setIsOverlappedColored]);
 
   const handleClose = () => {
     setActiveToggleIndex(-1);

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsRadioButton.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsRadioButton.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import React, { useEffect, useState } from "react";
 import type { ToggleSwitchProps } from "@itwin/itwinui-react";
-import { toaster, Radio } from "@itwin/itwinui-react";
+import { Radio, toaster } from "@itwin/itwinui-react";
 import { clearEmphasizedOverriddenElements, visualizeElements, zoomToElements } from "./viewerUtils";
 import { Presentation } from "@itwin/presentation-frontend";
 import { useGroupingMappingApiConfig } from "./context/GroupingApiConfigContext";
@@ -32,7 +32,7 @@ export const OverlappedElementsRadioButton = ({
     const visualize = async () => {
       try {
         setIsLoading(true);
-        
+
         if (showOverlappedColor) {
           clearEmphasizedOverriddenElements();
           Presentation.selection.clearSelection(

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsRadioButton.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/OverlappedElementsRadioButton.tsx
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import React, { useEffect, useState } from "react";
+import type { ToggleSwitchProps } from "@itwin/itwinui-react";
+import { toaster, Radio } from "@itwin/itwinui-react";
+import { clearEmphasizedOverriddenElements, visualizeElements, zoomToElements } from "./viewerUtils";
+import { Presentation } from "@itwin/presentation-frontend";
+import { useGroupingMappingApiConfig } from "./context/GroupingApiConfigContext";
+
+export type OverlappedElementsRadioButtonProps = Partial<ToggleSwitchProps> & {
+  color: string;
+  ids: string[];
+  showOverlappedColor: boolean;
+  setShowOverlappedColor: (showOverlappedColor: boolean) => void;
+};
+
+export const OverlappedElementsRadioButton = ({
+  color,
+  ids,
+  showOverlappedColor,
+  setShowOverlappedColor,
+}: OverlappedElementsRadioButtonProps) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { iModelConnection } = useGroupingMappingApiConfig();
+  if (!iModelConnection) {
+    throw new Error("This component requires an active iModelConnection.");
+  }
+
+  useEffect(() => {
+    const visualize = async () => {
+      try {
+        setIsLoading(true);
+        
+        if (showOverlappedColor) {
+          clearEmphasizedOverriddenElements();
+          Presentation.selection.clearSelection(
+            "GroupingMappingWidget",
+            iModelConnection,
+          );
+
+          visualizeElements(ids, color);
+          await zoomToElements(ids);
+        }
+      } catch (error) {
+        toaster.negative("There was an error visualizing overlapped Elements.");
+        /* eslint-disable no-console */
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void visualize();
+  }, [iModelConnection, color, ids, showOverlappedColor]);
+
+  return (
+    <Radio
+      disabled={isLoading}
+      checked={showOverlappedColor}
+      onClick={() => setShowOverlappedColor(!showOverlappedColor)}
+    />
+  );
+};

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
@@ -12,7 +12,7 @@ export interface QueryCacheItem {
 }
 export interface OverlappedInfo {
   groupIds: string[];
-  elements: string[]
+  elements: string[];
 }
 export interface GroupHilitedElements {
   hilitedElementsQueryCache: MutableRefObject<Map<string, QueryCacheItem>>;

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/context/GroupHilitedElementsContext.ts
@@ -10,16 +10,28 @@ export interface QueryCacheItem {
   keySet: KeySet;
   ids: string[];
 }
+export interface OverlappedInfo {
+  groupIds: string[];
+  elements: string[]
+}
 export interface GroupHilitedElements {
   hilitedElementsQueryCache: MutableRefObject<Map<string, QueryCacheItem>>;
   hiddenGroupsIds: Set<string>;
   showGroupColor: boolean;
   groups: Group[];
   numberOfVisualizedGroups: number;
+  overlappedElementsInfo: Map<string, OverlappedInfo[]>;
+  groupElementsInfo: Map<string,number>;
+  isOverlappedColored: boolean;
+  totalNumberOfVisualization: number;
   setGroups: (groups: Group[]) => void;
   setHiddenGroupsIds: (hiddenGroupIds: Set<string>) => void;
   setShowGroupColor: (showGroupColor: boolean | ((showGroupColor: boolean) => boolean)) => void;
   setNumberOfVisualizedGroups: (numberOfVisualizedGroups: number | ((numberOfVisualizedGroups: number) => number)) => void;
+  setOverlappedElementsInfo: (overlappedElementsInfo: Map<string, OverlappedInfo[]> | ((overlappedElementsInfo: Map<string, OverlappedInfo[]>) => Map<string, OverlappedInfo[]>)) => void;
+  setGroupElementsInfo: (groupElementsInfo: Map<string, number> | ((groupElementsInfo: Map<string, number>) => Map<string, number>)) => void;
+  setIsOverlappedColored: (isOverlappedColored: boolean | ((isOverlappedColored: boolean) => boolean)) => void;
+  setTotalNumberOfVisualization: (totalNumberOfVisualization: number) => void;
 }
 
 export const GroupHilitedElementsContext = React.createContext<GroupHilitedElements>({
@@ -28,10 +40,18 @@ export const GroupHilitedElementsContext = React.createContext<GroupHilitedEleme
   showGroupColor: false,
   groups: [],
   numberOfVisualizedGroups: 0,
+  overlappedElementsInfo: new Map(),
+  groupElementsInfo: new Map(),
+  isOverlappedColored: false,
+  totalNumberOfVisualization: 1,
   setGroups: () => { },
   setHiddenGroupsIds: () => { },
   setShowGroupColor: () => { },
   setNumberOfVisualizedGroups: () => { },
+  setOverlappedElementsInfo: () => { },
+  setGroupElementsInfo: () => { },
+  setIsOverlappedColored: () => { },
+  setTotalNumberOfVisualization: () => { },
 });
 
 export const useGroupHilitedElementsContext = (): GroupHilitedElements => {

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/groupsHelpers.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/groupsHelpers.ts
@@ -7,13 +7,17 @@ import type { IModelConnection } from "@itwin/core-frontend";
 import type { Group } from "@itwin/insights-client";
 import { toaster } from "@itwin/itwinui-react";
 import { KeySet } from "@itwin/presentation-common";
-import type { QueryCacheItem } from "./context/GroupHilitedElementsContext";
+import type { QueryCacheItem, OverlappedInfo } from "./context/GroupHilitedElementsContext";
 import { clearEmphasizedOverriddenElements, emphasizeElements, getHiliteIds, hideElements, overrideElements, zoomToElements } from "./viewerUtils";
 
 const goldenAngle = 180 * (3 - Math.sqrt(5));
 
 export const getGroupColor = function (index: number) {
-  return `hsl(${index * goldenAngle + 60}, 100%, 50%)`;
+  var hue = (index * goldenAngle + 60) % 360;
+  while (hue >= 335 || hue <= 25) {
+    hue = (hue + (index * goldenAngle)) % 360;
+  }
+  return `hsl(${hue}, 100%, 50%)`;
 };
 
 export const getHiliteIdsFromGroups = async (
@@ -61,22 +65,25 @@ export const hideGroup = async (
 };
 
 const processGroupVisualization = async (
-  iModelConnection: IModelConnection,
-  group: Group,
+  elements: Set<string>,
+  elementGroups: Set<string>,
   hiddenGroupsIds: Set<string>,
-  hilitedElementsQueryCache: React.MutableRefObject<Map<string, QueryCacheItem>>,
   doEmphasizeElements: boolean,
-  groupColor: string,
+  index: number,
   setNumberOfVisualizedGroups: (numberOfVisualizedGroups: number | ((numberOfVisualizedGroups: number) => number)) => void,
 ) => {
-  const result = await getHiliteIdsAndKeysetFromGroup(iModelConnection, group, hilitedElementsQueryCache);
-  const hilitedIds = result.ids;
-  overrideElements(hilitedIds, groupColor, FeatureOverrideType.ColorAndAlpha);
+  const hilitedIds = Array.from(elements);
+  overrideElements(hilitedIds, elementGroups.size === 1 ? getGroupColor(index) : "hsl(0, 100%, 50%)", FeatureOverrideType.ColorAndAlpha);
   setNumberOfVisualizedGroups((numberOfVisualizedGroups) => numberOfVisualizedGroups + 1);
 
   doEmphasizeElements && emphasizeElements(hilitedIds, undefined);
 
-  return hiddenGroupsIds.has(group.id) ? [] : hilitedIds;
+  for (var id in elementGroups) {
+    if (hiddenGroupsIds.has(id)) {
+      return [];
+    }
+  }
+  return hilitedIds;
 };
 
 export const visualizeGroupColors = async (
@@ -85,18 +92,25 @@ export const visualizeGroupColors = async (
   hiddenGroupsIds: Set<string>,
   hilitedElementsQueryCache: React.MutableRefObject<Map<string, QueryCacheItem>>,
   setNumberOfVisualizedGroups: (numberOfVisualizedGroups: number | ((numberOfVisualizedGroups: number) => number)) => void,
+  setOverlappedElementsInfo: (overlappedElementsInfo: Map<string, OverlappedInfo[]> | ((overlappedElementsInfo: Map<string, OverlappedInfo[]>) => Map<string, OverlappedInfo[]>)) => void,
+  setGroupElementsInfo: (groupElementsInfo: Map<string, number> | ((groupElementsInfo: Map<string, number>) => Map<string, number>)) => void,
+  setTotalNumberOfVisualization: (totalNumberOfVisualization: number) => void,
   doEmphasizeElements: boolean = true,
 ) => {
   clearEmphasizedOverriddenElements();
 
-  const allIdsPromises = groups.map(async (group, index) =>
+  var { updatedGroups, overlappedElementsInfo, numberOfElementsInGroups } = await getGroups(groups, iModelConnection, hiddenGroupsIds, hilitedElementsQueryCache);
+  setOverlappedElementsInfo(overlappedElementsInfo);
+  setGroupElementsInfo(numberOfElementsInGroups);
+  setTotalNumberOfVisualization(updatedGroups.length);
+
+  const allIdsPromises = updatedGroups.map(async (group, index) =>
     processGroupVisualization(
-      iModelConnection,
-      group,
+      group.element,
+      group.groups,
       hiddenGroupsIds,
-      hilitedElementsQueryCache,
       doEmphasizeElements,
-      getGroupColor(index),
+      index,
       setNumberOfVisualizedGroups,
     )
   );
@@ -134,3 +148,87 @@ export const getHiliteIdsAndKeysetFromGroup = async (
   }
 
 };
+
+interface OverlappedElements {
+  element: Set<string>;
+  groups: Set<string>
+};
+
+const processGroupIds = async (
+  iModelConnection: IModelConnection,
+  group: Group,
+  hiddenGroupsIds: Set<string>,
+  hilitedElementsQueryCache: React.MutableRefObject<Map<string, QueryCacheItem>>,
+) => {
+  const result = await getHiliteIdsAndKeysetFromGroup(iModelConnection, group, hilitedElementsQueryCache);
+  const hilitedIds = result.ids;
+  return hiddenGroupsIds.has(group.id) ? [] : hilitedIds;
+};
+
+const getOverlappedElementsInfo = (overlappedElements: OverlappedElements[]) => {
+  const overlappedElementsInfo: Map<string, OverlappedInfo[]> = new Map();
+
+  overlappedElements.forEach((elementGroup) => {
+    const { element, groups } = elementGroup;
+
+    groups.forEach((group) => {
+      const otherGroups = Array.from(groups).filter((grp) => grp !== group);
+      const overlappedInfoArray = overlappedElementsInfo.get(group) ?? [];
+      overlappedInfoArray.push({ groupIds: otherGroups, elements: Array.from(element) });
+      overlappedElementsInfo.set(group, overlappedInfoArray);
+    });
+  });
+  return overlappedElementsInfo;
+}
+
+const mergeElementsByGroup = (elems: Map<string, Set<string>>) => {
+  const mergedList:  Map<string, OverlappedElements> = new Map();
+  elems.forEach((groups,elementId) =>{
+    const sortedGroups = Array.from(groups).sort();
+    const key = sortedGroups.join('-');
+    var overlap = mergedList.get(key);
+    if (overlap) {
+      overlap.element.add(elementId);
+    }
+    else {
+      mergedList.set(key, { element: new Set([elementId]), groups: groups });
+    }
+  });
+  return mergedList;
+};
+
+const getGroups = async (
+  groups: Group[],
+  iModelConnection: IModelConnection,
+  hiddenGroupsIds: Set<string>,
+  hilitedElementsQueryCache: React.MutableRefObject<Map<string, QueryCacheItem>>,
+) => {
+  var groupsInformation: {groupName: string, elements: string[]}[] = await Promise.all(groups.map(async (group) => ({
+    groupName: group.id,
+    elements: await processGroupIds(iModelConnection, group, hiddenGroupsIds, hilitedElementsQueryCache)
+  })));
+
+  const allGroups: OverlappedElements[] = [];
+  const elems: Map<string,Set<string>> = new Map();
+  const groupElementsMapping: Map<string,number> = new Map();
+
+  for (let i = 0; i < groupsInformation.length; i++) {
+    for (let j = 0; j < groupsInformation[i].elements.length; j++) {
+      var elem = groupsInformation[i].elements[j];
+      var elemGroups = elems.get(elem);
+      if (elemGroups) {
+        elemGroups.add(groupsInformation[i].groupName);
+      }
+      else {
+        elems.set(elem,  new Set([groupsInformation[i].groupName])) ;
+      }
+    }
+    allGroups[i] = { element: new Set(groupsInformation[i].elements), groups: new Set([groupsInformation[i].groupName]) };
+    groupElementsMapping.set(groupsInformation[i].groupName,groupsInformation[i].elements.length);
+  }
+
+  var mergedList = mergeElementsByGroup(elems);
+  const overlappedGroupsInformation: OverlappedElements[] = Array.from(mergedList.values()).filter(value => value.groups.size > 1);
+  return { updatedGroups: [...allGroups, ...overlappedGroupsInformation], overlappedElementsInfo: getOverlappedElementsInfo(overlappedGroupsInformation), numberOfElementsInGroups: groupElementsMapping }
+};
+

--- a/packages/itwin/grouping-mapping-widget/src/widget/components/viewerUtils.tsx
+++ b/packages/itwin/grouping-mapping-widget/src/widget/components/viewerUtils.tsx
@@ -138,7 +138,7 @@ export const overrideElements = (
     vp,
     ColorDef.fromString(color),
     overrideType,
-    true,
+    false,
   );
 };
 

--- a/packages/itwin/grouping-mapping-widget/src/widget/hooks/useVisualization.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/hooks/useVisualization.ts
@@ -24,7 +24,7 @@ export const useVisualization = (shouldVisualize: boolean, iModelConnection: IMo
       clearOverriddenElements();
     }
     clearEmphasizedElements();
-  }, [groups, hiddenGroupsIds, hilitedElementsQueryCache, iModelConnection, showGroupColor, shouldVisualize,setNumberOfVisualizedGroups]);
+  }, [groups, hiddenGroupsIds, hilitedElementsQueryCache, iModelConnection, showGroupColor, shouldVisualize,setNumberOfVisualizedGroups, setOverlappedElementsInfo, setGroupElementsInfo, setTotalNumberOfVisualization ]);
 
   useEffect(() => {
     if (!shouldVisualize) return;

--- a/packages/itwin/grouping-mapping-widget/src/widget/hooks/useVisualization.ts
+++ b/packages/itwin/grouping-mapping-widget/src/widget/hooks/useVisualization.ts
@@ -13,13 +13,13 @@ import { clearEmphasizedElements, clearOverriddenElements, transparentOverridden
 
 export const useVisualization = (shouldVisualize: boolean, iModelConnection: IModelConnection, query: string, queryGenerationType: string) => {
   const [isRendering, setIsRendering] = useState<boolean>(false);
-  const { showGroupColor, groups, hiddenGroupsIds, hilitedElementsQueryCache, setNumberOfVisualizedGroups } = useGroupHilitedElementsContext();
+  const { showGroupColor, groups, hiddenGroupsIds, hilitedElementsQueryCache, setNumberOfVisualizedGroups, setOverlappedElementsInfo, setGroupElementsInfo, setTotalNumberOfVisualization } = useGroupHilitedElementsContext();
   const [simpleSelectionQuery, setSimpleSelectionQuery] = useState<string>("");
 
   const resetView = useCallback(async () => {
     if (!shouldVisualize) return;
     if (showGroupColor) {
-      await visualizeGroupColors(iModelConnection, groups, hiddenGroupsIds, hilitedElementsQueryCache, setNumberOfVisualizedGroups);
+      await visualizeGroupColors(iModelConnection, groups, hiddenGroupsIds, hilitedElementsQueryCache, setNumberOfVisualizedGroups, setOverlappedElementsInfo, setGroupElementsInfo, setTotalNumberOfVisualization);
     } else {
       clearOverriddenElements();
     }


### PR DESCRIPTION
1) Overlapped Elements are visualized "Red" in the viewer. No groups are assigned the color "Red".
2) The horizontal tiles in the groups page, now, shows "No. of Overlapped Elements/ Total No. of Elements" for every group.
3) Alert is displayed in the groups page to let users know about overlapped elements.
4) In the Menu Icon for the groups there is an option "Overlap Info" which when clicked opens an Information panel. The panel has info about the overlaps and users can visualize each overlap.

Major changes in the files:
1) Added 3 new files, OverlappedElementsInformationPanel.tsx, OverlappedElementsInformationPanel.scss, and OverlappedElementsRadioButton.tsx . These files are used to make the Infromation Panel.
2) Major change in groupHelpers.ts. Added new functions to visualize the elements with overlaps visualized differently.
3) For GroupMenuAction.tsx, the menuItems needed to be changed to have "Overlap Info" displayed conditionally.

https://github.com/iTwin/viewer-components-react/assets/69795197/97421b14-0595-4703-8232-f211e07c447f

