### PR TITLE
fix test-viewer auth issues

### DIFF
--- a/apps/test-viewer/.env.template
+++ b/apps/test-viewer/.env.template
@@ -6,7 +6,8 @@ IMJS_AUTH_CLIENT_SCOPES = "imodelaccess:read imodels:read realitydata:read"
 IMJS_AUTH_AUTHORITY= "https://ims.bentley.com"
 
 # ---- Demo client with demo imodels can be used instead
-IMJS_DEMO_CLIENT=false
+# ---- Set to true or leave blank
+IMJS_DEMO_CLIENT=
 
 # ---- Test ids ----
 IMJS_ITWIN_ID = ""


### PR DESCRIPTION
- Promises for auth methods need to be awaited for their rejections to be caught.
- Since .env file booleans are strings, IMJS_DEMO_CLIENT's `"false"` was being interpreted as truthy. Make undefined the default.