### PR TITLE
[Reports Config] Remove trash icon when update job is queued

### DIFF
--- a/common/changes/@itwin/reports-config-widget-react/uyen-horizontal-tile-icons_2023-08-14-20-25.json
+++ b/common/changes/@itwin/reports-config-widget-react/uyen-horizontal-tile-icons_2023-08-14-20-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/reports-config-widget-react",
+      "comment": "Removed trash icon in tile if update dataset is queued",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/reports-config-widget-react"
+}

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -108,7 +108,7 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
                 }}
               ></ExtractionStatus>
             )}
-          <IconButton
+          {!jobStarted && <IconButton
             styleType="borderless"
             title={ReportsConfigWidget.localization.getLocalizedString(
               "ReportsConfigWidget:Remove"
@@ -116,10 +116,9 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
             onClick={() => {
               props.onClickDelete();
             }}
-            disabled={jobStarted}
           >
             <SvgDelete />
-          </IconButton>
+          </IconButton>}
         </div >
       )}
     />

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -86,20 +86,33 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
           data-testid="tile-action-button">
           {extractionState === ExtractionStates.None ?
             (
-              <IconButton
-                styleType="borderless"
-                title={ReportsConfigWidget.localization.getLocalizedString(
-                  "ReportsConfigWidget:UpdateDataset"
-                )}
-                onClick={async () => {
-                  setExtractionState(ExtractionStates.Starting);
-                  await props.bulkExtractor.runIModelExtraction(props.mapping.imodelId);
-                  props.jobStartEvent.raiseEvent(props.mapping.imodelId);
-                }}
-                disabled={jobStarted}
-              >
-                <SvgRefresh />
-              </IconButton>
+              <>
+                <IconButton
+                  styleType="borderless"
+                  title={ReportsConfigWidget.localization.getLocalizedString(
+                    "ReportsConfigWidget:UpdateDataset"
+                  )}
+                  onClick={async () => {
+                    setExtractionState(ExtractionStates.Starting);
+                    await props.bulkExtractor.runIModelExtraction(props.mapping.imodelId);
+                    props.jobStartEvent.raiseEvent(props.mapping.imodelId);
+                  }}
+                  disabled={jobStarted}
+                >
+                  <SvgRefresh />
+                </IconButton>
+                <IconButton
+                  styleType="borderless"
+                  title={ReportsConfigWidget.localization.getLocalizedString(
+                    "ReportsConfigWidget:Remove"
+                  )}
+                  onClick={() => {
+                    props.onClickDelete();
+                  }}
+                >
+                  <SvgDelete />
+                </IconButton>
+              </>
             ) : (
               <ExtractionStatus
                 state={extractionState}
@@ -108,17 +121,6 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
                 }}
               ></ExtractionStatus>
             )}
-          {!jobStarted && <IconButton
-            styleType="borderless"
-            title={ReportsConfigWidget.localization.getLocalizedString(
-              "ReportsConfigWidget:Remove"
-            )}
-            onClick={() => {
-              props.onClickDelete();
-            }}
-          >
-            <SvgDelete />
-          </IconButton>}
         </div >
       )}
     />

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -99,7 +99,7 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
                   }}
                   disabled={jobStarted}
                 >
-                  <SvgRefresh />
+                  <SvgPlay />
                 </IconButton>
                 <IconButton
                   styleType="borderless"


### PR DESCRIPTION
Removed trash icon in horizontal tile when update dataset job is queued
![remove-trash-icon-when-queued](https://github.com/iTwin/viewer-components-react/assets/56598021/cefa015d-a85d-4d42-8435-47fd017a8a8d)