### PR TITLE
Tests fix imodel react hooks

### DIFF
--- a/change/@itwin-imodel-react-hooks-559d8d84-e1ad-466b-828f-993f7cef0338.json
+++ b/change/@itwin-imodel-react-hooks-559d8d84-e1ad-466b-828f-993f7cef0338.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing tests for imodel-react-hooks that were being skipped",
+  "packageName": "@itwin/imodel-react-hooks",
+  "email": "70723971+ben-bartholomew@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/imodel-react-hooks/src/FeatureOverrides/useFeatureOverrides.tsx
+++ b/packages/itwin/imodel-react-hooks/src/FeatureOverrides/useFeatureOverrides.tsx
@@ -4,10 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import type { FeatureOverrideProvider, FeatureSymbology, Viewport } from "@itwin/core-frontend";
+import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { IModelApp } from "@itwin/core-frontend";
-import React, { useContext, useEffect, useMemo, useRef } from "react";
-import { useCallback } from "react";
-
 import { useOnMountInRenderOrder } from "../utils/basic-hooks";
 import { makeContextWithProviderRequired } from "../utils/react-context";
 
@@ -116,14 +114,14 @@ export const FeatureOverrideReactProvider = ({
     };
     attach();
 
-    IModelApp.viewManager.onViewOpen.addListener(attach);
+    const removeListener = IModelApp.viewManager.onViewOpen.addListener(attach);
     return () => {
       for (const vp of IModelApp.viewManager) {
         if (!viewFilter || viewFilter(vp)) {
           vp.dropFeatureOverrideProvider(impl);
         }
       }
-      IModelApp.viewManager.onViewOpen.removeListener(attach);
+      removeListener();
     };
   }, [impl, viewFilter]);
 
@@ -147,7 +145,7 @@ export const FeatureOverrideReactProvider = ({
       },
       invalidate,
     }),
-    [providers, viewFilter]
+    [providers, invalidate]
   );
 
   return (

--- a/packages/itwin/imodel-react-hooks/src/utils/basic-hooks.ts
+++ b/packages/itwin/imodel-react-hooks/src/utils/basic-hooks.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 /** perform code on mount, executing in render order, which
  * effects cannot do.


### PR DESCRIPTION
Some of the tests for useFeatureOverrides in the package imodel-react-hooks were skipped during a previous upgrade. These changes fix and re-enable them.