### PR TITLE
[Reports Config] Changed Update Dataset icon

### DIFF
--- a/common/changes/@itwin/reports-config-widget-react/uyen-update-dataset-icon_2023-08-14-19-56.json
+++ b/common/changes/@itwin/reports-config-widget-react/uyen-update-dataset-icon_2023-08-14-19-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/reports-config-widget-react",
+      "comment": "Changed update dataset icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/reports-config-widget-react"
+}

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -11,7 +11,7 @@ import { ReportsConfigWidget } from "../../ReportsConfigWidget";
 import { IconButton } from "@itwin/itwinui-react";
 import {
   SvgDelete,
-  SvgRefresh,
+  SvgPlay,
 } from "@itwin/itwinui-icons-react";
 import { HorizontalTile } from "./HorizontalTile";
 import type { ReportMappingAndMapping } from "./ReportMappings";
@@ -98,7 +98,7 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
                 }}
                 disabled={jobStarted}
               >
-                <SvgRefresh />
+                <SvgPlay />
               </IconButton>
             ) : (
               <ExtractionStatus


### PR DESCRIPTION
Changed Update Dataset icon from SvgRefresh to SvgPlay to be consistent with the main Report component.
![image](https://github.com/iTwin/viewer-components-react/assets/56598021/86808503-223e-48e7-bcd9-ed9f74a40f04)
