### PR TITLE
Tree Widget: Cannot change visibility of newly inserted subject

### DIFF
--- a/change/@itwin-tree-widget-react-e7365ba7-b435-4360-9a77-85ab88ae7fa8.json
+++ b/change/@itwin-tree-widget-react-e7365ba7-b435-4360-9a77-85ab88ae7fa8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed subject node visibility not changing after new subject is inserted",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-e7365ba7-b435-4360-9a77-85ab88ae7fa8.json
+++ b/change/@itwin-tree-widget-react-e7365ba7-b435-4360-9a77-85ab88ae7fa8.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed subject node visibility not changing after new subject is inserted",
+  "comment": "Fixed newly inserted subject node visibility not changing",
   "packageName": "@itwin/tree-widget-react",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -458,6 +458,8 @@ export function showAllModels(models: string[], viewport: Viewport): Promise<voi
 export class SubjectModelIdsCache {
     constructor(imodel: IModelConnection);
     // (undocumented)
+    clear(): void;
+    // (undocumented)
     getSubjectModelIds(subjectId: Id64String): Promise<Id64String[]>;
 }
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTree.tsx
@@ -297,7 +297,6 @@ function useVisibilityHandler(
   iModel: IModelConnection,
   activeView: Viewport,
   visibilityHandler?: ModelsVisibilityHandler | ((props: ModelsVisibilityHandlerProps) => ModelsVisibilityHandler),
-  hierarchyAutoUpdateEnabled?: boolean,
 ) {
   const subjectModelIdsCache = useMemo(() => new SubjectModelIdsCache(iModel), [iModel]);
   const [state, setState] = useState<ModelsVisibilityHandler>();
@@ -310,7 +309,6 @@ function useVisibilityHandler(
     const visibilityHandlerProps: ModelsVisibilityHandlerProps = {
       rulesetId,
       viewport: activeView,
-      hierarchyAutoUpdateEnabled,
       subjectModelIdsCache,
     };
 
@@ -319,7 +317,7 @@ function useVisibilityHandler(
     return () => {
       handler.dispose();
     };
-  }, [rulesetId, activeView, hierarchyAutoUpdateEnabled, subjectModelIdsCache, visibilityHandler]);
+  }, [rulesetId, activeView, subjectModelIdsCache, visibilityHandler]);
 
   return visibilityHandler && typeof visibilityHandler !== "function" ? visibilityHandler : state;
 }

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -606,8 +606,8 @@ export class SubjectModelIdsCache {
 
   // istanbul ignore next
   public clear() {
-    this._subjectsHierarchy = undefined;
-    this._subjectModels = undefined;
+    this._subjectsHierarchy?.clear();
+    this._subjectModels?.clear();
     this._init = undefined;
   }
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -72,17 +72,15 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     this._listeners.push(this._props.viewport.onViewedModelsChanged.addListener(this.onViewChanged));
     this._listeners.push(this._props.viewport.onAlwaysDrawnChanged.addListener(this.onElementAlwaysDrawnChanged));
     this._listeners.push(this._props.viewport.onNeverDrawnChanged.addListener(this.onElementNeverDrawnChanged));
-    if (this._props.hierarchyAutoUpdateEnabled) {
-      this._listeners.push(
-        // eslint-disable-next-line @itwin/no-internal
-        Presentation.presentation.onIModelHierarchyChanged.addListener(
-          /* istanbul ignore next */ () => {
-            this._elementIdsCache.clear();
-            this._subjectModelIdsCache.clear();
-          },
-        ),
-      );
-    }
+    this._listeners.push(
+      // eslint-disable-next-line @itwin/no-internal
+      Presentation.presentation.onIModelHierarchyChanged.addListener(
+        /* istanbul ignore next */ () => {
+          this._elementIdsCache.clear();
+          this._subjectModelIdsCache.clear();
+        },
+      ),
+    );
   }
 
   public dispose() {

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -73,7 +73,15 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     this._listeners.push(this._props.viewport.onAlwaysDrawnChanged.addListener(this.onElementAlwaysDrawnChanged));
     this._listeners.push(this._props.viewport.onNeverDrawnChanged.addListener(this.onElementNeverDrawnChanged));
     if (this._props.hierarchyAutoUpdateEnabled) {
-      this._listeners.push(Presentation.presentation.onIModelHierarchyChanged.addListener(/* istanbul ignore next */ () => this._elementIdsCache.clear())); // eslint-disable-line @itwin/no-internal
+      this._listeners.push(
+        // eslint-disable-next-line @itwin/no-internal
+        Presentation.presentation.onIModelHierarchyChanged.addListener(
+          /* istanbul ignore next */ () => {
+            this._elementIdsCache.clear();
+            this._subjectModelIdsCache.clear();
+          },
+        ),
+      );
     }
   }
 
@@ -594,6 +602,13 @@ export class SubjectModelIdsCache {
     if (childSubjectIds) {
       childSubjectIds.forEach((cs) => this.appendSubjectModelsRecursively(modelIds, cs));
     }
+  }
+
+  // istanbul ignore next
+  public clear() {
+    this._subjectsHierarchy = undefined;
+    this._subjectModels = undefined;
+    this._init = undefined;
   }
 
   public async getSubjectModelIds(subjectId: Id64String): Promise<Id64String[]> {


### PR DESCRIPTION
Newly inserted subject visibility is not changing after clicking checkbox. Need to clear subject models cache after iModel is updated.