### PR TITLE
[Map Layers] fix 'No active viewport or geo-located iModel available.' when viewport remounts

### DIFF
--- a/common/changes/@itwin/map-layers/fix-map-layers-remount_2023-12-18-17-19.json
+++ b/common/changes/@itwin/map-layers/fix-map-layers-remount_2023-12-18-17-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "ensure the isGeolocated runs when active viewport changes even if the onEcefLocationChanged has already fired",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.tsx
@@ -26,6 +26,8 @@ export function MapLayersWidget(props: MapLayersWidgetProps) {
 
   React.useEffect(() => {
     const updateIsGeoLocated = () => setIsGeoLocated(!!activeViewport?.iModel.isGeoLocated);
+    // call immediately in case the activeViewport changes after its iModel.onEcefLocationChanged has already emitted
+    updateIsGeoLocated();
     return activeViewport?.iModel.onEcefLocationChanged.addListener(updateIsGeoLocated);
   }, [activeViewport?.iModel]);
 


### PR DESCRIPTION
- fixes an issue where if the viewport remounts the map layers widget doesn't react correctly because it only updates the isGeolocated either on initial mount or when the `iModel.onEcefLocationChanged` fires
- solution is to run the `updateIsGeoLocated` routine that runs when `iModel.onEcefLocationChanged` fires immediately when the `activeViewport` changes
- see gif to illustrate the problem
![Recording 2023-12-18 at 11 12 53](https://github.com/iTwin/viewer-components-react/assets/25822334/d927e0bc-212a-4b0c-8672-3cd61f652b25)
