### PR TITLE
[Reports Config] Moved toolbar icons to the right

### DIFF
--- a/common/changes/@itwin/reports-config-widget-react/uyen-reposition-toolbar-icons_2023-08-14-21-51.json
+++ b/common/changes/@itwin/reports-config-widget-react/uyen-reposition-toolbar-icons_2023-08-14-21-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/reports-config-widget-react",
+      "comment": "Moved toolbar icons to the right",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/reports-config-widget-react"
+}

--- a/packages/itwin/reports-config-widget/src/widget/components/Reports.scss
+++ b/packages/itwin/reports-config-widget/src/widget/components/Reports.scss
@@ -18,9 +18,8 @@
     flex-wrap: wrap;
 
     .rcw-search-bar-container {
-      flex-basis: var(--iui-size-3xl);
       flex-shrink: 1;
-      flex-grow: 1;
+      flex-grow: 0;
       display: flex;
     }
 


### PR DESCRIPTION
Moved search and refresh icons to the right side of Report component.
![image](https://github.com/iTwin/viewer-components-react/assets/56598021/b38824ae-93eb-41c9-99e2-1598311a1bb2)
