### PR TITLE
Stateless Models Tree: Improve performance of Filter Dialog initial loading.

### DIFF
--- a/change/@itwin-tree-widget-react-c4738993-b001-49c1-886e-4e8021e7da18.json
+++ b/change/@itwin-tree-widget-react-c4738993-b001-49c1-886e-4e8021e7da18.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Stateless Models Tree: Improve performance of Filter Dialog initial loading",
+  "comment": "Models Tree: Improve performance of Filter Dialog initial loading",
   "packageName": "@itwin/tree-widget-react",
   "email": "yato333@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-c4738993-b001-49c1-886e-4e8021e7da18.json
+++ b/change/@itwin-tree-widget-react-c4738993-b001-49c1-886e-4e8021e7da18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stateless Models Tree: Improve performance of Filter Dialog initial loading",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "yato333@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Closes #914 
Micro-optimization of calling `KeySet.fromJson` helps us to improve performance of key collection process by around 50% because it avoids calling inefficient `KeySet.add` method.

Even without these changes actual performance is much better that it seems. See [issue comment](https://github.com/iTwin/viewer-components-react/issues/914#issuecomment-2178732174) for more details.

![Screenshot 2024-06-19 161149](https://github.com/iTwin/viewer-components-react/assets/29233962/85480428-b562-45cc-babb-4d0763dad39f)

