### PR TITLE
Fix an issue in the 'Add New Layer' dialog where invalid credentials warning would not appear after a first invalid attempt

### DIFF
--- a/common/changes/@itwin/map-layers/geo-fix_invalidCreds_ui_2023-10-20-15-18.json
+++ b/common/changes/@itwin/map-layers/geo-fix_invalidCreds_ui_2023-10-20-15-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "Fix an issue in the 'Add New Layer' dialog where invalid credentials warning would not appear after a first invalid attempt.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -165,7 +165,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   // return true if authorization is needed
   const updateAuthState = React.useCallback(async (source: MapLayerSource, sourceValidation: MapLayerSourceValidation) => {
     const sourceRequireAuth = (sourceValidation.status === MapLayerSourceStatus.RequireAuth);
-    const invalidCredentials = (sourceValidation.status === MapLayerSourceStatus.InvalidCredentials);
+    let invalidCredentials = (sourceValidation.status === MapLayerSourceStatus.InvalidCredentials);
     if (sourceRequireAuth) {
       const settings = source.toLayerSettings();
 
@@ -180,6 +180,9 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
         } catch (_error) {
 
         }
+      } else if (userName.length > 0 || password.length > 0 ) {
+        // This is a patch until @itwin\core-frontend return the expected 'InvalidCredentials' status.
+        invalidCredentials = true;
       }
 
     }
@@ -191,7 +194,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
     }
 
     return sourceRequireAuth || invalidCredentials;
-  }, [accessClient, invalidCredentialsProvided]);
+  }, [accessClient, invalidCredentialsProvided, password.length, userName.length]);
 
   const onNameChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setMapName(event.target.value);

--- a/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -181,7 +181,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
 
         }
       } else if (userName.length > 0 || password.length > 0 ) {
-        // This is a patch until @itwin\core-frontend return the expected 'InvalidCredentials' status.
+        // This is a patch until @itwin\core-frontend return the expected 'InvalidCredentials' status .
         invalidCredentials = true;
       }
 


### PR DESCRIPTION
Make sure the credentials warning is correctly displayed after an 'ArcGIS' map-layer (so the first time, but also after an invalid attempt):
![image](https://github.com/iTwin/viewer-components-react/assets/8309609/f3d40578-0550-4633-b553-8aa2f4d0b566)

This is needed because `@itwin\core-frontend` package doesn't return the appropriate `InvalidCredentials` status after an invalid attempt.
