### PR TITLE
ModelsTree: move onNodeDoubleClick to ModelsTreeEventHandler

### DIFF
--- a/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
+++ b/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": " - Move `onNodeDoubleClick` event handling to newly added `ModelsTreeEventHandler`.\n - Expand `UseVisibilityTreeState` hook to support custom extensions of `VisibilityTreeEventHandler`.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "114080994+ViliusBa@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
+++ b/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": " - Move `onNodeDoubleClick` event handling to newly added `ModelsTreeEventHandler`.\n - Expand `UseVisibilityTreeState` hook to support custom extensions of `VisibilityTreeEventHandler`.",
+  "comment": " - Move `VisibilityTreeEventHandler.onNodeDoubleClick` event handler to newly added `ModelsTreeEventHandler`.\n - Expand `useVisibilityTreeState` hook to support custom `VisibilityTreeEventHandler`'s.",
   "packageName": "@itwin/tree-widget-react",
   "email": "114080994+ViliusBa@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/src/components/trees/VisibilityTreeEventHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/VisibilityTreeEventHandler.ts
@@ -10,12 +10,9 @@ import { Observable } from "rxjs";
 import { from } from "rxjs/internal/observable/from";
 import { map } from "rxjs/internal/operators/map";
 import { mergeMap } from "rxjs/internal/operators/mergeMap";
-import { IModelApp } from "@itwin/core-frontend";
 import { CheckBoxState } from "@itwin/core-react";
-import { NodeKey } from "@itwin/presentation-common";
-import { isPresentationTreeNodeItem, UnifiedSelectionTreeEventHandler } from "@itwin/presentation-components";
+import { UnifiedSelectionTreeEventHandler } from "@itwin/presentation-components";
 import { isPromiseLike } from "../utils/IsPromiseLike";
-import { ModelsTreeNodeType, ModelsVisibilityHandler } from "./models-tree/ModelsVisibilityHandler";
 
 import type { BeEvent, IDisposable } from "@itwin/core-bentley";
 import type {
@@ -23,7 +20,6 @@ import type {
   CheckboxStateChange,
   TreeCheckboxStateChangeEventArgs,
   TreeModelNode,
-  TreeNodeEventArgs,
   TreeNodeItem,
   TreeSelectionChange,
   TreeSelectionModificationEventArgs,
@@ -114,24 +110,6 @@ export class VisibilityTreeEventHandler extends UnifiedSelectionTreeEventHandler
     }
 
     return items.filter((item) => this._selectionPredicate!(item));
-  }
-
-  public override async onNodeDoubleClick({ nodeId }: TreeNodeEventArgs) {
-    const model = this.modelSource.getModel();
-    const node = model.getNode(nodeId);
-
-    if (
-      !node ||
-      !isPresentationTreeNodeItem(node.item) ||
-      ModelsVisibilityHandler.getNodeType(node.item) !== ModelsTreeNodeType.Element ||
-      !NodeKey.isInstancesNodeKey(node.item.key)
-    ) {
-      return;
-    }
-
-    const instanceIds = node.item.key.instanceKeys.map((instanceKey) => instanceKey.id);
-
-    await IModelApp.viewManager.selectedView?.zoomToElements(instanceIds);
   }
 
   public override onSelectionModified({ modifications }: TreeSelectionModificationEventArgs) {

--- a/packages/itwin/tree-widget/src/components/trees/common/UseVisibilityTreeState.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/common/UseVisibilityTreeState.tsx
@@ -30,7 +30,7 @@ export interface UseVisibilityTreeStateProps extends Omit<UsePresentationTreeSta
   onFilterChange?: (filteredDataProvider?: IFilteredPresentationTreeDataProvider, matchesCount?: number) => void;
   /** Callback that is used to determine if node can be selected. If not provided all nodes are selectable. */
   selectionPredicate?: VisibilityTreeSelectionPredicate;
-  /** Callback that can be used for passing a custom extension of VisibilityTreeEventHandler. Default is VisibilityTreeEventHandler. */
+  /** Factory for custom `VisibilityTreeEventHandler`. Defaults to `VisibilityTreeEventHandler`. */
   eventHandler?: (props: VisibilityTreeEventHandlerParams) => VisibilityTreeEventHandler;
 }
 
@@ -56,19 +56,13 @@ export function useVisibilityTreeState({
         return undefined;
       }
 
-      return (
-        (eventHandler &&
-          eventHandler({
-            nodeLoader: params.nodeLoader,
-            visibilityHandler,
-            selectionPredicate,
-          })) ??
-        new VisibilityTreeEventHandler({
-          nodeLoader: params.nodeLoader,
-          visibilityHandler,
-          selectionPredicate,
-        })
-      );
+      const eventHandlerProps: VisibilityTreeEventHandlerParams = {
+        nodeLoader: params.nodeLoader,
+        visibilityHandler,
+        selectionPredicate,
+      };
+
+      return eventHandler ? eventHandler(eventHandlerProps) : new VisibilityTreeEventHandler(eventHandlerProps);
     },
     [visibilityHandler, selectionPredicate, eventHandler],
   );

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -13,16 +13,17 @@ import { ClassGroupingOption } from "../common/Types";
 import { useVisibilityTreeState } from "../common/UseVisibilityTreeState";
 import { addCustomTreeNodeItemLabelRenderer, addTreeNodeItemCheckbox, combineTreeNodeItemCustomizations } from "../common/Utils";
 import { createVisibilityTreeRenderer, VisibilityTreeNoFilteredData } from "../VisibilityTreeRenderer";
+import { ModelsTreeEventHandler } from "./ModelsTreeEventHandler";
 import { ModelsVisibilityHandler, SubjectModelIdsCache } from "./ModelsVisibilityHandler";
 import { addModelsTreeNodeItemIcons, createRuleset, createSearchRuleset } from "./Utils";
 
+import type { VisibilityTreeEventHandlerParams } from "../VisibilityTreeEventHandler";
 import type { Ruleset, SingleSchemaClassSpecification } from "@itwin/presentation-common";
 import type { IModelConnection, Viewport } from "@itwin/core-frontend";
 import type { TreeNodeItem } from "@itwin/components-react";
 import type { IFilteredPresentationTreeDataProvider } from "@itwin/presentation-components";
 import type { BaseFilterableTreeProps } from "../common/Types";
 import type { ModelsTreeSelectionPredicate, ModelsVisibilityHandlerProps } from "./ModelsVisibilityHandler";
-
 const PAGING_SIZE = 20;
 
 /**
@@ -205,6 +206,7 @@ function useTreeState({
           : selectionPredicateRef.current(node.key, ModelsVisibilityHandler.getNodeType(node)),
       [],
     ),
+    eventHandler: useCallback((props: VisibilityTreeEventHandlerParams) => new ModelsTreeEventHandler(props), []),
   });
 }
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -206,8 +206,12 @@ function useTreeState({
           : selectionPredicateRef.current(node.key, ModelsVisibilityHandler.getNodeType(node)),
       [],
     ),
-    eventHandler: useCallback((props: VisibilityTreeEventHandlerParams) => new ModelsTreeEventHandler(props), []),
+    eventHandler: eventHandlerFactory,
   });
+}
+
+function eventHandlerFactory(props: VisibilityTreeEventHandlerParams) {
+  return new ModelsTreeEventHandler(props);
 }
 
 function useVisibilityHandler(

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeEventHandler.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeEventHandler.tsx
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module IModelComponents
+ */
+
+import { IModelApp } from "@itwin/core-frontend";
+import { NodeKey } from "@itwin/presentation-common";
+import { isPresentationTreeNodeItem } from "@itwin/presentation-components";
+import { VisibilityTreeEventHandler } from "../VisibilityTreeEventHandler";
+import { ModelsTreeNodeType, ModelsVisibilityHandler } from "./ModelsVisibilityHandler";
+
+import type { TreeNodeEventArgs } from "@itwin/components-react";
+export class ModelsTreeEventHandler extends VisibilityTreeEventHandler {
+  public override async onNodeDoubleClick({ nodeId }: TreeNodeEventArgs) {
+    const model = this.modelSource.getModel();
+    const node = model.getNode(nodeId);
+
+    if (
+      !node ||
+      !isPresentationTreeNodeItem(node.item) ||
+      ModelsVisibilityHandler.getNodeType(node.item) !== ModelsTreeNodeType.Element ||
+      !NodeKey.isInstancesNodeKey(node.item.key)
+    ) {
+      return;
+    }
+
+    const instanceIds = node.item.key.instanceKeys.map((instanceKey) => instanceKey.id);
+
+    await IModelApp.viewManager.selectedView?.zoomToElements(instanceIds);
+  }
+}

--- a/packages/itwin/tree-widget/src/test/trees/VisibilityTreeEventHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/VisibilityTreeEventHandler.test.ts
@@ -13,7 +13,7 @@ import { CheckBoxState } from "@itwin/core-react";
 import { waitFor } from "@testing-library/react";
 import { VisibilityTreeEventHandler } from "../../components/trees/VisibilityTreeEventHandler";
 import { flushAsyncOperations, TestUtils } from "../TestUtils";
-import { createCategoryNode, createElementNode, createModelNode, createSimpleTreeModelNode, createSubjectNode } from "./Common";
+import { createSimpleTreeModelNode } from "./Common";
 
 import type { AbstractTreeNodeLoaderWithProvider, CheckboxStateChange } from "@itwin/components-react";
 import type { PresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
@@ -174,41 +174,6 @@ describe("VisibilityTreeEventHandler", () => {
         await flushAsyncOperations();
       });
       expect(getVisibilityStatus).to.be.calledTwice;
-    });
-  });
-
-  describe("onNodeDoubleClick", () => {
-    [{ nodeItem: createSubjectNode() }, { nodeItem: createModelNode() }, { nodeItem: createCategoryNode() }].forEach(({ nodeItem }) => {
-      it(`does not call zoomToElement when node item is ${nodeItem.id} node.`, async () => {
-        const { nodeLoader, modelSource } = setupTreeModel(["testId"], nodeItem);
-        modelSource.modifyModel = () => {};
-        const eventHandler = createHandler(nodeLoader);
-
-        const zoomSpy = sinon.spy();
-        sinon.stub(IModelApp, "viewManager").get(() => ({ selectedView: { zoomToElements: zoomSpy } }));
-
-        await using(eventHandler, async (_) => {
-          await eventHandler.onNodeDoubleClick({ nodeId: "testId" });
-        });
-
-        expect(zoomSpy).to.not.be.called;
-      });
-    });
-
-    it(`calls zoomToElement when node is element node.`, async () => {
-      const { nodeLoader, modelSource } = setupTreeModel(["testId"], createElementNode());
-      modelSource.modifyModel = () => {};
-      const eventHandler = createHandler(nodeLoader);
-
-      const zoomSpy = sinon.spy();
-      sinon.stub(IModelApp, "viewManager").get(() => ({ selectedView: { zoomToElements: zoomSpy } }));
-
-      await using(eventHandler, async (_) => {
-        await waitFor(() => expect(getVisibilityStatus).to.be.calledOnce);
-        await eventHandler.onNodeDoubleClick({ nodeId: "testId" });
-      });
-
-      expect(zoomSpy).to.be.called;
     });
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeEventHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeEventHandler.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { EMPTY } from "rxjs";
+import sinon from "sinon";
+import { MutableTreeModel, TreeModelSource } from "@itwin/components-react";
+import { BeEvent, using } from "@itwin/core-bentley";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { ModelsTreeEventHandler } from "../../../components/trees/models-tree/ModelsTreeEventHandler";
+import { TestUtils } from "../../TestUtils";
+import { createCategoryNode, createElementNode, createModelNode, createSimpleTreeModelNode, createSubjectNode } from "../Common";
+
+import type { IVisibilityHandler, VisibilityChangeListener } from "../../../components/trees/VisibilityTreeEventHandler";
+import type { AbstractTreeNodeLoaderWithProvider } from "@itwin/components-react";
+import type { PresentationTreeDataProvider, PresentationTreeNodeItem } from "@itwin/presentation-components";
+import type { SelectionHandler } from "@itwin/presentation-frontend";
+
+describe("ModelsTreeEventHandler", () => {
+  const selectionHandlerStub = {
+    getSelection: () => {},
+  } as any as SelectionHandler;
+
+  const onVisibilityChange = new BeEvent<VisibilityChangeListener>();
+
+  const visibilityHandler = { onVisibilityChange } as IVisibilityHandler;
+
+  before(async () => {
+    await NoRenderApp.startup();
+    await TestUtils.initialize();
+  });
+
+  after(async () => {
+    TestUtils.terminate();
+    await IModelApp.shutdown();
+  });
+
+  afterEach(() => {
+    onVisibilityChange.clear();
+    sinon.restore();
+  });
+
+  function setupTreeModel(nodeIds: string[], item?: PresentationTreeNodeItem) {
+    const model = new MutableTreeModel();
+    model.setChildren(
+      undefined,
+      nodeIds.map((nodeId) => {
+        return { ...createSimpleTreeModelNode(nodeId), isLoading: false, item: item ?? createSimpleTreeModelNode("node-item") };
+      }),
+      0,
+    );
+    const modelSource = new TreeModelSource(model);
+
+    const nodeLoaderStub = {
+      loadNode: () => EMPTY,
+      modelSource,
+      dataProvider: {} as any as PresentationTreeDataProvider,
+    } as any as AbstractTreeNodeLoaderWithProvider<PresentationTreeDataProvider>;
+
+    return { modelSource, nodeLoader: nodeLoaderStub };
+  }
+
+  function createHandler(nodeLoader: AbstractTreeNodeLoaderWithProvider<PresentationTreeDataProvider>): ModelsTreeEventHandler {
+    return new ModelsTreeEventHandler({ visibilityHandler, nodeLoader, selectionHandler: selectionHandlerStub });
+  }
+
+  describe("onNodeDoubleClick", () => {
+    [{ nodeItem: createSubjectNode() }, { nodeItem: createModelNode() }, { nodeItem: createCategoryNode() }].forEach(({ nodeItem }) => {
+      it(`does not call zoomToElement when node item is ${nodeItem.id} node.`, async () => {
+        const { nodeLoader, modelSource } = setupTreeModel(["testId"], nodeItem);
+        modelSource.modifyModel = () => {};
+        const eventHandler = createHandler(nodeLoader);
+
+        const zoomSpy = sinon.spy();
+        sinon.stub(IModelApp, "viewManager").get(() => ({ selectedView: { zoomToElements: zoomSpy } }));
+
+        await using(eventHandler, async (_) => {
+          await eventHandler.onNodeDoubleClick({ nodeId: "testId" });
+        });
+
+        expect(zoomSpy).to.not.be.called;
+      });
+    });
+
+    it(`calls zoomToElement when node is element node.`, async () => {
+      const { nodeLoader, modelSource } = setupTreeModel(["testId"], createElementNode());
+      modelSource.modifyModel = () => {};
+      const eventHandler = createHandler(nodeLoader);
+
+      const zoomSpy = sinon.spy();
+      sinon.stub(IModelApp, "viewManager").get(() => ({ selectedView: { zoomToElements: zoomSpy } }));
+
+      await using(eventHandler, async (_) => {
+        await eventHandler.onNodeDoubleClick({ nodeId: "testId" });
+      });
+
+      expect(zoomSpy).to.be.called;
+    });
+  });
+});


### PR DESCRIPTION
This refactor was needed because having the current implementation in `VisibilityTreeEventHandler` would only work with `ModelsTree`, so creating a new `ModelsTreeEventHandler` which would hold logic that is specific for `ModelsTree` is more correct.