### PR TITLE
Fix flaky test in property-grid

### DIFF
--- a/common/changes/@itwin/property-grid-react/property-grid-fix-flaky-test_2023-11-14-14-03.json
+++ b/common/changes/@itwin/property-grid-react/property-grid-fix-flaky-test_2023-11-14-14-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/property-grid-react",
+      "comment": "Fix flaky test.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/property-grid-react"
+}

--- a/packages/itwin/property-grid/src/test/components/PropertyGridContent.test.tsx
+++ b/packages/itwin/property-grid/src/test/components/PropertyGridContent.test.tsx
@@ -149,14 +149,12 @@ describe("<PropertyGridContent />", () => {
       <PropertyGridContent
         dataProvider={provider}
         imodel={imodel}
-        settingsMenuItems={[
-          (props) => <ShowHideNullValuesSettingsMenuItem {...props} />,
-        ]}
       />
     );
 
     await waitFor(() => {
-      expect(queryByText("Test Category")).to.not.be.null;
+      expect(queryByText("Test Prop")).to.not.be.null;
+      expect(queryByText("Null Prop")).to.not.be.null;
     });
 
     const searchButton = await waitFor(() => getByTitle(PropertyGridManager.translate("search-bar.open")));
@@ -164,16 +162,19 @@ describe("<PropertyGridContent />", () => {
 
     const searchTextInput =  await waitFor(() => getByRole("searchbox"));
     // input text that should match
-    await user.type(searchTextInput, "test");
+    await user.type(searchTextInput, "test prop");
 
     await waitFor(() => {
-      expect(queryByText("Test Category")).to.not.be.null;
+      expect(queryByText("Test Prop")).to.not.be.null;
+      expect(queryByText("Null Prop")).to.be.null;
     });
 
     // input text that should not match
-    await user.type(searchTextInput, "input text for test");
+    await user.clear(searchTextInput);
+    await user.type(searchTextInput, "null prop");
     await waitFor(() => {
-      expect(queryByText("Test Category")).to.be.null;
+      expect(queryByText("Test Prop")).to.be.null;
+      expect(queryByText("Null Prop")).to.not.be.null;
     });
   });
 


### PR DESCRIPTION
Property filtering test seemed to be flaky on macOS machines. Although the reason for the test failing is unclear, this is an attempt to rewrite the test in a more robust way to reduce the chance of it being flaky.