### PR TITLE
Tree Widget 2.x: Clear models tree cache when briefcase changes

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -1,12 +1,14 @@
 trigger:
   - master
   - gh-readonly-queue/master
+  - tree-widget-2.x
 
 pr:
   drafts: false
   branches:
     include:
       - master
+      - tree-widget-2.x
 
 jobs:
   - job: Build

--- a/change/@itwin-tree-widget-react-e0796f73-eaee-4561-bade-fef10cb46d44.json
+++ b/change/@itwin-tree-widget-react-e0796f73-eaee-4561-bade-fef10cb46d44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated `ModelsVisibilityHandler` to clear element and subject caches when briefcase is updated.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "33428304+jasdom@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -6,6 +6,7 @@
 import "../VisibilityTreeBase.scss";
 import classNames from "classnames";
 import { Fragment, useEffect, useMemo, useState } from "react";
+import { from } from "rxjs";
 import { useActiveIModelConnection, useActiveViewport } from "@itwin/appui-react";
 import { SvgVisibilityHalf, SvgVisibilityHide, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
 import { Button, IconButton } from "@itwin/itwinui-react";
@@ -18,9 +19,11 @@ import { ModelsTree } from "./ModelsTree";
 import { areAllModelsVisible, hideAllModels, invertAllModels, showAllModels, toggleModels } from "./ModelsVisibilityHandler";
 import { queryModelsForHeaderActions } from "./Utils";
 
+import type { Subscription } from "rxjs";
 import type { IModelConnection, ScreenViewport, Viewport } from "@itwin/core-frontend";
 import type { TreeHeaderButtonProps } from "../../tree-header/TreeHeader";
 import type { ModelsTreeProps } from "./ModelsTree";
+
 /**
  * Information about a single Model.
  * @public
@@ -125,20 +128,23 @@ function ModelsTreeComponentImpl(props: ModelTreeComponentProps & { iModel: IMod
   const contentClassName = classNames("tree-widget-tree-content", props.density === "enlarged" && "enlarge");
 
   useEffect(() => {
+    let subscription: Subscription | undefined;
     const queryModels = () => {
-      queryModelsForHeaderActions(iModel)
-        .then((modelInfos: ModelInfo[]) => {
-          setAvailableModels(modelInfos);
-        })
-        .catch((_e) => {
-          setAvailableModels([]);
-        });
+      subscription?.unsubscribe();
+      subscription = from(queryModelsForHeaderActions(iModel)).subscribe({
+        next: (modelInfos) => setAvailableModels(modelInfos),
+        error: () => setAvailableModels([]),
+      });
     };
     queryModels();
     // eslint-disable-next-line @itwin/no-internal
     const listeners = [Presentation.presentation.onIModelHierarchyChanged.addListener(queryModels)];
     iModel.isBriefcaseConnection() && listeners.push(iModel.txns.onChangesApplied.addListener(queryModels));
-    return listeners.forEach((remove) => remove());
+
+    return () => {
+      listeners.forEach((remove) => remove());
+      subscription?.unsubscribe();
+    };
   }, [iModel]);
 
   const filterInfo = useMemo(

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -72,15 +72,19 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     this._listeners.push(this._props.viewport.onViewedModelsChanged.addListener(this.onViewChanged));
     this._listeners.push(this._props.viewport.onAlwaysDrawnChanged.addListener(this.onElementAlwaysDrawnChanged));
     this._listeners.push(this._props.viewport.onNeverDrawnChanged.addListener(this.onElementNeverDrawnChanged));
+
+    const clearCaches = () => {
+      this._elementIdsCache.clear();
+      this._subjectModelIdsCache.clear();
+    };
+
     this._listeners.push(
       // eslint-disable-next-line @itwin/no-internal
-      Presentation.presentation.onIModelHierarchyChanged.addListener(
-        /* istanbul ignore next */ () => {
-          this._elementIdsCache.clear();
-          this._subjectModelIdsCache.clear();
-        },
-      ),
+      Presentation.presentation.onIModelHierarchyChanged.addListener(clearCaches),
     );
+    if (this._props.viewport.iModel.isBriefcaseConnection()) {
+      this._listeners.push(this._props.viewport.iModel.txns.onChangesApplied.addListener(clearCaches));
+    }
   }
 
   public dispose() {

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsVisibilityHandler.ts
@@ -73,6 +73,7 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     this._listeners.push(this._props.viewport.onAlwaysDrawnChanged.addListener(this.onElementAlwaysDrawnChanged));
     this._listeners.push(this._props.viewport.onNeverDrawnChanged.addListener(this.onElementNeverDrawnChanged));
 
+    /* istanbul ignore next */
     const clearCaches = () => {
       this._elementIdsCache.clear();
       this._subjectModelIdsCache.clear();

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeComponent.test.tsx
@@ -10,15 +10,18 @@ import * as moq from "typemoq";
 import { UiFramework } from "@itwin/appui-react";
 import { BeEvent } from "@itwin/core-bentley";
 import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { Presentation } from "@itwin/presentation-frontend";
 import * as treeHeader from "../../../components/tree-header/TreeHeader";
 import * as modelsTree from "../../../components/trees/models-tree/ModelsTree";
 import * as modelsVisibilityHandler from "../../../components/trees/models-tree/ModelsVisibilityHandler";
 import { ModelsTreeComponent, TreeWidget } from "../../../tree-widget-react";
 import { act, mockViewport, render, TestUtils, waitFor } from "../../TestUtils";
 
+import type { IModelHierarchyChangeEventArgs, PresentationManager } from "@itwin/presentation-frontend";
 import type { ModelInfo, ModelsTreeHeaderButtonProps } from "../../../tree-widget-react";
-import type { IModelConnection, Viewport } from "@itwin/core-frontend";
+import type { BriefcaseConnection, BriefcaseTxns, IModelConnection, Viewport } from "@itwin/core-frontend";
 import type { TreeHeaderProps } from "../../../components/tree-header/TreeHeader";
+
 describe("<ModelsTreeComponent />", () => {
   before(async () => {
     await NoRenderApp.startup();
@@ -31,11 +34,29 @@ describe("<ModelsTreeComponent />", () => {
   });
 
   let vpMock = moq.Mock.ofType<Viewport>();
+  const imodelMock = moq.Mock.ofType<BriefcaseConnection>();
+  const txnsMock = moq.Mock.ofType<BriefcaseTxns>();
+  const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+  const onIModelHierarchyChangedEvent = new BeEvent<(args: IModelHierarchyChangeEventArgs) => void>();
+  const onChangesAppliedEvent = new BeEvent<() => void>();
+
+  beforeEach(() => {
+    // eslint-disable-next-line @itwin/no-internal
+    presentationManagerMock.setup((x) => x.onIModelHierarchyChanged).returns(() => onIModelHierarchyChangedEvent);
+    // eslint-disable-next-line @itwin/no-internal
+    imodelMock.setup((x) => x.isBriefcaseConnection()).returns(() => true);
+    imodelMock.setup((x) => x.txns).returns(() => txnsMock.object);
+    txnsMock.setup((x) => x.onChangesApplied).returns(() => onChangesAppliedEvent);
+    sinon.stub(Presentation, "presentation").get(() => presentationManagerMock.object);
+  });
 
   afterEach(() => {
+    presentationManagerMock.reset();
+    imodelMock.reset();
+    txnsMock.reset();
     sinon.restore();
     vpMock.reset();
-    vpMock = mockViewport();
+    vpMock = mockViewport({ imodel: imodelMock.object });
   });
 
   const models: ModelInfo[] = [{ id: "testModelId1" }, { id: "testModelId2" }];
@@ -46,7 +67,6 @@ describe("<ModelsTreeComponent />", () => {
     onViewedModelsChanged: new BeEvent<(vp: Viewport) => void>(),
     onAlwaysDrawnChanged: new BeEvent<() => void>(),
     onNeverDrawnChanged: new BeEvent<() => void>(),
-    onIModelHierarchyChanged: new BeEvent<() => void>(),
   } as unknown as Viewport;
 
   it("returns null if iModel is undefined", async () => {
@@ -60,7 +80,7 @@ describe("<ModelsTreeComponent />", () => {
   });
 
   it("returns null if viewport is undefined", async () => {
-    sinon.stub(UiFramework, "getIModelConnection").returns({} as IModelConnection);
+    sinon.stub(UiFramework, "getIModelConnection").returns({ isBriefcaseConnection: () => false } as IModelConnection);
     const modelsTreeSpy = sinon.stub(modelsTree, "ModelsTree");
     const result = render(<ModelsTreeComponent />);
     await waitFor(() => {
@@ -72,7 +92,7 @@ describe("<ModelsTreeComponent />", () => {
   it("renders `ModelsTree` when iModel and viewport are defined", async () => {
     const modelsTreeSpy = sinon.stub(modelsTree, "ModelsTree").returns(<></>);
     sinon.stub(IModelApp.viewManager, "selectedView").get(() => viewport);
-    sinon.stub(UiFramework, "getIModelConnection").returns({} as IModelConnection);
+    sinon.stub(UiFramework, "getIModelConnection").returns({ isBriefcaseConnection: () => false } as IModelConnection);
     const result = render(<ModelsTreeComponent />);
     await waitFor(() => {
       expect(result.container.children).to.not.be.empty;
@@ -100,6 +120,7 @@ describe("<ModelsTreeComponent />", () => {
             },
           ],
         },
+        isBriefcaseConnection: () => false,
       } as unknown as IModelConnection;
       const spy = sinon.stub().returns(<></>);
       sinon.stub(modelsTree, "ModelsTree").returns(<></>);
@@ -123,6 +144,7 @@ describe("<ModelsTreeComponent />", () => {
             throw new Error();
           },
         },
+        isBriefcaseConnection: () => false,
       } as unknown as IModelConnection);
       render(<ModelsTreeComponent headerButtons={[spy]} />);
       await waitFor(() => expect(spy).to.be.calledWith(sinon.match((props: ModelsTreeHeaderButtonProps) => props.models.length === 0)));
@@ -134,7 +156,7 @@ describe("<ModelsTreeComponent />", () => {
       const treewHeaderSpy = sinon.stub(treeHeader, "TreeHeader").returns(<></>);
       sinon.stub(modelsTree, "ModelsTree").returns(<></>);
       sinon.stub(IModelApp.viewManager, "selectedView").get(() => viewport);
-      sinon.stub(UiFramework, "getIModelConnection").returns({} as IModelConnection);
+      sinon.stub(UiFramework, "getIModelConnection").returns({ isBriefcaseConnection: () => false } as IModelConnection);
       render(<ModelsTreeComponent />);
       await waitFor(() => {
         expect(treewHeaderSpy).to.be.calledWith(sinon.match((props: TreeHeaderProps) => Children.count(props.children) === 5));
@@ -146,7 +168,7 @@ describe("<ModelsTreeComponent />", () => {
       const spy = sinon.stub().returns(<></>);
       sinon.stub(modelsTree, "ModelsTree").returns(<></>);
       sinon.stub(IModelApp.viewManager, "selectedView").get(() => viewport);
-      sinon.stub(UiFramework, "getIModelConnection").returns({} as IModelConnection);
+      sinon.stub(UiFramework, "getIModelConnection").returns({ isBriefcaseConnection: () => false } as IModelConnection);
       render(<ModelsTreeComponent headerButtons={[spy]} />);
       await waitFor(() => {
         expect(treewHeaderSpy).to.be.calledWith(sinon.match((props: TreeHeaderProps) => Children.count(props.children) === 1));


### PR DESCRIPTION
Fixes for https://github.com/iTwin/itwinjs-core/issues/6955.