### PR TITLE
Tree Widget: Fix `ModelsTree` not changing visibility of child elements

### DIFF
--- a/change/@itwin-tree-widget-react-a643610a-60a7-4820-bcdf-c67d0579ca14.json
+++ b/change/@itwin-tree-widget-react-a643610a-60a7-4820-bcdf-c67d0579ca14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed `ModelsTree` not changing visibility for child elements.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/Utils.ts
@@ -185,28 +185,6 @@ export function createRuleset(props: CreateRulesetProps): Ruleset {
           },
         ],
       },
-      {
-        ruleType: "Content",
-        condition: `ContentDisplayType = "AssemblyElementsRequest"`,
-        specifications: [
-          {
-            specType: "SelectedNodeInstances",
-          },
-          {
-            specType: "ContentRelatedInstances",
-            relationshipPaths: [
-              {
-                relationship: {
-                  schemaName: "BisCore",
-                  className: "ElementOwnsChildElements",
-                },
-                direction: "Forward",
-                count: "*",
-              },
-            ],
-          },
-        ],
-      },
     ],
   };
 }

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.test.snap
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.test.snap
@@ -345,28 +345,6 @@ Object {
       ],
       "ruleType": "Grouping",
     },
-    Object {
-      "condition": "ContentDisplayType = \\"AssemblyElementsRequest\\"",
-      "ruleType": "Content",
-      "specifications": Array [
-        Object {
-          "specType": "SelectedNodeInstances",
-        },
-        Object {
-          "relationshipPaths": Array [
-            Object {
-              "count": "*",
-              "direction": "Forward",
-              "relationship": Object {
-                "className": "ElementOwnsChildElements",
-                "schemaName": "BisCore",
-              },
-            },
-          ],
-          "specType": "ContentRelatedInstances",
-        },
-      ],
-    },
   ],
 }
 `;
@@ -715,28 +693,6 @@ Object {
         },
       ],
       "ruleType": "Grouping",
-    },
-    Object {
-      "condition": "ContentDisplayType = \\"AssemblyElementsRequest\\"",
-      "ruleType": "Content",
-      "specifications": Array [
-        Object {
-          "specType": "SelectedNodeInstances",
-        },
-        Object {
-          "relationshipPaths": Array [
-            Object {
-              "count": "*",
-              "direction": "Forward",
-              "relationship": Object {
-                "className": "ElementOwnsChildElements",
-                "schemaName": "BisCore",
-              },
-            },
-          ],
-          "specType": "ContentRelatedInstances",
-        },
-      ],
     },
   ],
 }
@@ -1087,28 +1043,6 @@ Object {
       ],
       "ruleType": "Grouping",
     },
-    Object {
-      "condition": "ContentDisplayType = \\"AssemblyElementsRequest\\"",
-      "ruleType": "Content",
-      "specifications": Array [
-        Object {
-          "specType": "SelectedNodeInstances",
-        },
-        Object {
-          "relationshipPaths": Array [
-            Object {
-              "count": "*",
-              "direction": "Forward",
-              "relationship": Object {
-                "className": "ElementOwnsChildElements",
-                "schemaName": "BisCore",
-              },
-            },
-          ],
-          "specType": "ContentRelatedInstances",
-        },
-      ],
-    },
   ],
 }
 `;
@@ -1457,28 +1391,6 @@ Object {
         },
       ],
       "ruleType": "Grouping",
-    },
-    Object {
-      "condition": "ContentDisplayType = \\"AssemblyElementsRequest\\"",
-      "ruleType": "Content",
-      "specifications": Array [
-        Object {
-          "specType": "SelectedNodeInstances",
-        },
-        Object {
-          "relationshipPaths": Array [
-            Object {
-              "count": "*",
-              "direction": "Forward",
-              "relationship": Object {
-                "className": "ElementOwnsChildElements",
-                "schemaName": "BisCore",
-              },
-            },
-          ],
-          "specType": "ContentRelatedInstances",
-        },
-      ],
     },
   ],
 }


### PR DESCRIPTION
`@itwin/presentation-components` do not register ruleset anymore. Need to pass whole ruleset instead of id when loading instance keys for assembly elements.