### PR TITLE
measure-tools-react: Fixes measureToolsWidget rise value for sheet measurements

### DIFF
--- a/change/@itwin-measure-tools-react-2f1c01b1-1b05-4a20-bd7d-89429de46144.json
+++ b/change/@itwin-measure-tools-react-2f1c01b1-1b05-4a20-bd7d-89429de46144.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixed bad rise",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-measure-tools-react-2f1c01b1-1b05-4a20-bd7d-89429de46144.json
+++ b/change/@itwin-measure-tools-react-2f1c01b1-1b05-4a20-bd7d-89429de46144.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "fixed bad rise",
   "packageName": "@itwin/measure-tools-react",
-  "email": "email not defined",
+  "email": "125395992+Maxime-Brassard@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -476,7 +476,7 @@ export class DistanceMeasurement extends Measurement {
 
     const distance = this.worldScale * this._startPoint.distance(this._endPoint);
     const run = this.drawingMetaData?.worldScale !== undefined ? this.worldScale * Math.abs(this._endPoint.x - this._startPoint.x): this._startPoint.distanceXY(this._endPoint);
-    const rise = this.drawingMetaData?.worldScale !== undefined ? this.worldScale * this._endPoint.y - this._startPoint.y: this._endPoint.z - this._startPoint.z;
+    const rise = this.drawingMetaData?.worldScale !== undefined ? this.worldScale * (this._endPoint.y - this._startPoint.y): this._endPoint.z - this._startPoint.z;
     const slope = 0.0 < run ? (100 * rise) / run : 0.0;
     const dx = Math.abs(this._endPoint.x - this._startPoint.x);
     const dy = Math.abs(this._endPoint.y - this._startPoint.y);


### PR DESCRIPTION
There was an operation priority error in the measureToolsWidget when calculating the value for sheet measurements.