### PR TITLE
Clean up E2E tests

### DIFF
--- a/change/@itwin-property-grid-react-bf921e2f-5414-4d27-97dc-23fdc3fdec97.json
+++ b/change/@itwin-property-grid-react-bf921e2f-5414-4d27-97dc-23fdc3fdec97.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "",
+  "packageName": "@itwin/property-grid-react",
+  "email": "114080994+ViliusBa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-tree-widget-react-da85ee4d-5dda-4be9-b4b5-00bc8fed76ed.json
+++ b/change/@itwin-tree-widget-react-da85ee4d-5dda-4be9-b4b5-00bc8fed76ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "114080994+ViliusBa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/itwin/property-grid/src/e2e-tests/PropertyGrid.test.ts
+++ b/packages/itwin/property-grid/src/e2e-tests/PropertyGrid.test.ts
@@ -100,13 +100,10 @@ test.describe("property grid", () => {
       const propertyWidget = await selectMultipleElements(page);
       await propertyWidget.getByTitle("Selected Elements").click();
 
-      const elementList = propertyWidget.locator(".property-grid-react-element-list").getByRole("list");
-      await elementList.getByText("BayTown", { exact: false }).first().click();
+      const elementList = propertyWidget.getByRole("list");
+      await elementList.getByRole("listitem").filter({ hasText: "BayTown" }).click();
 
-      // wait for element's label and values (use text that's not in elements' list)
-      const singleElementPropertyGrid = propertyWidget.locator(".property-grid-react-single-element-property-grid").first();
-      await singleElementPropertyGrid.getByText("Subject", { exact: false }).first().waitFor();
-      await singleElementPropertyGrid.getByText("Empty seed file.", { exact: false }).first().waitFor();
+      await propertyWidget.getByTitle("Empty seed file.").waitFor();
 
       return propertyWidget;
     };

--- a/packages/itwin/tree-widget/src/e2e-tests/TreeWidget.test.ts
+++ b/packages/itwin/tree-widget/src/e2e-tests/TreeWidget.test.ts
@@ -70,7 +70,7 @@ test.describe("should match image snapshot", () => {
     await locateInstanceFilter(page).waitFor();
     await selectPropertyInDialog(page, "Is Private");
 
-    await page.locator(".presentation-instance-filter-dialog-apply-button", { hasText: "Apply" }).click();
+    await page.getByRole("button", { name: "Apply" }).click();
 
     // hover the node for the button to appear
     await physicalModelNode.hover();
@@ -89,11 +89,14 @@ test.describe("should match image snapshot", () => {
     await locateInstanceFilter(page).waitFor();
     await selectPropertyInDialog(page, "Is Private");
 
-    await page.locator(".fb-row-condition", { hasText: "Is true" }).click();
+    await page
+      .getByRole("combobox")
+      .filter({ has: page.getByText("Is true") })
+      .click();
     await page.getByRole("option", { name: "Is true" }).waitFor();
     await page.getByRole("option", { name: "Is false" }).click();
 
-    await page.locator(".presentation-instance-filter-dialog-apply-button", { hasText: "Apply" }).click();
+    await page.getByRole("button", { name: "Apply" }).click();
 
     // hover the node for buttons to appear
     await physicalModelNode.hover();


### PR DESCRIPTION
Make sure no class selectors are used for playwright tests (where possible) as it is recommended [here](https://playwright.dev/docs/best-practices)