### PR TITLE
Tree widget: Fix Models tree hierarchy definition

### DIFF
--- a/change/@itwin-tree-widget-react-19b98ff9-0300-4234-b159-33ec66a1a5c5.json
+++ b/change/@itwin-tree-widget-react-19b98ff9-0300-4234-b159-33ec66a1a5c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
@@ -186,6 +186,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 grouping: { byLabel: { action: "merge", groupId: "subject" } },
                 extendedData: {
                   imageId: "icon-folder",
+                  isSubject: true,
                 },
                 supportsFiltering: true,
               })}
@@ -232,6 +233,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   hasChildren: true,
                   extendedData: {
                     imageId: "icon-model",
+                    isModel: true,
                   },
                   supportsFiltering: true,
                 })}


### PR DESCRIPTION
Add missing `isSubject` and `isModel` entries to nodes' extended data. Broken with https://github.com/iTwin/viewer-components-react/pull/849