### PR TITLE
Stateless tree widget: Add thousands separator to the filter dialog result count

### DIFF
--- a/change/@itwin-tree-widget-react-b54f61d9-9108-4b0a-8fd6-c5daf692422c.json
+++ b/change/@itwin-tree-widget-react-b54f61d9-9108-4b0a-8fd6-c5daf692422c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add thousands separator to filter dialog result count",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "yato333@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/public/locales/en/TreeWidget.json
+++ b/packages/itwin/tree-widget/public/locales/en/TreeWidget.json
@@ -94,7 +94,7 @@
     "disableInstanceFocus": "Disable Instance Focus",
     "noNodesMatchFilter": "There are no nodes matching filter - \"{{filter}}\"",
     "failedToCalculateMatchingInstances": "Failed to calculate matching instances count",
-    "matchingInstancesCount": "Current filter matching instances count: {{count}}",
+    "matchingInstancesCount": "Current filter matching instances count: {{instanceCount}}",
     "filterExceedsLimit": "Current filter exceeds instances count of {{limit}}",
     "dataIsNotAvailable": "The data required for this tree layout is not available in this iModel.",
     "unknownFilterError": "An unknown error occurred while filtering the tree.",

--- a/packages/itwin/tree-widget/src/components/trees/stateless/common/UseHierarchyFiltering.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/stateless/common/UseHierarchyFiltering.tsx
@@ -126,10 +126,12 @@ function MatchingInstancesCount({ filter, defaultHierarchyLevelSizeLimit, hierar
             hierarchyLevelSizeLimit: hierarchyLevelDetails.sizeLimit ?? defaultHierarchyLevelSizeLimit,
           }),
         );
-        return TreeWidget.translate("stateless.matchingInstancesCount", { count: instanceKeys.length });
+        return TreeWidget.translate("stateless.matchingInstancesCount", {
+          instanceCount: instanceKeys.length.toLocaleString(undefined, { useGrouping: true }),
+        });
       } catch (e) {
         if (e instanceof RowsLimitExceededError) {
-          return TreeWidget.translate("stateless.filterExceedsLimit", { limit: e.limit });
+          return TreeWidget.translate("stateless.filterExceedsLimit", { limit: e.limit.toLocaleString(undefined, { useGrouping: true }) });
         }
         return TreeWidget.translate("stateless.failedToCalculateMatchingInstances");
       }


### PR DESCRIPTION
Closes #910 
`count` was renamed to `instanceCount` because it serves a special purpose in the translation library options type.
```ts
export interface TranslationOptions {
    /** for interpolation values */
    [key: string]: any;
    /**
     * count value used for plurals
     */
    count?: number;
}
```