### PR TITLE
Add extract-api step for the PR CI build

### DIFF
--- a/.pipelines/templates/build-steps.yaml
+++ b/.pipelines/templates/build-steps.yaml
@@ -20,5 +20,5 @@ steps:
   # - script: pnpm exec prettier . --check
   #   displayName: Check formatting
 
-  - script: pnpm exec lage lint cover extract-api --grouped
+  - script: pnpm exec lage lint extract-api cover --grouped
     displayName: Build, Lint, Cover and check for unexpected API changes

--- a/.pipelines/templates/build-steps.yaml
+++ b/.pipelines/templates/build-steps.yaml
@@ -20,11 +20,8 @@ steps:
   # - script: pnpm exec prettier . --check
   #   displayName: Check formatting
 
-  - script: pnpm exec lage lint cover --grouped
-    displayName: Build, Lint and Cover
-
-  - script: pnpm exec lage extract-api --grouped
-    displayName: Extract API
+  - script: pnpm exec lage lint cover extract-api --grouped
+    displayName: Build, Lint, Cover and check for unexpected API changes
     env:
-      # Fail the build if there are uncommitted API changes
+      # Fail the build if package uses api-extractor and there are uncommitted API changes
       TF_BUILD: 1

--- a/.pipelines/templates/build-steps.yaml
+++ b/.pipelines/templates/build-steps.yaml
@@ -22,6 +22,3 @@ steps:
 
   - script: pnpm exec lage lint cover extract-api --grouped
     displayName: Build, Lint, Cover and check for unexpected API changes
-    env:
-      # Fail the build if package uses api-extractor and there are uncommitted API changes
-      TF_BUILD: 1

--- a/.pipelines/templates/build-steps.yaml
+++ b/.pipelines/templates/build-steps.yaml
@@ -22,3 +22,9 @@ steps:
 
   - script: pnpm exec lage lint cover --grouped
     displayName: Build, Lint and Cover
+
+  - script: pnpm exec lage extract-api --grouped
+    displayName: Extract API
+    env:
+      # Fail the build if there are uncommitted API changes
+      TF_BUILD: 1

--- a/change/@itwin-property-grid-react-6141cefa-e559-437e-85ff-3904f0fd207e.json
+++ b/change/@itwin-property-grid-react-6141cefa-e559-437e-85ff-3904f0fd207e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add extract api step",
+  "packageName": "@itwin/property-grid-react",
+  "email": "yato333@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-property-grid-react-6141cefa-e559-437e-85ff-3904f0fd207e.json
+++ b/change/@itwin-property-grid-react-6141cefa-e559-437e-85ff-3904f0fd207e.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Add extract api step",
+  "comment": "",
   "packageName": "@itwin/property-grid-react",
   "email": "yato333@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@itwin-tree-widget-react-1de32109-0cd0-442d-8e17-ccf77b483c50.json
+++ b/change/@itwin-tree-widget-react-1de32109-0cd0-442d-8e17-ccf77b483c50.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Add extract api step",
+  "comment": "",
   "packageName": "@itwin/tree-widget-react",
   "email": "yato333@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@itwin-tree-widget-react-1de32109-0cd0-442d-8e17-ccf77b483c50.json
+++ b/change/@itwin-tree-widget-react-1de32109-0cd0-442d-8e17-ccf77b483c50.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add extract api step",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "yato333@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -31,7 +31,7 @@ module.exports = {
       inputs: ["src/**"],
     },
     "extract-api": {
-      dependsOn: [],
+      dependsOn: ["build"],
       outputs: ["./api/**"],
       inputs: ["src/**"],
     },

--- a/packages/itwin/property-grid/api/property-grid-react.api.md
+++ b/packages/itwin/property-grid/api/property-grid-react.api.md
@@ -12,7 +12,7 @@ import type { IModelConnection } from '@itwin/core-frontend';
 import type { InstanceKey } from '@itwin/presentation-common';
 import type { IPresentationPropertyDataProvider } from '@itwin/presentation-components';
 import type { IPropertyDataFilterer } from '@itwin/components-react';
-import type { Localization } from '@itwin/core-common';
+import { Localization } from '@itwin/core-common';
 import type { LocalizationOptions } from '@itwin/core-i18n';
 import type { PropertyCategory } from '@itwin/components-react';
 import type { PropertyDataFilterResult } from '@itwin/components-react';
@@ -75,7 +75,7 @@ export interface FavoritePropertiesContextMenuItemProps extends DefaultContextMe
 }
 
 // @internal
-export function FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildCategories, ...props }: FilteringPropertyGridProps): JSX.Element;
+export function FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildCategories, ...props }: FilteringPropertyGridProps): JSX.Element | null;
 
 // @public
 export interface FilteringPropertyGridProps extends VirtualizedPropertyGridWithDataProviderProps {
@@ -145,7 +145,7 @@ export interface PreferencesStorage {
 }
 
 // @public
-export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element;
+export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element | null;
 
 // @public
 export function PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null;
@@ -276,7 +276,7 @@ export interface SingleElementDataProviderProps extends DataProviderProps {
 }
 
 // @public
-export function SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element;
+export function SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element | null;
 
 // @public
 export type SingleElementPropertyGridProps = Omit<PropertyGridContentProps, "dataProvider" | "dataRenderer"> & SingleElementDataProviderProps;
@@ -298,7 +298,7 @@ export function useContextMenu({ dataProvider, imodel, contextMenuItems }: UseCo
 // @internal
 export function useDataProvider({ imodel, createDataProvider }: DataProviderProps & {
     imodel: IModelConnection;
-}): IPresentationPropertyDataProvider;
+}): IPresentationPropertyDataProvider | undefined;
 
 // @internal
 export function useInstanceSelection({ imodel }: InstanceSelectionProps): {

--- a/packages/itwin/property-grid/api/property-grid-react.api.md
+++ b/packages/itwin/property-grid/api/property-grid-react.api.md
@@ -137,6 +137,9 @@ export interface NullValueSettingContextValue {
 }
 
 // @public
+export type PerformanceTrackedFeatures = "properties-load" | "elements-list-load";
+
+// @public
 export interface PreferencesStorage {
     // (undocumented)
     get(key: string): Promise<string | undefined>;
@@ -148,10 +151,11 @@ export interface PreferencesStorage {
 export function PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element | null;
 
 // @public
-export function PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null;
+export function PropertyGridComponent({ preferencesStorage, onPerformanceMeasured, ...props }: PropertyGridComponentProps): JSX.Element | null;
 
 // @public
 export interface PropertyGridComponentProps extends Omit<MultiElementPropertyGridProps, "imodel"> {
+    onPerformanceMeasured?: (feature: PerformanceTrackedFeatures, elapsedTime: number) => void;
     preferencesStorage?: PreferencesStorage;
 }
 
@@ -280,6 +284,9 @@ export function SingleElementPropertyGrid({ instanceKey, createDataProvider, ...
 
 // @public
 export type SingleElementPropertyGridProps = Omit<PropertyGridContentProps, "dataProvider" | "dataRenderer"> & SingleElementDataProviderProps;
+
+// @public
+export function TelemetryContextProvider({ onPerformanceMeasured, children }: PropsWithChildren<TelemetryContextProviderProps>): JSX.Element;
 
 // @internal
 export interface UseContentMenuProps extends ContextMenuProps {

--- a/packages/itwin/property-grid/api/property-grid-react.exports.csv
+++ b/packages/itwin/property-grid/api/property-grid-react.exports.csv
@@ -19,9 +19,10 @@ internal;NonEmptyValuesPropertyDataFilterer
 internal;NoopPropertyDataFilterer 
 public;NullValueSettingContext({ children }: PropsWithChildren
 internal;NullValueSettingContextValue
+public;PerformanceTrackedFeatures = "properties-load" | "elements-list-load"
 public;PreferencesStorage
 public;PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element | null
-public;PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null
+public;PropertyGridComponent({ preferencesStorage, onPerformanceMeasured, ...props }: PropertyGridComponentProps): JSX.Element | null
 public;PropertyGridComponentProps 
 internal;PropertyGridContent({ dataProvider, imodel, contextMenuItems, className, onBackButton, headerControls, settingsMenuItems, dataRenderer, onPropertyUpdated, ...props }: PropertyGridContentProps): JSX.Element
 public;PropertyGridContentBaseProps 
@@ -47,6 +48,7 @@ internal;SHOWNULL_KEY = "showNullValues"
 public;SingleElementDataProviderProps 
 public;SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element | null
 public;SingleElementPropertyGridProps = Omit
+public;TelemetryContextProvider({ onPerformanceMeasured, children }: PropsWithChildren
 internal;UseContentMenuProps 
 internal;useContextMenu({ dataProvider, imodel, contextMenuItems }: UseContentMenuProps):
 internal;useDataProvider({ imodel, createDataProvider }: DataProviderProps &

--- a/packages/itwin/property-grid/api/property-grid-react.exports.csv
+++ b/packages/itwin/property-grid/api/property-grid-react.exports.csv
@@ -9,7 +9,7 @@ public;CopyPropertyTextContextMenuItem({ record, onSelect }: DefaultContextMenuI
 public;DataProviderProps
 public;DefaultContextMenuItemProps 
 public;FavoritePropertiesContextMenuItemProps 
-internal;FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildCategories, ...props }: FilteringPropertyGridProps): JSX.Element
+internal;FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildCategories, ...props }: FilteringPropertyGridProps): JSX.Element | null
 public;FilteringPropertyGridProps 
 public;IModelAppUserPreferencesStorage 
 internal;InstanceSelectionProps
@@ -20,7 +20,7 @@ internal;NoopPropertyDataFilterer
 public;NullValueSettingContext({ children }: PropsWithChildren
 internal;NullValueSettingContextValue
 public;PreferencesStorage
-public;PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element
+public;PropertyGrid({ createDataProvider, ...props }: PropertyGridProps): JSX.Element | null
 public;PropertyGridComponent({ preferencesStorage, ...props }: PropertyGridComponentProps): JSX.Element | null
 public;PropertyGridComponentProps 
 internal;PropertyGridContent({ dataProvider, imodel, contextMenuItems, className, onBackButton, headerControls, settingsMenuItems, dataRenderer, onPropertyUpdated, ...props }: PropertyGridContentProps): JSX.Element
@@ -45,7 +45,7 @@ public;ShowHideNullValuesSettingsMenuItem({ close, persist }: ShowHideNullValues
 public;ShowHideNullValuesSettingsMenuItemProps 
 internal;SHOWNULL_KEY = "showNullValues"
 public;SingleElementDataProviderProps 
-public;SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element
+public;SingleElementPropertyGrid({ instanceKey, createDataProvider, ...props }: SingleElementPropertyGridProps): JSX.Element | null
 public;SingleElementPropertyGridProps = Omit
 internal;UseContentMenuProps 
 internal;useContextMenu({ dataProvider, imodel, contextMenuItems }: UseContentMenuProps):

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -121,13 +121,13 @@ export class CategoryVisibilityHandler implements IVisibilityHandler {
     // (undocumented)
     enableSubCategory(key: string, enabled: boolean): void;
     // (undocumented)
-    getCategoryVisibility(id: string): "hidden" | "visible";
+    getCategoryVisibility(id: string): "visible" | "hidden";
     // (undocumented)
     static getInstanceIdFromTreeNodeKey(nodeKey: NodeKey): string;
     // (undocumented)
     getParent(key: string): CategoryInfo | undefined;
     // (undocumented)
-    getSubCategoryVisibility(id: string): "hidden" | "visible";
+    getSubCategoryVisibility(id: string): "visible" | "hidden";
     // (undocumented)
     getVisibilityStatus(node: TreeNodeItem): VisibilityStatus;
     // (undocumented)
@@ -168,7 +168,7 @@ export function createVisibilityTreeNodeRenderer({ levelOffset, disableRootNodeC
 export function createVisibilityTreeRenderer({ nodeRendererProps, ...restProps }: VisibilityTreeRendererProps): (treeProps: TreeRendererProps) => JSX.Element;
 
 // @public
-export function DefaultLabelRenderer({ label, context }: DefaultLabelRendererProps): JSX.Element;
+export function DefaultLabelRenderer({ label, context }: DefaultLabelRendererProps): React.JSX.Element;
 
 // @public
 export interface DefaultLabelRendererProps {
@@ -321,7 +321,7 @@ export enum ModelsTreeNodeType {
 // @public
 export interface ModelsTreeProps extends BaseFilterableTreeProps {
     activeView: Viewport;
-    // @alpha
+    // @alpha @deprecated
     enableHierarchyAutoUpdate?: boolean;
     hierarchyConfig?: ModelsTreeHierarchyConfiguration;
     // @beta
@@ -409,6 +409,8 @@ export function SelectableTree(props: SelectableTreeProps): JSX.Element | null;
 // @public
 export interface SelectableTreeProps {
     // (undocumented)
+    density?: "enlarged" | "default";
+    // (undocumented)
     trees: TreeDefinition[];
 }
 
@@ -451,7 +453,7 @@ export interface TreeContextMenuProps {
 export interface TreeDefinition {
     getLabel: () => string;
     id: string;
-    render: () => React.ReactNode;
+    render: (props: TreeRenderProps) => React.ReactNode;
     shouldShow?: (imodel: IModelConnection) => Promise<boolean>;
 }
 
@@ -497,6 +499,12 @@ export interface TreeRendererBaseProps extends TreeContextMenuProps, TreeNodeRen
 export type TreeRendererProps = TreeRendererProps_2 & TreeRendererBaseProps;
 
 // @public
+export interface TreeRenderProps {
+    // (undocumented)
+    density?: "enlarged" | "default";
+}
+
+// @public
 export class TreeWidget {
     static get i18n(): Localization;
     static get i18nNamespace(): string;
@@ -506,6 +514,9 @@ export class TreeWidget {
 }
 
 // @public
+export function TreeWidgetComponent(props: SelectableTreeProps): JSX.Element;
+
+// @public
 export const TreeWidgetId = "tree-widget-react:trees";
 
 // @public
@@ -513,6 +524,7 @@ export interface TreeWidgetOptions {
     defaultPanelLocation?: StagePanelLocation;
     defaultPanelSection?: StagePanelSection;
     defaultTreeWidgetPriority?: number;
+    density?: "enlarged" | "default";
     trees?: TreeDefinition[];
 }
 

--- a/packages/itwin/tree-widget/api/tree-widget-react.exports.csv
+++ b/packages/itwin/tree-widget/api/tree-widget-react.exports.csv
@@ -15,7 +15,7 @@ public;ClassGroupingOption
 public;ContextMenuItemProps
 public;createVisibilityTreeNodeRenderer({ levelOffset, disableRootNodeCollapse, descriptionEnabled, iconsEnabled, }: VisibilityTreeNodeRendererProps): (treeNodeProps: TreeNodeRendererProps_2) => JSX.Element
 public;createVisibilityTreeRenderer({ nodeRendererProps, ...restProps }: VisibilityTreeRendererProps): (treeProps: TreeRendererProps) => JSX.Element
-public;DefaultLabelRenderer({ label, context }: DefaultLabelRendererProps): JSX.Element
+public;DefaultLabelRenderer({ label, context }: DefaultLabelRendererProps): React.JSX.Element
 public;DefaultLabelRendererProps
 alpha;ExternalSourcesTree(props: ExternalSourcesTreeProps): JSX.Element | null
 alpha;ExternalSourcesTreeComponent:
@@ -69,7 +69,9 @@ public;TreeNodeRendererProps
 public;TreeRenderer({ contextMenuItems, nodeRenderer, nodeLabelRenderer, density, ...restProps }: TreeRendererProps): JSX.Element
 public;TreeRendererBaseProps 
 public;TreeRendererProps = TreeRendererProps_2 & TreeRendererBaseProps
+public;TreeRenderProps
 public;TreeWidget
+public;TreeWidgetComponent(props: SelectableTreeProps): JSX.Element
 public;TreeWidgetId = "tree-widget-react:trees"
 public;TreeWidgetOptions
 public;TreeWidgetUiItemsProvider 

--- a/packages/itwin/tree-widget/src/TreeWidget.ts
+++ b/packages/itwin/tree-widget/src/TreeWidget.ts
@@ -68,4 +68,8 @@ export class TreeWidget {
     const stringKey = `${TreeWidget.i18nNamespace}:${key}`;
     return TreeWidget.i18n.getLocalizedString(stringKey, options);
   }
+
+  public static test(): number {
+    return 42;
+  }
 }

--- a/packages/itwin/tree-widget/src/TreeWidget.ts
+++ b/packages/itwin/tree-widget/src/TreeWidget.ts
@@ -68,8 +68,4 @@ export class TreeWidget {
     const stringKey = `${TreeWidget.i18nNamespace}:${key}`;
     return TreeWidget.i18n.getLocalizedString(stringKey, options);
   }
-
-  public static test(): number {
-    return 42;
-  }
 }


### PR DESCRIPTION
Currently, some packages uses api-extractor tool, which helps to check for breaking API changes.
Added a build step that will fail if `pnpm extract-api` produces a result that differs from the one that is committed.