### PR TITLE
Tree widget: Fix Subject nodes that are leaf filter targets being auto-expanded in some cases

### DIFF
--- a/change/@itwin-tree-widget-react-8fa3a110-48a3-4980-87c1-53690c8cd4b9.json
+++ b/change/@itwin-tree-widget-react-8fa3a110-48a3-4980-87c1-53690c8cd4b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Subject nodes that are leaf filter targets being auto-expanded when they have hidden child Models that also match filter criteria.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/models-tree/ModelsTreeDefinition.ts
@@ -630,7 +630,11 @@ async function createInstanceKeyPathsFromInstanceLabel(
             m.ECInstanceId,
             ${elementLabelSelectClause} Label
           FROM BisCore.GeometricModel3d m
-          JOIN BisCore.Element e on e.ECInstanceId = m.ModeledElement.Id
+          JOIN BisCore.Element e ON e.ECInstanceId = m.ModeledElement.Id
+          WHERE NOT m.IsPrivate
+            AND EXISTS (SELECT 1 FROM bis.GeometricElement3d WHERE Model.Id = m.ECInstanceId)
+            AND json_extract(e.JsonProperties, '$.PhysicalPartition.Model.Content') IS NULL
+            AND json_extract(e.JsonProperties, '$.GraphicalPartition3d.Model.Content') IS NULL
         )
         WHERE Label LIKE '%' || ? || '%' ESCAPE '\\'
       `,

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/stateless/ModelsTreeFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/stateless/ModelsTreeFiltering.test.ts
@@ -391,11 +391,8 @@ describe("Models tree", () => {
           insertPhysicalElement({ builder, userLabel: `element-2`, modelId: model2.id, categoryId: category.id });
           return { rootSubject, childSubject, model1, model2, category };
         },
-        (x) => [
-          [x.rootSubject, x.childSubject],
-          [x.rootSubject, x.childSubject, { className: "BisCore.GeometricModel3d", id: x.model1.id }],
-        ],
-        (x) => [x.childSubject, x.model1],
+        (x) => [[x.rootSubject, x.childSubject]],
+        (x) => [x.childSubject],
         (_x) => "matching",
         (x) => [
           NodeValidators.createForInstanceNode({
@@ -405,7 +402,7 @@ describe("Models tree", () => {
               NodeValidators.createForInstanceNode({
                 instanceKeys: [x.childSubject],
                 label: "matching child subject",
-                autoExpand: true,
+                autoExpand: false,
                 children: [
                   NodeValidators.createForInstanceNode({
                     label: "category",


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/880