### PR TITLE
measure-tools-react: Export SheetMeasurementHelper in measure-tools-react package

### DIFF
--- a/change/@itwin-measure-tools-react-ee48a9ad-bfde-45a0-97db-75a631feda58.json
+++ b/change/@itwin-measure-tools-react-ee48a9ad-bfde-45a0-97db-75a631feda58.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Export SheetMeasurementHelper in measure-tools-react package",
   "packageName": "@itwin/measure-tools-react",
-  "email": "email not defined",
+  "email": "125395992+Maxime-Brassard@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@itwin-measure-tools-react-ee48a9ad-bfde-45a0-97db-75a631feda58.json
+++ b/change/@itwin-measure-tools-react-ee48a9ad-bfde-45a0-97db-75a631feda58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export SheetMeasurementHelper in measure-tools-react package",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/measure-tools-react.ts
+++ b/packages/itwin/measure-tools/src/measure-tools-react.ts
@@ -19,6 +19,7 @@ export * from "./api/MeasurementUIEvents";
 export * from "./api/MeasurementViewTarget";
 export * from "./api/MeasureToolsLoggerCategory";
 export * from "./api/Polygon";
+export * from "./api/SheetMeasurementHelper";
 export * from "./api/TextMarker";
 export * from "./api/ViewHelper";
 


### PR DESCRIPTION
Exporting the sheet measurement helper file in order to use it in consuming apps.