### PR TITLE
Fix map feature info widget tech preview badge

### DIFF
--- a/change/@itwin-map-layers-72a70bdf-2393-4315-8a88-420ab9ac81d2.json
+++ b/change/@itwin-map-layers-72a70bdf-2393-4315-8a88-420ab9ac81d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix map feature info widget tech preview badge",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
+++ b/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
@@ -60,7 +60,7 @@ export class FeatureInfoUiItemsProvider implements UiItemsProvider { // eslint-d
         icon: <SvgMapInfo/>,
         content: <MapFeatureInfoWidget featureInfoOpts={this._featureInfoOpts} />,
         defaultState: WidgetState.Hidden,
-        badgeType: BadgeType.TechnicalPreview,
+        badge: BadgeType.TechnicalPreview,
       });
     }
 


### PR DESCRIPTION
Incorrectly added tech preview badge with badgeType property instead of badge for the map feature info widget.