### PR TITLE
Property grid: Correctly determine if element has parent

### DIFF
--- a/common/changes/@itwin/property-grid-react/property_grid_fix_ancestor_detection_2023-08-18-08-51.json
+++ b/common/changes/@itwin/property-grid-react/property_grid_fix_ancestor_detection_2023-08-18-08-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Correctly determine if element has parent element when both are instances of the same class.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/test/hooks/UseInstanceSelection.test.ts
+++ b/packages/itwin/property-grid/src/test/hooks/UseInstanceSelection.test.ts
@@ -19,10 +19,10 @@ import type { InstanceSelectionProps } from "../../hooks/UseInstanceSelection";
 describe("useInstanceSelection", () => {
   const imodel = {} as IModelConnection;
 
-  const parentKey: InstanceKey = { id: "0x1", className: "ParentClass" };
-  const childKey: InstanceKey = { id: "0x2", className: "ChildClass" };
-  const grandChildKey: InstanceKey = { id: "0x3", className: "GranChildClass" };
-  const noParentKey: InstanceKey = { id: "0x4", className: "NoParentElementClass" };
+  const parentKey: InstanceKey = { id: "0x1", className: "TestClass" };
+  const childKey: InstanceKey = { id: "0x2", className: "TestClass" };
+  const grandChildKey: InstanceKey = { id: "0x3", className: "TestClass" };
+  const noParentKey: InstanceKey = { id: "0x4", className: "TestClass" };
 
   let selectionManager: ReturnType<typeof stubSelectionManager>;
 


### PR DESCRIPTION
Property grid was incorrectly determining if element has parent which resulted in ancestor navigation not working.