### PR TITLE
[ReportsConfig] Report mapping extractions state fix

### DIFF
--- a/change/@itwin-reports-config-widget-react-24fa861a-d5b9-475e-b9f8-143e67464a4c.json
+++ b/change/@itwin-reports-config-widget-react-24fa861a-d5b9-475e-b9f8-143e67464a4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue that caused the extraction state for the mappings in the ReportMappings component to keep appearing after every rerender while in a final state.",
+  "packageName": "@itwin/reports-config-widget-react",
+  "email": "Guillar1@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -26,15 +26,12 @@ export interface ReportMappingHorizontalTileProps {
 
 export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTileProps) => {
   const [extractionState, setExtractionState] = useState<ExtractionStates>(ExtractionStates.None);
-  const [jobStarted, setJobStarted] = useState<boolean>(true);
   const interval = useRef<number>();
-  const initialLoad = useRef<boolean>(true);
 
   useEffect(() => {
     const listener = (startedIModelId: string) => {
       if (startedIModelId === props.mapping.imodelId) {
         setExtractionState(ExtractionStates.Starting);
-        setJobStarted(true);
       }
     };
     props.jobStartEvent.addListener(listener);
@@ -42,38 +39,43 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
     return () => {
       props.jobStartEvent.removeListener(listener);
     };
-  }, [props.jobStartEvent, props.mapping]);
+  }, [props.jobStartEvent, props.mapping.imodelId]);
 
   const getExtractionState = useCallback(async () => {
-    const state = await props.bulkExtractor.getIModelState(props.mapping.imodelId, props.mapping.iModelName, props.odataFeedUrl);
-    if (state === ExtractionStates.Failed || state === ExtractionStates.Succeeded || state === ExtractionStates.None) {
-      setJobStarted(false);
-      if (initialLoad.current) {
-        initialLoad.current = false;
-        setExtractionState(ExtractionStates.None);
-        return;
+    try {
+      const state = await props.bulkExtractor.getIModelState(props.mapping.imodelId, props.mapping.iModelName, props.odataFeedUrl);
+      if (state === ExtractionStates.Failed || state === ExtractionStates.Succeeded) {
+        if (extractionState === ExtractionStates.Running) {
+          setExtractionState(state);
+        }
+      } else {
+        setExtractionState(state);
       }
-    } else {
-      initialLoad.current = false;
+    } catch (error) {
+      setExtractionState(ExtractionStates.Failed);
+      /* eslint-disable no-console */
+      console.error(error);
     }
-    setExtractionState(state);
-  }, [props.mapping, props.bulkExtractor, props.odataFeedUrl]);
+  }, [props.bulkExtractor, props.mapping.imodelId, props.mapping.iModelName, props.odataFeedUrl, extractionState]);
 
   useEffect(() => {
-    if (jobStarted) {
-      getExtractionState().catch((error) => {
-        setExtractionState(ExtractionStates.Failed);
-        setJobStarted(false);
-        /* eslint-disable no-console */
-        console.error(error);
-      });
-      window.clearInterval(interval.current);
-      interval.current = window.setInterval(async () => {
-        await getExtractionState();
-      }, STATUS_CHECK_INTERVAL);
-    }
+    void getExtractionState();
+  }, [extractionState, getExtractionState]);
+
+  useEffect(() => {
+    window.clearInterval(interval.current);
+    if (extractionState === ExtractionStates.None) return;
+    interval.current = window.setInterval(async () => {
+      await getExtractionState();
+    }, STATUS_CHECK_INTERVAL);
     return () => window.clearInterval(interval.current);
-  }, [jobStarted, getExtractionState]);
+  }, [extractionState, getExtractionState]);
+
+  const handleUpdateDataset = useCallback(async () => {
+    setExtractionState(ExtractionStates.Starting);
+    await props.bulkExtractor.runIModelExtraction(props.mapping.imodelId);
+    props.jobStartEvent.raiseEvent(props.mapping.imodelId);
+  }, [props.bulkExtractor, props.jobStartEvent, props.mapping.imodelId]);
 
   return (
     <HorizontalTile
@@ -92,12 +94,7 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
                   title={ReportsConfigWidget.localization.getLocalizedString(
                     "ReportsConfigWidget:UpdateDataset"
                   )}
-                  onClick={async () => {
-                    setExtractionState(ExtractionStates.Starting);
-                    await props.bulkExtractor.runIModelExtraction(props.mapping.imodelId);
-                    props.jobStartEvent.raiseEvent(props.mapping.imodelId);
-                  }}
-                  disabled={jobStarted}
+                  onClick={handleUpdateDataset}
                 >
                   <SvgPlay />
                 </IconButton>

--- a/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
+++ b/packages/itwin/reports-config-widget/src/widget/components/ReportMappingHorizontalTile.tsx
@@ -41,7 +41,7 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
     };
   }, [props.jobStartEvent, props.mapping.imodelId]);
 
-  const getExtractionState = useCallback(async () => {
+  const updateExtractionState = useCallback(async () => {
     try {
       const state = await props.bulkExtractor.getIModelState(props.mapping.imodelId, props.mapping.iModelName, props.odataFeedUrl);
       if (state === ExtractionStates.Failed || state === ExtractionStates.Succeeded) {
@@ -59,17 +59,17 @@ export const ReportMappingHorizontalTile = (props: ReportMappingHorizontalTilePr
   }, [props.bulkExtractor, props.mapping.imodelId, props.mapping.iModelName, props.odataFeedUrl, extractionState]);
 
   useEffect(() => {
-    void getExtractionState();
-  }, [extractionState, getExtractionState]);
+    void updateExtractionState();
+  }, [extractionState, updateExtractionState]);
 
   useEffect(() => {
     window.clearInterval(interval.current);
     if (extractionState === ExtractionStates.None) return;
     interval.current = window.setInterval(async () => {
-      await getExtractionState();
+      await updateExtractionState();
     }, STATUS_CHECK_INTERVAL);
     return () => window.clearInterval(interval.current);
-  }, [extractionState, getExtractionState]);
+  }, [extractionState, updateExtractionState]);
 
   const handleUpdateDataset = useCallback(async () => {
     setExtractionState(ExtractionStates.Starting);


### PR DESCRIPTION
The iModel extraction states for the mappings after it finished kept appearing after each rerender. React Strict mode made this bug more obvious.

- Simplified the logic by removing the `initialLoad` and the `jobStarted` state which was no longer necessary.
- The disabled prop that took advantage of jobStarted was also unnecessary. The whole action group gets replaced by a loading spinner anyways. This might change when eventually the component will allow for single mapping runs instead of entire iModel scoped runs, due to how the bulk extractor only keeps states on the iModel level.