### PR TITLE
TS Bump

### DIFF
--- a/common/changes/@itwin/ec3-widget-react/ts-bump_2023-08-15-04-32.json
+++ b/common/changes/@itwin/ec3-widget-react/ts-bump_2023-08-15-04-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ec3-widget-react",
+      "comment": "Typescript version bump to ^4.5.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/ec3-widget-react"
+}

--- a/common/changes/@itwin/grouping-mapping-widget/ts-bump_2023-08-15-04-32.json
+++ b/common/changes/@itwin/grouping-mapping-widget/ts-bump_2023-08-15-04-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/grouping-mapping-widget",
+      "comment": "Typescript version bump to ^4.5.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/grouping-mapping-widget"
+}

--- a/common/changes/@itwin/reports-config-widget-react/ts-bump_2023-08-15-04-32.json
+++ b/common/changes/@itwin/reports-config-widget-react/ts-bump_2023-08-15-04-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/reports-config-widget-react",
+      "comment": "Typescript version bump to ^4.5.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/reports-config-widget-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
       simple-react-validator: ^1.6.1
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ^4.5.0
+      typescript: ~4.5.0
     dependencies:
       '@itwin/insights-client': 0.4.0
       '@itwin/itwinui-icons-react': 1.15.1_react-dom@17.0.2+react@17.0.2
@@ -319,7 +319,7 @@ importers:
       '@itwin/core-orbitgt': 3.6.1
       '@itwin/core-quantity': 3.6.1_@itwin+core-bentley@3.6.1
       '@itwin/core-react': 3.6.1_c1200f78e7794c610fc6d7a00f23b599
-      '@itwin/eslint-plugin': 3.6.1_eslint@7.32.0+typescript@4.8.4
+      '@itwin/eslint-plugin': 3.6.1_eslint@7.32.0+typescript@4.5.5
       '@itwin/imodel-components-react': 3.6.1_c4d89ce21e4101355356fa6502cf443d
       '@itwin/presentation-common': 3.6.1_9c79d62e02daad891eb3d5514837e4b9
       '@itwin/presentation-frontend': 3.6.1_0c0acd4fe7e30ef67a491ed12173564d
@@ -332,7 +332,7 @@ importers:
       '@types/node': 14.18.12
       '@types/react': 17.0.44
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.62.0_eslint@7.32.0+typescript@4.5.5
       cpx2: 3.0.2
       eslint: 7.32.0
       jest: 27.5.1
@@ -344,9 +344,9 @@ importers:
       react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       redux: 4.1.2
       rimraf: 3.0.2
-      ts-jest: 27.1.4_3e98952c91d0ad38e7beba6fb8181295
+      ts-jest: 27.1.4_e895f328252188a9ef9395e8fdc8fccc
       typemoq: 2.1.0
-      typescript: 4.8.4
+      typescript: 4.5.5
 
   ../../packages/itwin/geo-tools:
     specifiers:
@@ -549,7 +549,7 @@ importers:
       sinon: ^7.5.0
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ^4.5.0
+      typescript: ~4.5.0
     dependencies:
       '@dnd-kit/core': 6.0.5_react-dom@17.0.2+react@17.0.2
       '@dnd-kit/sortable': 7.0.1_@dnd-kit+core@6.0.5+react@17.0.2
@@ -583,7 +583,7 @@ importers:
       '@itwin/core-react': 4.1.0_4ad6e8154b3716bdf782b5d5451595ad
       '@itwin/core-telemetry': 4.0.0_@itwin+core-geometry@4.0.0
       '@itwin/ecschema-metadata': 4.0.0_30ffdc5308dd22bc25a719275cab883f
-      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.8.4
+      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.5.5
       '@itwin/imodel-components-react': 4.1.0_78603e3e11bdd64decb4bbc2e9634747
       '@itwin/presentation-common': 4.0.0_b65abb2eba6f77a1811421d5706635e7
       '@itwin/presentation-components': 4.0.0_7e4e4521f20239b42e219ead84d17bda
@@ -603,8 +603,8 @@ importers:
       '@types/react-table': 7.7.10
       '@types/sinon': 7.5.2
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.19.0_1ae3bbb68a9afeba62062669d8d58174
-      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.19.0_a8023c488b04c563b8304dd7b58080f4
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.5.5
       chai: 4.3.6
       cpx2: 3.0.2
       eslint: 7.32.0
@@ -622,9 +622,9 @@ importers:
       redux: 4.1.2
       rimraf: 3.0.2
       sinon: 7.5.0
-      ts-jest: 27.1.4_b923098489636dcff574df1a610aba95
+      ts-jest: 27.1.4_8fa130d172bf7d71653f05507c50c5a3
       typemoq: 2.1.0
-      typescript: 4.8.4
+      typescript: 4.5.5
 
   ../../packages/itwin/imodel-react-hooks:
     specifiers:
@@ -1184,7 +1184,7 @@ importers:
       simple-react-validator: ^1.6.1
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ^4.5.0
+      typescript: ~4.5.0
       xmlhttprequest: ^1.8.0
     dependencies:
       '@itwin/imodels-access-frontend': 4.0.4_87470ce6503c5fb6443995f18c22e7bd
@@ -1210,7 +1210,7 @@ importers:
       '@itwin/core-orbitgt': 4.0.6
       '@itwin/core-quantity': 4.0.6_@itwin+core-bentley@4.0.6
       '@itwin/core-react': 4.3.0_ee36221829551e48b04f84197abaa039
-      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.8.4
+      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.5.5
       '@itwin/imodel-components-react': 4.3.0_74a15eae6395feb7815d2443954bbd28
       '@itwin/presentation-common': 4.0.0_ba3cb7d223ce459cd163e7ffe7ae5424
       '@itwin/presentation-frontend': 4.0.0_11c73f855a02b231999953b253489c51
@@ -1227,8 +1227,8 @@ importers:
       '@types/react-dom': 17.0.15
       '@types/react-table': 7.7.10
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.19.0_1ae3bbb68a9afeba62062669d8d58174
-      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.19.0_a8023c488b04c563b8304dd7b58080f4
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.5.5
       chai: 4.3.6
       cpx2: 3.0.2
       eslint: 7.32.0
@@ -1244,9 +1244,9 @@ importers:
       react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       redux: 4.1.2
       rimraf: 3.0.2
-      ts-jest: 27.1.4_b923098489636dcff574df1a610aba95
+      ts-jest: 27.1.4_8fa130d172bf7d71653f05507c50c5a3
       typemoq: 2.1.0
-      typescript: 4.8.4
+      typescript: 4.5.5
       xmlhttprequest: 1.8.0
 
   ../../packages/itwin/tree-widget:
@@ -5934,19 +5934,19 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/eslint-plugin/3.6.1_eslint@7.32.0+typescript@4.8.4:
+  /@itwin/eslint-plugin/3.6.1_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-kqsjp318uc9CgB1XgZWAigTKFIVJhgQ72WnR4YsveZ0gfRFWfXz5/n8SslQOaQhRiy13AW13pKURM/q6/PQMWA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_05aa3c03a546068232566ecaed778be0
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 4.31.2_0a99a37e7bc46eb6a74f7e8d940075b8
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.5.5
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.7.1_ee2ddb12623c985c36290f985ad5559c
-      eslint-plugin-deprecation: 1.2.1_eslint@7.32.0+typescript@4.8.4
+      eslint-plugin-deprecation: 1.2.1_eslint@7.32.0+typescript@4.5.5
       eslint-plugin-import: 2.23.4_eslint@7.32.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
@@ -5955,7 +5955,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.32.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.32.0
       require-dir: 1.2.0
-      typescript: 4.8.4
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5986,19 +5986,19 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/eslint-plugin/3.7.8_eslint@7.32.0+typescript@4.8.4:
+  /@itwin/eslint-plugin/3.7.8_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-zPgGUZro3NZNH5CVCrzxy+Zyi0CucCMO3aYsPn8eaAvLQE1iqWt+M0XT+ih6FwZXRiHSrPhNrjTvP8cuFC96og==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_05aa3c03a546068232566ecaed778be0
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 4.31.2_0a99a37e7bc46eb6a74f7e8d940075b8
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.5.5
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.7.1_e1c9859ba2273375f63f636e4f560b52
-      eslint-plugin-deprecation: 1.4.1_eslint@7.32.0+typescript@4.8.4
+      eslint-plugin-deprecation: 1.4.1_eslint@7.32.0+typescript@4.5.5
       eslint-plugin-import: 2.27.5_eslint@7.32.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
@@ -6007,7 +6007,7 @@ packages:
       eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       require-dir: 1.2.0
-      typescript: 4.8.4
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9386,7 +9386,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/4.31.2_05aa3c03a546068232566ecaed778be0:
+  /@typescript-eslint/eslint-plugin/4.31.2_0a99a37e7bc46eb6a74f7e8d940075b8:
     resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -9397,16 +9397,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.32.0+typescript@4.8.4
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.32.0+typescript@4.5.5
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.5.5
       '@typescript-eslint/scope-manager': 4.31.2
       debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9486,33 +9486,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.19.0_1ae3bbb68a9afeba62062669d8d58174:
-    resolution: {integrity: sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
-      '@typescript-eslint/scope-manager': 5.19.0
-      '@typescript-eslint/type-utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
-      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
-      debug: 4.3.4
-      eslint: 7.32.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/5.19.0_316196ac7fa871a145624422293381c8:
     resolution: {integrity: sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9563,6 +9536,33 @@ packages:
       semver: 7.3.7
       tsutils: 3.21.0_typescript@4.3.5
       typescript: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.19.0_a8023c488b04c563b8304dd7b58080f4:
+    resolution: {integrity: sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.5.5
+      '@typescript-eslint/scope-manager': 5.19.0
+      '@typescript-eslint/type-utils': 5.19.0_eslint@7.32.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.5.5
+      debug: 4.3.4
+      eslint: 7.32.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9703,7 +9703,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.62.0_eslint@7.32.0+typescript@4.8.4:
+  /@typescript-eslint/eslint-plugin/5.62.0_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9716,16 +9716,16 @@ packages:
     dependencies:
       '@eslint-community/regexpp': 4.5.0
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/type-utils': 5.62.0_eslint@7.32.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.5.5
       debug: 4.3.4
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9764,6 +9764,23 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.5.5
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9773,23 +9790,6 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.6.3
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -9834,6 +9834,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 4.31.2
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.5.5
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9844,24 +9862,6 @@ packages:
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
       '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.6.3
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 4.31.2
-      '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -9923,6 +9923,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/4.31.2_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.31.2
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.5.5
+      debug: 4.3.4
+      eslint: 7.32.0
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/4.31.2_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9939,26 +9959,6 @@ packages:
       debug: 4.3.4
       eslint: 7.32.0
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser/4.31.2_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.31.2
-      '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.8.4
-      debug: 4.3.4
-      eslint: 7.32.0
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9983,7 +9983,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.19.0_eslint@7.32.0+typescript@4.8.4:
+  /@typescript-eslint/parser/5.19.0_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9995,10 +9995,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.19.0
       '@typescript-eslint/types': 5.19.0
-      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.5.5
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.8.4
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10168,6 +10168,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.19.0_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.5.5
+      debug: 4.3.4
+      eslint: 7.32.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/type-utils/5.19.0_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10183,25 +10202,6 @@ packages:
       eslint: 7.32.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils/5.19.0_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
-      debug: 4.3.4
-      eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10285,7 +10285,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.62.0_eslint@7.32.0+typescript@4.8.4:
+  /@typescript-eslint/type-utils/5.62.0_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10295,12 +10295,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.8.4
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.5.5
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.5.5
       debug: 4.3.4
       eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10388,6 +10388,28 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.5.5:
+    resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/visitor-keys': 3.10.1
+      debug: 4.3.4
+      glob: 7.2.0
+      is-glob: 4.0.3
+      lodash: 4.17.21
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/3.10.1_typescript@4.6.3:
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -10406,28 +10428,6 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.8.4:
-    resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/visitor-keys': 3.10.1
-      debug: 4.3.4
-      glob: 7.2.0
-      is-glob: 4.0.3
-      lodash: 4.17.21
-      semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10474,6 +10474,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.5.5:
+    resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/visitor-keys': 4.31.2
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/4.31.2_typescript@4.6.3:
     resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -10491,27 +10512,6 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.8.4:
-    resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/visitor-keys': 4.31.2
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10578,6 +10578,27 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/typescript-estree/5.19.0_typescript@4.5.5:
+    resolution: {integrity: sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.19.0
+      '@typescript-eslint/visitor-keys': 5.19.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.19.0_typescript@4.6.3:
     resolution: {integrity: sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10595,27 +10616,6 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/5.19.0_typescript@4.8.4:
-    resolution: {integrity: sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.19.0
-      '@typescript-eslint/visitor-keys': 5.19.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10725,7 +10725,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.62.0_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree/5.62.0_typescript@4.5.5:
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10740,8 +10740,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10803,6 +10803,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.19.0_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.19.0
+      '@typescript-eslint/types': 5.19.0
+      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.5.5
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/utils/5.19.0_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10813,24 +10831,6 @@ packages:
       '@typescript-eslint/scope-manager': 5.19.0
       '@typescript-eslint/types': 5.19.0
       '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.6.3
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.19.0_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.19.0
-      '@typescript-eslint/types': 5.19.0
-      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -10957,7 +10957,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.62.0_eslint@7.32.0+typescript@4.8.4:
+  /@typescript-eslint/utils/5.62.0_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10968,7 +10968,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.5.5
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -14483,6 +14483,21 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-plugin-deprecation/1.2.1_eslint@7.32.0+typescript@4.5.5:
+    resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0
+      typescript: ^3.7.5 || ^4.0.0
+    dependencies:
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.32.0+typescript@4.5.5
+      eslint: 7.32.0
+      tslib: 1.14.1
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-deprecation/1.2.1_eslint@7.32.0+typescript@4.6.3:
     resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
@@ -14494,21 +14509,6 @@ packages:
       tslib: 1.14.1
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-plugin-deprecation/1.2.1_eslint@7.32.0+typescript@4.8.4:
-    resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-      typescript: ^3.7.5 || ^4.0.0
-    dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.32.0+typescript@4.8.4
-      eslint: 7.32.0
-      tslib: 1.14.1
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14528,17 +14528,17 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-deprecation/1.4.1_eslint@7.32.0+typescript@4.8.4:
+  /eslint-plugin-deprecation/1.4.1_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-4vxTghWzxsBukPJVQupi6xlTuDc8Pyi1QlRCrFiLgwLPMJQW3cJCNaehJUKQqQFvuue5m4W27e179Y3Qjzeghg==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: ^3.7.5 || ^4.0.0 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.5.5
       eslint: 7.32.0
       tslib: 2.3.1
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -23931,41 +23931,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.4_3e98952c91d0ad38e7beba6fb8181295:
-    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@types/jest': 27.5.2
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.8.4
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest/27.1.4_b923098489636dcff574df1a610aba95:
+  /ts-jest/27.1.4_8fa130d172bf7d71653f05507c50c5a3:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -23995,7 +23961,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.7
-      typescript: 4.8.4
+      typescript: 4.5.5
       yargs-parser: 20.2.9
     dev: true
 
@@ -24065,6 +24031,40 @@ packages:
       make-error: 1.3.6
       semver: 7.3.7
       typescript: 4.3.5
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest/27.1.4_e895f328252188a9ef9395e8fdc8fccc:
+    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@types/jest': 27.5.2
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.5.5
       yargs-parser: 20.2.9
     dev: true
 
@@ -24139,6 +24139,16 @@ packages:
       tslib: 1.14.1
       typescript: 4.4.4
 
+  /tsutils/3.21.0_typescript@4.5.5:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.5.5
+    dev: true
+
   /tsutils/3.21.0_typescript@4.6.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -24147,16 +24157,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.6.3
-    dev: true
-
-  /tsutils/3.21.0_typescript@4.8.4:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.8.4
     dev: true
 
   /tsutils/3.21.0_typescript@5.0.4:
@@ -24323,6 +24323,12 @@ packages:
     resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+
+  /typescript/4.5.5:
+    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
 
   /typescript/4.6.3:
     resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       '@itwin/appui-abstract': 4.0.6_@itwin+core-bentley@4.0.6
       '@itwin/appui-layout-react': 4.3.0_a15530b1b218cc32d3ec6ade15225a27
       '@itwin/appui-react': 4.3.0_95010a99ad239167390c73a26ef3edcc
-      '@itwin/breakdown-trees-react': file:../../packages/itwin/breakdown-trees_c8d1880a3dfbfaf90f7998cb5612f14a
+      '@itwin/breakdown-trees-react': file:../../packages/itwin/breakdown-trees_451630d9dd21b50ff8e51a4ff2762962
       '@itwin/browser-authorization': 0.8.0_@itwin+core-bentley@4.0.6
       '@itwin/components-react': 4.3.0_a15530b1b218cc32d3ec6ade15225a27
       '@itwin/core-bentley': 4.0.6
@@ -297,7 +297,7 @@ importers:
       simple-react-validator: ^1.6.1
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ~4.3.0
+      typescript: ^4.5.0
     dependencies:
       '@itwin/insights-client': 0.4.0
       '@itwin/itwinui-icons-react': 1.15.1_react-dom@17.0.2+react@17.0.2
@@ -319,7 +319,7 @@ importers:
       '@itwin/core-orbitgt': 3.6.1
       '@itwin/core-quantity': 3.6.1_@itwin+core-bentley@3.6.1
       '@itwin/core-react': 3.6.1_c1200f78e7794c610fc6d7a00f23b599
-      '@itwin/eslint-plugin': 3.6.1_eslint@7.32.0+typescript@4.3.5
+      '@itwin/eslint-plugin': 3.6.1_eslint@7.32.0+typescript@4.8.4
       '@itwin/imodel-components-react': 3.6.1_c4d89ce21e4101355356fa6502cf443d
       '@itwin/presentation-common': 3.6.1_9c79d62e02daad891eb3d5514837e4b9
       '@itwin/presentation-frontend': 3.6.1_0c0acd4fe7e30ef67a491ed12173564d
@@ -332,7 +332,7 @@ importers:
       '@types/node': 14.18.12
       '@types/react': 17.0.44
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.62.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 5.62.0_eslint@7.32.0+typescript@4.8.4
       cpx2: 3.0.2
       eslint: 7.32.0
       jest: 27.5.1
@@ -344,9 +344,9 @@ importers:
       react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       redux: 4.1.2
       rimraf: 3.0.2
-      ts-jest: 27.1.4_9c2bb0de79d00985140535e369b1df3e
+      ts-jest: 27.1.4_3e98952c91d0ad38e7beba6fb8181295
       typemoq: 2.1.0
-      typescript: 4.3.5
+      typescript: 4.8.4
 
   ../../packages/itwin/geo-tools:
     specifiers:
@@ -549,7 +549,7 @@ importers:
       sinon: ^7.5.0
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ~4.3.0
+      typescript: ^4.5.0
     dependencies:
       '@dnd-kit/core': 6.0.5_react-dom@17.0.2+react@17.0.2
       '@dnd-kit/sortable': 7.0.1_@dnd-kit+core@6.0.5+react@17.0.2
@@ -583,7 +583,7 @@ importers:
       '@itwin/core-react': 4.1.0_4ad6e8154b3716bdf782b5d5451595ad
       '@itwin/core-telemetry': 4.0.0_@itwin+core-geometry@4.0.0
       '@itwin/ecschema-metadata': 4.0.0_30ffdc5308dd22bc25a719275cab883f
-      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.3.5
+      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.8.4
       '@itwin/imodel-components-react': 4.1.0_78603e3e11bdd64decb4bbc2e9634747
       '@itwin/presentation-common': 4.0.0_b65abb2eba6f77a1811421d5706635e7
       '@itwin/presentation-components': 4.0.0_7e4e4521f20239b42e219ead84d17bda
@@ -603,8 +603,8 @@ importers:
       '@types/react-table': 7.7.10
       '@types/sinon': 7.5.2
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.19.0_725bf6bcf2ceaaf4f4f9385fbbfa4252
-      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 5.19.0_1ae3bbb68a9afeba62062669d8d58174
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
       chai: 4.3.6
       cpx2: 3.0.2
       eslint: 7.32.0
@@ -622,9 +622,9 @@ importers:
       redux: 4.1.2
       rimraf: 3.0.2
       sinon: 7.5.0
-      ts-jest: 27.1.4_d66bf574fe8cd4e531c57da2e08c8633
+      ts-jest: 27.1.4_b923098489636dcff574df1a610aba95
       typemoq: 2.1.0
-      typescript: 4.3.5
+      typescript: 4.8.4
 
   ../../packages/itwin/imodel-react-hooks:
     specifiers:
@@ -1184,7 +1184,7 @@ importers:
       simple-react-validator: ^1.6.1
       ts-jest: ^27.1.3
       typemoq: ^2.1.0
-      typescript: ~4.3.0
+      typescript: ^4.5.0
       xmlhttprequest: ^1.8.0
     dependencies:
       '@itwin/imodels-access-frontend': 4.0.4_87470ce6503c5fb6443995f18c22e7bd
@@ -1210,7 +1210,7 @@ importers:
       '@itwin/core-orbitgt': 4.0.6
       '@itwin/core-quantity': 4.0.6_@itwin+core-bentley@4.0.6
       '@itwin/core-react': 4.3.0_ee36221829551e48b04f84197abaa039
-      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.3.5
+      '@itwin/eslint-plugin': 3.7.8_eslint@7.32.0+typescript@4.8.4
       '@itwin/imodel-components-react': 4.3.0_74a15eae6395feb7815d2443954bbd28
       '@itwin/presentation-common': 4.0.0_ba3cb7d223ce459cd163e7ffe7ae5424
       '@itwin/presentation-frontend': 4.0.0_11c73f855a02b231999953b253489c51
@@ -1227,8 +1227,8 @@ importers:
       '@types/react-dom': 17.0.15
       '@types/react-table': 7.7.10
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.19.0_725bf6bcf2ceaaf4f4f9385fbbfa4252
-      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 5.19.0_1ae3bbb68a9afeba62062669d8d58174
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
       chai: 4.3.6
       cpx2: 3.0.2
       eslint: 7.32.0
@@ -1244,9 +1244,9 @@ importers:
       react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       redux: 4.1.2
       rimraf: 3.0.2
-      ts-jest: 27.1.4_d66bf574fe8cd4e531c57da2e08c8633
+      ts-jest: 27.1.4_b923098489636dcff574df1a610aba95
       typemoq: 2.1.0
-      typescript: 4.3.5
+      typescript: 4.8.4
       xmlhttprequest: 1.8.0
 
   ../../packages/itwin/tree-widget:
@@ -5934,19 +5934,19 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/eslint-plugin/3.6.1_eslint@7.32.0+typescript@4.3.5:
+  /@itwin/eslint-plugin/3.6.1_eslint@7.32.0+typescript@4.8.4:
     resolution: {integrity: sha512-kqsjp318uc9CgB1XgZWAigTKFIVJhgQ72WnR4YsveZ0gfRFWfXz5/n8SslQOaQhRiy13AW13pKURM/q6/PQMWA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_1ff229bad5b3f782209b865beb048324
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 4.31.2_05aa3c03a546068232566ecaed778be0
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.7.1_ee2ddb12623c985c36290f985ad5559c
-      eslint-plugin-deprecation: 1.2.1_eslint@7.32.0+typescript@4.3.5
+      eslint-plugin-deprecation: 1.2.1_eslint@7.32.0+typescript@4.8.4
       eslint-plugin-import: 2.23.4_eslint@7.32.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
@@ -5955,7 +5955,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.32.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.32.0
       require-dir: 1.2.0
-      typescript: 4.3.5
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5986,19 +5986,19 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/eslint-plugin/3.7.8_eslint@7.32.0+typescript@4.3.5:
+  /@itwin/eslint-plugin/3.7.8_eslint@7.32.0+typescript@4.8.4:
     resolution: {integrity: sha512-zPgGUZro3NZNH5CVCrzxy+Zyi0CucCMO3aYsPn8eaAvLQE1iqWt+M0XT+ih6FwZXRiHSrPhNrjTvP8cuFC96og==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_1ff229bad5b3f782209b865beb048324
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 4.31.2_05aa3c03a546068232566ecaed778be0
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.7.1_e1c9859ba2273375f63f636e4f560b52
-      eslint-plugin-deprecation: 1.4.1_eslint@7.32.0+typescript@4.3.5
+      eslint-plugin-deprecation: 1.4.1_eslint@7.32.0+typescript@4.8.4
       eslint-plugin-import: 2.27.5_eslint@7.32.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
@@ -6007,7 +6007,7 @@ packages:
       eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       require-dir: 1.2.0
-      typescript: 4.3.5
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9386,6 +9386,31 @@ packages:
     dev: true
     optional: true
 
+  /@typescript-eslint/eslint-plugin/4.31.2_05aa3c03a546068232566ecaed778be0:
+    resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^4.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/scope-manager': 4.31.2
+      debug: 4.3.4
+      eslint: 7.32.0
+      functional-red-black-tree: 1.0.1
+      regexpp: 3.2.0
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin/4.31.2_1ff229bad5b3f782209b865beb048324:
     resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9457,6 +9482,33 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.19.0_1ae3bbb68a9afeba62062669d8d58174:
+    resolution: {integrity: sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.19.0
+      '@typescript-eslint/type-utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      debug: 4.3.4
+      eslint: 7.32.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9651,7 +9703,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.62.0_eslint@7.32.0+typescript@4.3.5:
+  /@typescript-eslint/eslint-plugin/5.62.0_eslint@7.32.0+typescript@4.8.4:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9664,16 +9716,16 @@ packages:
     dependencies:
       '@eslint-community/regexpp': 4.5.0
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0_eslint@7.32.0+typescript@4.3.5
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/type-utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
       debug: 4.3.4
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9729,6 +9781,23 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.8.4
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.3.5:
     resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9775,6 +9844,24 @@ packages:
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
       '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.6.3
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 4.31.2
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -9856,6 +9943,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/4.31.2_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.31.2
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.8.4
+      debug: 4.3.4
+      eslint: 7.32.0
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/5.19.0_eslint@7.32.0+typescript@4.3.5:
     resolution: {integrity: sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9872,6 +9979,26 @@ packages:
       debug: 4.3.4
       eslint: 7.32.0
       typescript: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser/5.19.0_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.19.0
+      '@typescript-eslint/types': 5.19.0
+      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.8.4
+      debug: 4.3.4
+      eslint: 7.32.0
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10060,6 +10187,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.19.0_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.8.4
+      debug: 4.3.4
+      eslint: 7.32.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/type-utils/5.19.0_eslint@8.38.0+typescript@4.4.4:
     resolution: {integrity: sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10139,7 +10285,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.62.0_eslint@7.32.0+typescript@4.3.5:
+  /@typescript-eslint/type-utils/5.62.0_eslint@7.32.0+typescript@4.8.4:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10149,12 +10295,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.3.5
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.8.4
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
       debug: 4.3.4
       eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10264,6 +10410,28 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.8.4:
+    resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/visitor-keys': 3.10.1
+      debug: 4.3.4
+      glob: 7.2.0
+      is-glob: 4.0.3
+      lodash: 4.17.21
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/4.31.2_typescript@4.3.5:
     resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -10323,6 +10491,27 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.8.4:
+    resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.31.2
+      '@typescript-eslint/visitor-keys': 4.31.2
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10406,6 +10595,27 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.19.0_typescript@4.8.4:
+    resolution: {integrity: sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.19.0
+      '@typescript-eslint/visitor-keys': 5.19.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10494,27 +10704,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.62.0_typescript@4.3.5:
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.0
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.62.0_typescript@4.4.4:
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10532,6 +10721,27 @@ packages:
       semver: 7.5.0
       tsutils: 3.21.0_typescript@4.4.4
       typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.62.0_typescript@4.8.4:
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10603,6 +10813,24 @@ packages:
       '@typescript-eslint/scope-manager': 5.19.0
       '@typescript-eslint/types': 5.19.0
       '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.6.3
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.19.0_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.19.0
+      '@typescript-eslint/types': 5.19.0
+      '@typescript-eslint/typescript-estree': 5.19.0_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -10709,26 +10937,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.62.0_eslint@7.32.0+typescript@4.3.5:
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@7.32.0
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.3.5
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      semver: 7.5.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils/5.62.0_eslint@7.32.0+typescript@4.4.4:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10741,6 +10949,26 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.4.4
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      semver: 7.5.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.62.0_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0_eslint@7.32.0
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.8.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -14270,17 +14498,17 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-deprecation/1.4.1_eslint@7.32.0+typescript@4.3.5:
-    resolution: {integrity: sha512-4vxTghWzxsBukPJVQupi6xlTuDc8Pyi1QlRCrFiLgwLPMJQW3cJCNaehJUKQqQFvuue5m4W27e179Y3Qjzeghg==}
+  /eslint-plugin-deprecation/1.2.1_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: ^3.7.5 || ^4.0.0 || ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0
+      typescript: ^3.7.5 || ^4.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.32.0+typescript@4.8.4
       eslint: 7.32.0
-      tslib: 2.3.1
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tslib: 1.14.1
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14296,6 +14524,21 @@ packages:
       tslib: 2.3.1
       tsutils: 3.21.0_typescript@4.4.4
       typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-deprecation/1.4.1_eslint@7.32.0+typescript@4.8.4:
+    resolution: {integrity: sha512-4vxTghWzxsBukPJVQupi6xlTuDc8Pyi1QlRCrFiLgwLPMJQW3cJCNaehJUKQqQFvuue5m4W27e179Y3Qjzeghg==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: ^3.7.5 || ^4.0.0 || ^5.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0_eslint@7.32.0+typescript@4.8.4
+      eslint: 7.32.0
+      tslib: 2.3.1
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -23688,7 +23931,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.4_9c2bb0de79d00985140535e369b1df3e:
+  /ts-jest/27.1.4_3e98952c91d0ad38e7beba6fb8181295:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -23718,7 +23961,41 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.7
-      typescript: 4.3.5
+      typescript: 4.8.4
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest/27.1.4_b923098489636dcff574df1a610aba95:
+    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.8.4
       yargs-parser: 20.2.9
     dev: true
 
@@ -23870,6 +24147,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.6.3
+    dev: true
+
+  /tsutils/3.21.0_typescript@4.8.4:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.8.4
     dev: true
 
   /tsutils/3.21.0_typescript@5.0.4:
@@ -25227,11 +25514,11 @@ packages:
       react: 17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2
 
-  file:../../packages/itwin/breakdown-trees_c8d1880a3dfbfaf90f7998cb5612f14a:
+  file:../../packages/itwin/breakdown-trees_451630d9dd21b50ff8e51a4ff2762962:
     resolution: {directory: ../../packages/itwin/breakdown-trees, type: directory}
     id: file:../../packages/itwin/breakdown-trees
     name: '@itwin/breakdown-trees-react'
-    version: 0.6.3
+    version: 0.6.4
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-layout-react': ^4.3.0
@@ -25246,7 +25533,7 @@ packages:
       '@itwin/presentation-common': ^4.0.0
       '@itwin/presentation-components': ^4.0.0
       '@itwin/presentation-frontend': ^4.0.0
-      '@itwin/tree-widget-react': workspace:^1.0.0
+      '@itwin/tree-widget-react': workspace:^1.1.0
       react: ^17.0.0
       react-dom: ^17.0.0
       react-redux: 7.2.6
@@ -25383,7 +25670,7 @@ packages:
     resolution: {directory: ../../packages/itwin/property-grid, type: directory}
     id: file:../../packages/itwin/property-grid
     name: '@itwin/property-grid-react'
-    version: 1.0.1
+    version: 1.1.0
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0
@@ -25419,7 +25706,7 @@ packages:
     resolution: {directory: ../../packages/itwin/tree-widget, type: directory}
     id: file:../../packages/itwin/tree-widget
     name: '@itwin/tree-widget-react'
-    version: 1.0.0
+    version: 1.1.0
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0

--- a/packages/itwin/ec3-widget/package.json
+++ b/packages/itwin/ec3-widget/package.json
@@ -102,7 +102,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "~4.3.0"
+    "typescript": "^4.5.0"
   },
   "peerDependencies": {
     "@itwin/appui-abstract": "^3.2.0",

--- a/packages/itwin/ec3-widget/package.json
+++ b/packages/itwin/ec3-widget/package.json
@@ -102,7 +102,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "^4.5.0"
+    "typescript": "~4.5.0"
   },
   "peerDependencies": {
     "@itwin/appui-abstract": "^3.2.0",

--- a/packages/itwin/grouping-mapping-widget/package.json
+++ b/packages/itwin/grouping-mapping-widget/package.json
@@ -129,7 +129,7 @@
     "sinon": "^7.5.0",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "~4.3.0"
+    "typescript": "^4.5.0"
   },
   "peerDependencies": {
     "@itwin/appui-abstract": "^4.0.0",

--- a/packages/itwin/grouping-mapping-widget/package.json
+++ b/packages/itwin/grouping-mapping-widget/package.json
@@ -129,7 +129,7 @@
     "sinon": "^7.5.0",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "^4.5.0"
+    "typescript": "~4.5.0"
   },
   "peerDependencies": {
     "@itwin/appui-abstract": "^4.0.0",

--- a/packages/itwin/reports-config-widget/package.json
+++ b/packages/itwin/reports-config-widget/package.json
@@ -115,7 +115,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "~4.3.0",
+    "typescript": "^4.5.0",
     "xmlhttprequest": "^1.8.0"
   },
   "peerDependencies": {

--- a/packages/itwin/reports-config-widget/package.json
+++ b/packages/itwin/reports-config-widget/package.json
@@ -115,7 +115,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "typemoq": "^2.1.0",
-    "typescript": "^4.5.0",
+    "typescript": "~4.5.0",
     "xmlhttprequest": "^1.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumped TS version for G&M, ReportsConfig, and EC3 widgets to ^4.5.0 to support new syntax within iTwinJs.