### PR TITLE
Tree widget: Escape special symbols when searching in CategoriesTree

### DIFF
--- a/change/@itwin-tree-widget-react-c544572f-f5aa-4a00-b5e2-3de8862d8685.json
+++ b/change/@itwin-tree-widget-react-c544572f-f5aa-4a00-b5e2-3de8862d8685.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Escape special SQL characters when searching by label in stateless CategoriesTree",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/stateless/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/categories-tree/CategoriesTreeDefinition.ts
@@ -202,9 +202,9 @@ async function createInstanceKeyPathsFromInstanceLabel(
           IIF(c.ChildCount > 1, sc.ECInstanceId, NULL) AS SubcategoryId
         FROM RootCategories c
         JOIN SubCategoriesWithLabels sc ON sc.ParentId = c.ECInstanceId
-        WHERE sc.DisplayLabel LIKE '%' || ? || '%'
+        WHERE sc.DisplayLabel LIKE '%' || ? || '%' ESCAPE '\\'
       `,
-      bindings: [{ type: "string", value: props.label }],
+      bindings: [{ type: "string", value: props.label.replace(/[%_\\]/g, "\\$&") }],
     },
     { restartToken: "tree-widget/categories-tree/filter-by-label-query" },
   );


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/906