### PR TITLE
Make stage usage configurable for measure tools

### DIFF
--- a/change/@itwin-measure-tools-react-2ed96585-e212-4e2a-9671-e9802caa99e9.json
+++ b/change/@itwin-measure-tools-react-2ed96585-e212-4e2a-9671-e9802caa99e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "The measure tools ui-provider can accept an array of strings for StageUsages, rather than hardcode \"General\". It still defaults to \"General\", so it's backwards compatible.",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "adrian.clinansmith@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -14,6 +14,7 @@ import { MeasurementSyncUiEventId } from "../api/MeasurementEnums";
 import { MeasurementUIEvents } from "../api/MeasurementUIEvents";
 import { MeasureTools } from "../MeasureTools";
 import { MeasureToolDefinitions } from "../tools/MeasureToolDefinitions";
+import type { RecursiveRequire } from "../utils/types";
 import { MeasurementPropertyWidget, MeasurementPropertyWidgetId } from "./MeasurementPropertyWidget";
 import { IModelApp } from "@itwin/core-frontend";
 
@@ -30,14 +31,24 @@ export interface MeasureToolsUiProviderOptions {
   };
   // If we check for sheet to 3d transformation when measuring in sheets
   enableSheetMeasurement?: boolean;
+  stageUsageList?: string[];
 }
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
   public readonly id = "MeasureToolsUiItemsProvider";
-  private _props?: MeasureToolsUiProviderOptions;
+  private _props: RecursiveRequire<MeasureToolsUiProviderOptions>;
 
   constructor(props?: MeasureToolsUiProviderOptions) {
-    this._props = props;
+    this._props = {
+      itemPriority: props?.itemPriority ?? 20,
+      groupPriority: props?.groupPriority ?? 10,
+      widgetPlacement: {
+        location: props?.widgetPlacement?.location ?? StagePanelLocation.Right,
+        section: props?.widgetPlacement?.section ?? StagePanelSection.Start,
+      },
+      enableSheetMeasurement: props?.enableSheetMeasurement ?? false,
+      stageUsageList: props?.stageUsageList ?? [StageUsage.General],
+    };
   }
 
   public provideToolbarItems(
@@ -46,17 +57,17 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
     toolbarUsage: ToolbarUsage,
     toolbarOrientation: ToolbarOrientation,
   ): ToolbarItem[] {
-    if (stageUsage === StageUsage.General && toolbarUsage === ToolbarUsage.ContentManipulation) {
+    if (this._props.stageUsageList.includes(stageUsage) && toolbarUsage === ToolbarUsage.ContentManipulation) {
       const featureFlags = MeasureTools.featureFlags;
       const tools: ToolItemDef[] = [];
       if (!featureFlags?.hideDistanceTool) {
-        tools.push(MeasureToolDefinitions.getMeasureDistanceToolCommand(this._props?.enableSheetMeasurement ?? false));
+        tools.push(MeasureToolDefinitions.getMeasureDistanceToolCommand(this._props.enableSheetMeasurement));
       }
       if (!featureFlags?.hideAreaTool) {
-        tools.push(MeasureToolDefinitions.getMeasureAreaToolCommand(this._props?.enableSheetMeasurement ?? false));
+        tools.push(MeasureToolDefinitions.getMeasureAreaToolCommand(this._props.enableSheetMeasurement));
       }
       if (!featureFlags?.hideLocationTool) {
-        tools.push(MeasureToolDefinitions.getMeasureLocationToolCommand(this._props?.enableSheetMeasurement ?? false));
+        tools.push(MeasureToolDefinitions.getMeasureLocationToolCommand(this._props.enableSheetMeasurement));
       }
       if (!featureFlags?.hideRadiusTool) {
         tools.push(MeasureToolDefinitions.measureRadiusToolCommand);
@@ -72,14 +83,14 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
         return [
           ToolbarItemUtilities.createGroupItem(
             "measure-tools-toolbar",
-            this._props?.itemPriority ?? 20,
+            this._props.itemPriority,
             "icon-measure",
             MeasureTools.localization.getLocalizedString(
               "MeasureTools:MeasurementGroupButton.tooltip",
             ),
             ToolbarHelper.constructChildToolbarItems(tools),
             {
-              groupPriority: this._props?.groupPriority ?? 10,
+              groupPriority: this._props.groupPriority,
               isHidden: new ConditionalBooleanValue(
                 isSheetViewActive,
                 [SyncUiEventId.ViewStateChanged],
@@ -119,13 +130,9 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
     section?: StagePanelSection | undefined,
   ): ReadonlyArray<Widget> {
     const widgets: Widget[] = [];
-    const preferredLocation = this._props?.widgetPlacement?.location ?? StagePanelLocation.Right;
-    const preferredSection = this._props?.widgetPlacement?.section ?? StagePanelSection.Start;
-    if (
-      stageUsage === StageUsage.General &&
-      location === preferredLocation &&
-      section === preferredSection
-    ) {
+    const preferredLocation = this._props.widgetPlacement.location;
+    const preferredSection = this._props.widgetPlacement.section;
+    if (this._props.stageUsageList.includes(stageUsage) && location === preferredLocation && section === preferredSection) {
       {
         widgets.push({
           id: MeasurementPropertyWidgetId,

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -14,7 +14,7 @@ import { MeasurementSyncUiEventId } from "../api/MeasurementEnums";
 import { MeasurementUIEvents } from "../api/MeasurementUIEvents";
 import { MeasureTools } from "../MeasureTools";
 import { MeasureToolDefinitions } from "../tools/MeasureToolDefinitions";
-import type { RecursiveRequire } from "../utils/types";
+import type { RecursiveRequired } from "../utils/types";
 import { MeasurementPropertyWidget, MeasurementPropertyWidgetId } from "./MeasurementPropertyWidget";
 import { IModelApp } from "@itwin/core-frontend";
 
@@ -36,7 +36,7 @@ export interface MeasureToolsUiProviderOptions {
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
   public readonly id = "MeasureToolsUiItemsProvider";
-  private _props: RecursiveRequire<MeasureToolsUiProviderOptions>;
+  private _props: RecursiveRequired<MeasureToolsUiProviderOptions>;
 
   constructor(props?: MeasureToolsUiProviderOptions) {
     this._props = {

--- a/packages/itwin/measure-tools/src/utils/types.ts
+++ b/packages/itwin/measure-tools/src/utils/types.ts
@@ -1,0 +1,2 @@
+/** A utility type which makes all keys required, including nested keys.  */
+export type RecursiveRequire<T> = { [K in keyof T]-?: RecursiveRequire<T[K]> };

--- a/packages/itwin/measure-tools/src/utils/types.ts
+++ b/packages/itwin/measure-tools/src/utils/types.ts
@@ -1,2 +1,2 @@
 /** A utility type which makes all keys required, including nested keys.  */
-export type RecursiveRequire<T> = { [K in keyof T]-?: RecursiveRequire<T[K]> };
+export type RecursiveRequired<T> = { [K in keyof T]-?: RecursiveRequired<T[K]> };


### PR DESCRIPTION
Closes #1019

[MeasureToolsUiItemsProvider ](https://github.com/iTwin/viewer-components-react/blob/master/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx) can optionally have an array of StageUsages passed to its constructor. It defaults to the original value of StageUsage.General.

I also refactored the code so that all the default values are inserted within the constructor, because stageUsageList is used more than once. 