### PR TITLE
Tree widget: Models tree instance keys lookup optimizations

### DIFF
--- a/change/@itwin-tree-widget-react-e246135d-f170-4a16-a5ad-9f21840c31d8.json
+++ b/change/@itwin-tree-widget-react-e246135d-f170-4a16-a5ad-9f21840c31d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Models tree filtering: substantial performance improvement, ability to filter not just by Subjects and Models, but also by Categories and Elements, fix filtering by labels containing special characters `%` and `_`.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/common/Rxjs.ts
+++ b/packages/itwin/tree-widget/src/components/trees/common/Rxjs.ts
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultIfEmpty, last, scan, takeWhile } from "rxjs";
+import { defaultIfEmpty, from, last, scan, takeWhile } from "rxjs";
 
-import type { Observable, OperatorFunction } from "rxjs";
+import type { Observable, ObservableInput, OperatorFunction } from "rxjs";
 
 /**
  * Applies reduce function and "returns" early if the predicate returns `false` for the accumulator.
@@ -26,6 +26,24 @@ export async function toVoidPromise(obs: Observable<any>): Promise<void> {
     obs.subscribe({
       complete: () => resolve(),
       error: reject,
+    });
+  });
+}
+
+/** Returns observable results in an array */
+export async function collect<T>(obs: ObservableInput<T>): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const arr = new Array<T>();
+    from(obs).subscribe({
+      next(item: T) {
+        arr.push(item);
+      },
+      complete() {
+        resolve(arr);
+      },
+      error(reason) {
+        reject(reason);
+      },
     });
   });
 }

--- a/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
@@ -632,9 +632,9 @@ async function createInstanceKeyPathsFromInstanceLabel(
           FROM BisCore.GeometricModel3d m
           JOIN BisCore.Element e on e.ECInstanceId = m.ModeledElement.Id
         )
-        WHERE Label LIKE '%' || ? || '%'
+        WHERE Label LIKE '%' || ? || '%' ESCAPE '\\'
       `,
-      bindings: [{ type: "string", value: props.label }],
+      bindings: [{ type: "string", value: props.label.replace(/[%_\\]/g, "\\$&") }],
     },
     { rowFormat: "Indexes", restartToken: "tree-widget/models-tree/filter-by-label-query" },
   );

--- a/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
@@ -3,12 +3,18 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { defer, EMPTY, from, map, merge, mergeAll, mergeMap } from "rxjs";
 import {
-  createClassBasedHierarchyDefinition, createNodesQueryClauseFactory, HierarchyNode, NodeSelectClauseColumnNames,
+  createClassBasedHierarchyDefinition,
+  createNodesQueryClauseFactory,
+  HierarchyNode,
+  NodeSelectClauseColumnNames,
 } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
+import { collect } from "../../common/Rxjs";
 
 import type { Id64String } from "@itwin/core-bentley";
+import type { Observable } from "rxjs";
 import type {
   DefineHierarchyLevelProps,
   DefineInstanceNodeChildHierarchyLevelProps,
@@ -23,7 +29,6 @@ import type {
 } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector, ECSchemaProvider, ECSqlBinding, IInstanceLabelSelectClauseFactory, InstanceKey } from "@itwin/presentation-shared";
 import type { ModelsTreeIdsCache } from "./internal/ModelsTreeIdsCache";
-
 interface ModelsTreeDefinitionProps {
   imodelAccess: ECSchemaProvider & ECClassHierarchyInspector & LimitingECSqlQueryExecutor;
   idsCache: ModelsTreeIdsCache;
@@ -490,87 +495,11 @@ function createECInstanceKeySelectClause(
   return `json_object('className', ec_classname(${classIdSelector}, 's.c'), 'id', ${instanceHexIdSelector})`;
 }
 
-async function createSubjectModelsInstanceKeysPathsCTEs(labelsFactory: IInstanceLabelSelectClauseFactory) {
+function createInstanceKeyPathsCTEs() {
   return [
-    `Models(ECClassId, ECInstanceId, HexId, ModeledElementParentId, Label) AS (
-      SELECT
-        m.ECClassId,
-        m.ECInstanceId,
-        printf('0x%x', m.ECInstanceId) HexId,
-        p.Parent.Id,
-        ${await labelsFactory.createSelectClause({
-          classAlias: "p",
-          className: "BisCore.Element",
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
-        })}
-      FROM bis.GeometricModel3d m
-      JOIN bis.Element p on p.ECInstanceId = m.ModeledElement.Id
-    )`,
-    `SubjectsHierarchy(TargetId, TargetLabel, ECClassId, ECInstanceId, ParentId, JsonProperties, Path) AS (
-      SELECT
-        s.ECInstanceId,
-        ${await labelsFactory.createSelectClause({
-          classAlias: "s",
-          className: "BisCore.Subject",
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
-        })},
-        s.ECClassId,
-        s.ECInstanceId,
-        s.Parent.Id,
-        s.JsonProperties,
-        CASE
-          WHEN (
-            json_extract(s.JsonProperties, '$.Subject.Job.Bridge') IS NOT NULL
-            OR json_extract(s.JsonProperties, '$.Subject.Model.Type') = 'Hierarchy'
-          )
-          THEN
-            json_array()
-          ELSE
-            json_array(${createECInstanceKeySelectClause({ alias: "s" })})
-        END
-      FROM bis.Subject s
-      UNION ALL
-      SELECT
-        c.TargetId,
-        c.TargetLabel,
-        p.ECClassId,
-        p.ECInstanceId,
-        p.Parent.Id,
-        p.JsonProperties,
-        CASE
-          WHEN (
-            json_extract(p.JsonProperties, '$.Subject.Job.Bridge') IS NOT NULL
-            OR json_extract(p.JsonProperties, '$.Subject.Model.Type') = 'Hierarchy'
-          )
-          THEN
-            c.Path
-          ELSE
-            json_insert(c.Path, '$[#]', ${createECInstanceKeySelectClause({ alias: "p" })})
-        END
-      FROM SubjectsHierarchy c
-      JOIN bis.Element p on p.ECInstanceId = c.ParentId
-    )`,
-    `Subjects(TargetId, TargetLabel, ECClassId, ECInstanceId, JsonProperties, Path) AS (
-      SELECT s.TargetId, s.TargetLabel, s.ECClassId, s.ECInstanceId, s.JsonProperties, s.Path
-      FROM SubjectsHierarchy s
-      WHERE s.ParentId IS NULL
-    )`,
-  ];
-}
-
-async function createInstanceKeyPathsCTEs(labelsFactory: IInstanceLabelSelectClauseFactory) {
-  return [
-    `GeometricElementsHierarchy(TargetId, TargetLabel, ECClassId, ECInstanceId, ParentId, ModelId, CategoryId, Path) AS (
+    `GeometricElementsHierarchy(TargetId, ECClassId, ECInstanceId, ParentId, ModelId, CategoryId, Path) AS (
       SELECT
         e.ECInstanceId,
-        ${await labelsFactory.createSelectClause({
-          classAlias: "e",
-          className: "BisCore.GeometricElement3d",
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
-        })},
         e.ECClassId,
         e.ECInstanceId,
         e.Parent.Id,
@@ -581,7 +510,6 @@ async function createInstanceKeyPathsCTEs(labelsFactory: IInstanceLabelSelectCla
       UNION ALL
       SELECT
         c.TargetId,
-        c.TargetLabel,
         p.ECClassId,
         p.ECInstanceId,
         p.Parent.Id,
@@ -591,31 +519,30 @@ async function createInstanceKeyPathsCTEs(labelsFactory: IInstanceLabelSelectCla
       FROM GeometricElementsHierarchy c
       JOIN bis.GeometricElement3d p on p.ECInstanceId = c.ParentId
     )`,
-    `GeometricElements(TargetId, TargetLabel, ECClassId, ECInstanceId, ModelId, CategoryId, Path) AS (
-      SELECT e.TargetId, e.TargetLabel, e.ECClassId, e.ECInstanceId, e.ModelId, e.CategoryId, e.Path
+    `GeometricElements(TargetId, ECClassId, ECInstanceId, ModelId, CategoryId, Path) AS (
+      SELECT e.TargetId, e.ECClassId, e.ECInstanceId, e.ModelId, e.CategoryId, e.Path
       FROM GeometricElementsHierarchy e
       WHERE e.ParentId IS NULL
     )`,
-    `Categories(ECClassId, ECInstanceId, HexId, Label) AS (
+    `Models(ECClassId, ECInstanceId, HexId) AS (
+      SELECT
+        m.ECClassId,
+        m.ECInstanceId,
+        printf('0x%x', m.ECInstanceId) HexId
+      FROM bis.GeometricModel3d m
+    )`,
+    `Categories(ECClassId, ECInstanceId, HexId) AS (
       SELECT
         c.ECClassId,
         c.ECInstanceId,
-        printf('0x%x', c.ECInstanceId) HexId,
-        ${await labelsFactory.createSelectClause({
-          classAlias: "c",
-          className: "BisCore.SpatialCategory",
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
-        })}
+        printf('0x%x', c.ECInstanceId) HexId
       FROM bis.SpatialCategory c
     )`,
-    `ModelsCategoriesElementsHierarchy(TargetElementId, TargetElementLabel, ModelId, ModelHexId, ModelParentId, Path) AS (
+    `ModelsCategoriesElementsHierarchy(TargetElementId, ModelId, ModelHexId, Path) AS (
       SELECT
         e.TargetId,
-        e.TargetLabel,
         m.ECInstanceId,
         m.HexId,
-        m.ModeledElementParentId,
         json_insert(
           e.Path,
           '$[#]', ${createECInstanceKeySelectClause({
@@ -633,10 +560,8 @@ async function createInstanceKeyPathsCTEs(labelsFactory: IInstanceLabelSelectCla
       UNION ALL
       SELECT
         mce.TargetElementId,
-        mce.TargetElementLabel,
         m.ECInstanceId,
         m.HexId,
-        m.ModeledElementParentId,
         json_insert(
           mce.Path,
           '$[#]', json(e.Path),
@@ -654,8 +579,62 @@ async function createInstanceKeyPathsCTEs(labelsFactory: IInstanceLabelSelectCla
       JOIN Categories c ON c.ECInstanceId = e.CategoryId
       JOIN Models m ON m.ECInstanceId = e.ModelId
     )`,
-    ...(await createSubjectModelsInstanceKeysPathsCTEs(labelsFactory)),
   ];
+}
+
+function createSubjectInstanceKeysPath(subjectId: Id64String, idsCache: ModelsTreeIdsCache): Observable<HierarchyNodeIdentifiersPath> {
+  return from(idsCache.getSubjectAncestorsPath(subjectId)).pipe(map((idsPath) => idsPath.map((id) => ({ className: "BisCore.Subject", id }))));
+}
+
+function createModelInstanceKeyPaths(modelId: Id64String, idsCache: ModelsTreeIdsCache): Observable<HierarchyNodeIdentifiersPath> {
+  return from(idsCache.getModelSubjects(modelId)).pipe(
+    mergeAll(),
+    mergeMap((modelSubjectId) =>
+      createSubjectInstanceKeysPath(modelSubjectId, idsCache).pipe(
+        map((subjectPath) => [...subjectPath, { className: "BisCore.GeometricModel3d", id: modelId }]),
+      ),
+    ),
+  );
+}
+
+function createCategoryInstanceKeyPaths(categoryId: Id64String, idsCache: ModelsTreeIdsCache): Observable<HierarchyNodeIdentifiersPath> {
+  return from(idsCache.getCategoryModels(categoryId)).pipe(
+    mergeAll(),
+    mergeMap((categoryModelId) =>
+      createModelInstanceKeyPaths(categoryModelId, idsCache).pipe(map((modelPath) => [...modelPath, { className: "BisCore.SpatialCategory", id: categoryId }])),
+    ),
+  );
+}
+
+function createGeometricElementInstanceKeyPaths(
+  imodelAccess: ECClassHierarchyInspector & LimitingECSqlQueryExecutor,
+  idsCache: ModelsTreeIdsCache,
+  elementIds: Id64String[],
+): Observable<HierarchyNodeIdentifiersPath> {
+  return defer(() => {
+    const ecsql = `
+      SELECT mce.ModelId, mce.Path
+      FROM ModelsCategoriesElementsHierarchy mce
+      WHERE mce.TargetElementId IN (${elementIds.map(() => "?").join(",")})
+    `;
+    return imodelAccess.createQueryReader(
+      { ctes: createInstanceKeyPathsCTEs(), ecsql, bindings: elementIds.map((id) => ({ type: "id", value: id })) },
+      { rowFormat: "Indexes" },
+    );
+  }).pipe(
+    map((row) => ({
+      modelId: row[0],
+      elementHierarchyPath: flatten<InstanceKey>(JSON.parse(row[1])).reverse(),
+    })),
+    mergeMap(({ modelId, elementHierarchyPath }) =>
+      createModelInstanceKeyPaths(modelId, idsCache).pipe(
+        map((modelPath) => {
+          modelPath.pop(); // model is already included in the element hierarchy path
+          return [...modelPath, ...elementHierarchyPath];
+        }),
+      ),
+    ),
+  );
 }
 
 async function createInstanceKeyPathsFromInstanceKeys(props: ModelsTreeInstanceKeyPathsFromInstanceKeysProps): Promise<HierarchyNodeIdentifiersPath[]> {
@@ -678,102 +657,48 @@ async function createInstanceKeyPathsFromInstanceKeys(props: ModelsTreeInstanceK
       }
     }),
   );
-
-  const queries = [];
-  if (ids.elements.length > 0) {
-    queries.push(`
-      SELECT json_insert(mce.Path, '$[#]', json(s.Path))
-      FROM ModelsCategoriesElementsHierarchy mce
-      JOIN Subjects s ON s.TargetId = mce.ModelParentId OR json_extract(s.JsonProperties,'$.Subject.Model.TargetPartition') = mce.ModelHexId
-      WHERE mce.TargetElementId IN (${ids.elements.map(() => "?").join(",")})
-    `);
-  }
-  if (ids.categories.length > 0) {
-    queries.push(`
-      SELECT
-        json_array(
-          ${createECInstanceKeySelectClause({ classIdAlias: "c", instanceHexIdSelector: "c.HexId" })},
-          ${createECInstanceKeySelectClause({ classIdAlias: "m", instanceHexIdSelector: "m.HexId" })},
-          json(s.Path)
-        )
-      FROM Categories c,
-           Models m
-      JOIN Subjects s ON s.TargetId = m.ModeledElementParentId OR json_extract(s.JsonProperties,'$.Subject.Model.TargetPartition') = m.HexId
-      WHERE
-        m.ECInstanceId IN (SELECT e.Model.Id FROM bis.GeometricElement3d e WHERE e.Category.Id = c.ECInstanceId)
-        AND c.ECInstanceId IN (${ids.categories.map(() => "?").join(",")})
-    `);
-  }
-  if (ids.models.length > 0) {
-    queries.push(`
-      SELECT
-        json_array(
-          ${createECInstanceKeySelectClause({ classIdAlias: "m", instanceHexIdSelector: "m.HexId" })},
-          json(s.Path)
-        )
-      FROM Models m
-      JOIN Subjects s ON s.TargetId = m.ModeledElementParentId OR json_extract(s.JsonProperties,'$.Subject.Model.TargetPartition') = m.HexId
-      WHERE m.ECInstanceId IN (${ids.models.map(() => "?").join(",")})
-    `);
-  }
-  if (ids.subjects.length > 0) {
-    queries.push(`
-      SELECT s.Path
-      FROM Subjects s
-      WHERE s.TargetId IN (${ids.subjects.map(() => "?").join(",")})
-    `);
-  }
-  if (queries.length === 0) {
-    return [];
-  }
-
-  const bindings: ECSqlBinding[] = [];
-  ids.elements.forEach((id) => bindings.push({ type: "id", value: id }));
-  ids.categories.forEach((id) => bindings.push({ type: "id", value: id }));
-  ids.models.forEach((id) => bindings.push({ type: "id", value: id }));
-  ids.subjects.forEach((id) => bindings.push({ type: "id", value: id }));
-
-  const reader = props.imodelAccess.createQueryReader(
-    {
-      ctes: await createInstanceKeyPathsCTEs({ createSelectClause: async () => "''" }),
-      ecsql: queries.join(" UNION ALL "),
-      bindings,
-    },
-    { rowFormat: "Indexes", restartToken: "tree-widget/models-tree/filter-by-keys-query" },
+  return collect(
+    merge(
+      from(ids.subjects).pipe(mergeMap((id) => createSubjectInstanceKeysPath(id, props.idsCache))),
+      from(ids.models).pipe(mergeMap((id) => createModelInstanceKeyPaths(id, props.idsCache))),
+      from(ids.categories).pipe(mergeMap((id) => createCategoryInstanceKeyPaths(id, props.idsCache))),
+      ids.elements.length ? createGeometricElementInstanceKeyPaths(props.imodelAccess, props.idsCache, ids.elements) : EMPTY,
+    ),
   );
-  const paths = new Array<HierarchyNodeIdentifiersPath>();
-  for await (const row of reader) {
-    paths.push(flatten<InstanceKey>(JSON.parse(row[0])).reverse());
-  }
-  return paths;
 }
 
 async function createInstanceKeyPathsFromInstanceLabel(
   props: ModelsTreeInstanceKeyPathsFromInstanceLabelProps & { labelsFactory: IInstanceLabelSelectClauseFactory },
 ) {
-  const queries = [];
-  queries.push(`
-    SELECT
-      m.Label AS Label,
-      json_array(
-        ${createECInstanceKeySelectClause({ classIdAlias: "m", instanceHexIdSelector: "m.HexId" })},
-        json(s.Path)
-      ) AS Path
-    FROM Models m
-    JOIN Subjects s ON s.TargetId = m.ModeledElementParentId OR json_extract(s.JsonProperties,'$.Subject.Model.TargetPartition') = m.HexId
-  `);
-  queries.push(`
-    SELECT s.TargetLabel AS Label, s.Path AS Path
-    FROM Subjects s
-  `);
-
-  const reader = props.imodelAccess.createQueryReader(
+  const targetsReader = props.imodelAccess.createQueryReader(
     {
-      ctes: await createSubjectModelsInstanceKeysPathsCTEs(props.labelsFactory),
       ecsql: `
-        SELECT DISTINCT Path
+        SELECT *
         FROM (
-          ${queries.join(" UNION ALL ")}
+          SELECT
+            ec_classname(s.ECClassId, 's.c'),
+            s.ECInstanceId,
+            ${await props.labelsFactory.createSelectClause({
+              classAlias: "s",
+              className: "BisCore.Subject",
+              // eslint-disable-next-line @typescript-eslint/unbound-method
+              selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
+            })} Label
+          FROM BisCore.Subject s
+
+          UNION ALL
+
+          SELECT
+            ec_classname(m.ECClassId, 's.c'),
+            m.ECInstanceId,
+            ${await props.labelsFactory.createSelectClause({
+              classAlias: "p",
+              className: "BisCore.Element",
+              // eslint-disable-next-line @typescript-eslint/unbound-method
+              selectorsConcatenator: ECSql.createConcatenatedValueStringSelector,
+            })} Label
+          FROM BisCore.GeometricModel3d m
+          JOIN BisCore.Element p on p.ECInstanceId = m.ModeledElement.Id
         )
         WHERE Label LIKE '%' || ? || '%'
       `,
@@ -781,11 +706,13 @@ async function createInstanceKeyPathsFromInstanceLabel(
     },
     { rowFormat: "Indexes", restartToken: "tree-widget/models-tree/filter-by-label-query" },
   );
-  const paths = new Array<HierarchyNodeIdentifiersPath>();
-  for await (const row of reader) {
-    paths.push(flatten<InstanceKey>(JSON.parse(row[0])).reverse());
+
+  const targetKeys = new Array<InstanceKey>();
+  for await (const row of targetsReader) {
+    targetKeys.push({ className: row[0], id: row[1] });
   }
-  return paths;
+
+  return createInstanceKeyPathsFromInstanceKeys({ ...props, keys: targetKeys });
 }
 
 type ArrayOrValue<T> = T | Array<ArrayOrValue<T>>;

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/stateless/ModelsTreeFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/stateless/ModelsTreeFiltering.test.ts
@@ -62,7 +62,7 @@ namespace TreeFilteringTestCaseDefinition {
   }
 }
 
-describe("Models Tree", () => {
+describe("Models tree", () => {
   describe("Hierarchy filtering", () => {
     before(async function () {
       await initializePresentationTesting({
@@ -326,8 +326,8 @@ describe("Models Tree", () => {
           return { rootSubject, model1, model2, model3 };
         },
         (x) => [
-          [x.rootSubject, x.model1],
-          [x.rootSubject, x.model3],
+          [x.rootSubject, { className: "BisCore.GeometricModel3d", id: x.model1.id }],
+          [x.rootSubject, { className: "BisCore.GeometricModel3d", id: x.model3.id }],
         ],
         (x) => [x.model1, x.model3],
         (_x) => "matching",
@@ -393,7 +393,7 @@ describe("Models Tree", () => {
         },
         (x) => [
           [x.rootSubject, x.childSubject],
-          [x.rootSubject, x.childSubject, x.model1],
+          [x.rootSubject, x.childSubject, { className: "BisCore.GeometricModel3d", id: x.model1.id }],
         ],
         (x) => [x.childSubject, x.model1],
         (_x) => "matching",
@@ -456,8 +456,8 @@ describe("Models Tree", () => {
           return { rootSubject, model1, model2, category1, category2, category3 };
         },
         (x) => [
-          [x.rootSubject, x.model1, x.category1],
-          [x.rootSubject, x.model2, x.category3],
+          [x.rootSubject, { className: "BisCore.GeometricModel3d", id: x.model1.id }, x.category1],
+          [x.rootSubject, { className: "BisCore.GeometricModel3d", id: x.model2.id }, x.category3],
         ],
         (x) => [x.category1, x.category3],
         undefined,
@@ -907,10 +907,18 @@ describe("Models Tree", () => {
           if (0 !== classNameCmp) {
             return classNameCmp;
           }
-          return lhsId.id.localeCompare(rhsId.id);
+          const idCmp = lhsId.id.localeCompare(rhsId.id);
+          if (0 !== idCmp) {
+            return idCmp;
+          }
+          continue;
         }
         if (HierarchyNodeIdentifier.isCustomNodeIdentifier(lhsId) && HierarchyNodeIdentifier.isCustomNodeIdentifier(rhsId)) {
-          return lhsId.key.localeCompare(rhsId.key);
+          const keyCmp = lhsId.key.localeCompare(rhsId.key);
+          if (0 !== keyCmp) {
+            return keyCmp;
+          }
+          continue;
         }
         return HierarchyNodeIdentifier.isCustomNodeIdentifier(lhsId) ? -1 : 1;
       }


### PR DESCRIPTION
- Fix https://github.com/iTwin/viewer-components-react/issues/854. Refactored the query to start recursion with target instance keys instead of using recursion to create a virtual elements table and scan through it looking for targets.

- Fix https://github.com/iTwin/viewer-components-react/issues/853. We can now rebuild Subjects, Models and Categories hierarchy from our `ModelsTreeIdsCache` - no need to run additional queries.

- Since the key paths lookup performance improved drastically, put back filtering by label for categories & elements. Tried this on a few larger iModels - on L size getting the paths takes ~1 second and on XL - ~5 seconds. Seems reasonable.

- Fixed characters `%` and `_` being treated as SQLite's special characters, thus making it impossible to filter using them. Now they get escaped.