### PR TITLE
Tree Widget: 2.0.0 release

### DIFF
--- a/beachball.config.dev.js
+++ b/beachball.config.dev.js
@@ -7,8 +7,8 @@ const base = require("./beachball.config.js");
 /** @type {import("beachball").BeachballConfig } */
 module.exports = {
   ...base,
-  scope: ["packages/itwin/tree-widget"],
-  tag: "nightly",
+  scope: [],
+  tag: "dev",
   prereleasePrefix: "dev",
   generateChangelog: false,
 };

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -11,7 +11,6 @@ module.exports = {
   tag: "latest",
   scope: [
     "packages/itwin/*",
-    "!packages/itwin/tree-widget", // tree-widget is in pre-release mode and should be ignore when publishing using this config. Check `beachball.config.dev.js`
     "!packages/itwin/breakdown-trees", // disable breakdown-trees publishing. It has peer dep on tree-widget that requires to publish new major versions when tree-widget is published.
   ],
   ignorePatterns: [".nycrc", "eslint.config.js", ".mocharc.json", ".*ignore", ".github/**", ".vscode/**", "**/test/**", "**/e2e-tests/**", "pnpm-lock.yaml"],

--- a/change/@itwin-tree-widget-react-053a36cb-2a49-4484-bdf2-0c94c23bc560.json
+++ b/change/@itwin-tree-widget-react-053a36cb-2a49-4484-bdf2-0c94c23bc560.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Updated Tree Widget header and its content to be touch friendly when using expanded layout.",
   "packageName": "@itwin/tree-widget-react",
   "email": "33428304+jasdom@users.noreply.github.com",

--- a/change/@itwin-tree-widget-react-1c957e2b-02ee-429c-ad72-0c43ceb25106.json
+++ b/change/@itwin-tree-widget-react-1c957e2b-02ee-429c-ad72-0c43ceb25106.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "Update `@itwin/presentation-components` peer dependency to `5.x`",
-  "packageName": "@itwin/tree-widget-react",
-  "email": "35135765+grigasp@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@itwin-tree-widget-react-48e8e3cb-8c0b-47f6-9147-dc45ffdce4c8.json
+++ b/change/@itwin-tree-widget-react-48e8e3cb-8c0b-47f6-9147-dc45ffdce4c8.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "Bumped AppUI peer dependencies versions to `^4.6.0`.",
-  "packageName": "@itwin/tree-widget-react",
-  "email": "24278440+saskliutas@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@itwin-tree-widget-react-7f145c8e-65a7-435a-9735-a4442833b1d9.json
+++ b/change/@itwin-tree-widget-react-7f145c8e-65a7-435a-9735-a4442833b1d9.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "Bumped `@itwin/presentation-components` peer dependency version to `^4.4.0`.",
-  "packageName": "@itwin/tree-widget-react",
-  "email": "24278440+saskliutas@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@itwin-tree-widget-react-b0746289-e3af-475b-893b-497773f59ecd.json
+++ b/change/@itwin-tree-widget-react-b0746289-e3af-475b-893b-497773f59ecd.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": " Bumped `@itwin/presentation-components` peer dependency to `^5.0.0`.",
+  "comment": " Bumped `@itwin/presentation-components` peer dependency version to `^5.0.0`.",
   "packageName": "@itwin/tree-widget-react",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-dc8434b0-71cd-4bcd-b428-1276f2d395b6.json
+++ b/change/@itwin-tree-widget-react-dc8434b0-71cd-4bcd-b428-1276f2d395b6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "TreeWidget:\n - Allow opt-in to hierarchy level filtering using `isHierarchyLevelFilteringEnabled` flag for all trees.\n - Add support for `enlarged` nodes in non-visibility trees.",
+  "comment": "TreeWidget: Allow opt-in to hierarchy level filtering using `isHierarchyLevelFilteringEnabled` flag for all trees. Add support for `enlarged` nodes in non-visibility trees.",
   "packageName": "@itwin/tree-widget-react",
   "email": "114080994+ViliusBa@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-dfc7aed4-3057-49d7-95fe-34794fd3381b.json
+++ b/change/@itwin-tree-widget-react-dfc7aed4-3057-49d7-95fe-34794fd3381b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update `@itwin/itwinui-react` version to `2.12.19`.",
-  "packageName": "@itwin/tree-widget-react",
-  "email": "35135765+grigasp@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@itwin-tree-widget-react-e3e9d660-17ad-4b5b-8495-c52e3c75f375.json
+++ b/change/@itwin-tree-widget-react-e3e9d660-17ad-4b5b-8495-c52e3c75f375.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "Bumped AppUI peer dependency to `^4.10.0`.",
+  "comment": "Bumped AppUI peer dependencies version to `^4.10.0`.",
   "packageName": "@itwin/tree-widget-react",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
+++ b/change/@itwin-tree-widget-react-f47044a2-d045-4f8b-b4fa-3baf127320c9.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": " - Move `VisibilityTreeEventHandler.onNodeDoubleClick` event handler to newly added `ModelsTreeEventHandler`.\n - Expand `useVisibilityTreeState` hook to support custom `VisibilityTreeEventHandler`'s.",
+  "comment": "Move `VisibilityTreeEventHandler.onNodeDoubleClick` event handler to newly added `ModelsTreeEventHandler`. Expand `useVisibilityTreeState` hook to support custom `VisibilityTreeEventHandler`'s.",
   "packageName": "@itwin/tree-widget-react",
   "email": "114080994+ViliusBa@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-f668236d-535e-4729-b98f-7b57def39fec.json
+++ b/change/@itwin-tree-widget-react-f668236d-535e-4729-b98f-7b57def39fec.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "[Tree widget]: Fix possible `onCheckboxStateChanged` failure when multiple `rxjs` versions are present (#750)",
+  "comment": "Tree Widget: Fix possible `onCheckboxStateChanged` failure when multiple `rxjs` versions are present (#750)",
   "packageName": "@itwin/tree-widget-react",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "none"


### PR DESCRIPTION
Prepare `@itwin/tree-widget-react` from 2.0.0 major release. Changelog:

### Major changes

- Bumped AppUI peer dependencies version to `^4.10.0`. ([#789](https://github.com/itwin/viewer-components-react/pull/789))
-  Bumped `@itwin/presentation-components` peer dependency version to `^5.0.0`. ([#789](https://github.com/itwin/viewer-components-react/pull/789))
- Update `@itwin/itwinui-react` dependency to `3.x` ([#771](https://github.com/itwin/viewer-components-react/pull/771))

### Minor changes

- Updated Tree Widget header and its content to be touch friendly when using expanded layout. ([#782](https://github.com/itwin/viewer-components-react/pull/782))
- TreeWidget: Allow opt-in to hierarchy level filtering using `isHierarchyLevelFilteringEnabled` flag for all trees. Add support for `enlarged` nodes in non-visibility trees. ([#751](https://github.com/itwin/viewer-components-react/pull/751))
- Move `VisibilityTreeEventHandler.onNodeDoubleClick` event handler to newly added `ModelsTreeEventHandler`. Expand `useVisibilityTreeState` hook to support custom `VisibilityTreeEventHandler`'s. ([#741](https://github.com/itwin/viewer-components-react/pull/741))
- Added React 18 support. ([#728](https://github.com/itwin/viewer-components-react/pull/728))
- Models Tree: zoom to viewport element on node double-click. ([#704](https://github.com/itwin/viewer-components-react/pull/704))
- Tree Widget: allow opt-in to hierarchy level size limiting. ([#761](https://github.com/itwin/viewer-components-react/pull/761))

### Patches

- Models Tree: For all header actions only consider Models that model either `InformationPartitionElement` or `GeometricElement3d`. This should omit Models that are not displayed in the component. ([#738](https://github.com/itwin/viewer-components-react/pull/738))