### PR TITLE
Add volume measurement tool

### DIFF
--- a/change/@itwin-measure-tools-react-d4cd4a91-77b9-405d-af6d-9d910bdd494d.json
+++ b/change/@itwin-measure-tools-react-d4cd4a91-77b9-405d-af6d-9d910bdd494d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add volume measurement tool",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "88331924+saaaaaally@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
+++ b/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
@@ -139,8 +139,10 @@
       "keyin": "Volume",
       "flyover": "Volume",
       "description": "Create volume measurements.",
-      "volume": "Volume:",
-      "toolTitle": "Volume Measurement [{0}]"
+      "net": "Net:",
+      "toolTitle": "Volume Measurement [{0}]",
+      "cut": "Cut:",
+      "fill": "Fill:"
     }
   },
   "Measurements": {

--- a/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
+++ b/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
@@ -134,6 +134,13 @@
       "pickAlignment": "Pick alignment",
       "restart": "Restart",
       "clearCurrentMeasurement": "Clear current"
+    },
+    "MeasureVolume": {
+      "keyin": "Volume",
+      "flyover": "Volume",
+      "description": "Create volume measurements.",
+      "volume": "Volume:",
+      "toolTitle": "Volume Measurement [{0}]"
     }
   },
   "Measurements": {
@@ -142,7 +149,8 @@
     "closePolygon": "Close Polygon",
     "distanceMeasurement": "Distance Measurement",
     "locationMeasurement": "Location Measurement",
-    "persistMeasurements": "Persist Measurements"
+    "persistMeasurements": "Persist Measurements",
+    "volumeMeasurement": "Volume Measurement"
   },
   "MeasurementGroupButton": {
     "label": "Measurement",

--- a/packages/itwin/measure-tools/src/MeasureTools.ts
+++ b/packages/itwin/measure-tools/src/MeasureTools.ts
@@ -14,6 +14,7 @@ import { MeasureRadiusTool } from "./tools/MeasureRadiusTool";
 import { MeasureAngleTool } from "./tools/MeasureAngleTool";
 import { MeasurePerpendicularTool } from "./tools/MeasurePerpendicularTool";
 import type { Localization } from "@itwin/core-common";
+import { MeasureVolumeTool } from "./tools/MeasureVolumeTool";
 
 export interface FeatureFlags {
   hideDistanceTool?: boolean;
@@ -23,6 +24,7 @@ export interface FeatureFlags {
   hideAngleTool?: boolean;
   hidePerpendicularTool?: boolean;
   hideToggleDisplayAxesTool?: boolean;
+  showVolumeTool?: boolean;
 }
 
 export interface StartupOptions {
@@ -84,6 +86,9 @@ export class MeasureTools {
     }
     if (!featureFlags?.hideToggleDisplayAxesTool) {
       toolsToRegister.push(ToggleDisplayMeasurementAxesTool);
+    }
+    if (featureFlags?.showVolumeTool) {
+      toolsToRegister.push(MeasureVolumeTool);
     }
     if (toolsToRegister.length > 0) {
       toolsToRegister.push(ClearMeasurementsTool);

--- a/packages/itwin/measure-tools/src/api/VolumePolygon.ts
+++ b/packages/itwin/measure-tools/src/api/VolumePolygon.ts
@@ -1,0 +1,288 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { ClipVector, Matrix3d, MomentData, Plane3dByOriginAndUnitNormal, Point3d, Range3d, Ray3d, StandardViewIndex, Vector3d } from "@itwin/core-geometry";
+import type { StyleSet } from "./GraphicStyle";
+import { Polygon } from "./Polygon";
+import {
+  IModelApp,
+  OffScreenViewport,
+  Pixel,
+  QuantityType,
+  type ScreenViewport,
+  SpatialViewState,
+  type Tile,
+  TileTreeLoadStatus,
+  type Viewport,
+  ViewRect,
+  type ViewState
+} from "@itwin/core-frontend";
+import { ColorDef, type ContextRealityModelProps, RenderMode } from "@itwin/core-common";
+
+export class VolumeInfo {
+  public get net() { return this.cut - this.fill; }
+  public cut = 0;   // in cubic-meter
+  public fill = 0;  // in cubic-meter
+  public area = 0;  // in square-meter
+  public hitCount = 0; // how many pixels were part of the computation
+  public pixelCount = 0; // how many pixels we had
+  public pixelSize = 0;
+}
+
+export class VolumePolygon extends Polygon {
+  private _volume: number;
+
+  public get volume(): number {
+    return this._volume;
+  }
+
+  constructor(points: Point3d[], copyPoints: boolean = true, styleSet?: StyleSet, worldScale?: number) {
+    super(points, copyPoints, styleSet, worldScale);
+    this._volume = 0;
+  }
+
+  public override async recomputeFromPoints(targetView?: ScreenViewport) {
+    super.recomputeFromPoints();
+    const volume = await this.computeVolume(targetView ?? IModelApp.viewManager.selectedView);
+    this._volume = volume?.net ?? 0;
+    const volumeFormatter = IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.Volume);
+
+    const fVolume = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._volume, volumeFormatter);
+    this.overrideText = [fVolume];
+  }
+
+  private async computeVolume(viewport?: ScreenViewport) {
+    const plane = this.computeShapePlane();
+    if (!plane)
+      return;
+    const shapeOnPlane = this.projectShapeToMeanPlane(plane);
+    if (!plane || !shapeOnPlane || !viewport)
+      return;
+
+    const clip = ClipVector.createEmpty();
+    if (!clip.appendShape(shapeOnPlane)) {
+      return;
+    }
+
+    const shapeRangeWorld = Range3d.createArray(shapeOnPlane);
+    const offscreenViewport = VolumePolygon.createElevationViewport(shapeRangeWorld, viewport.view, clip);
+
+    if (!offscreenViewport === undefined) {
+      return;
+    }
+
+    const volume = await this.doComputeVolume(offscreenViewport, plane);
+    if (!volume) {
+      return;
+    }
+
+    return volume;
+  }
+
+  private computeShapePlane(): Plane3dByOriginAndUnitNormal | undefined {
+    const momentData = MomentData.pointsToPrincipalAxes(this.points);
+    if (!momentData)
+      {return undefined;}
+
+    const colZ = momentData.localToWorldMap.matrix.columnZ();
+    return Plane3dByOriginAndUnitNormal.create(momentData.origin, colZ);
+  }
+
+  /* Compute the mean plane and project the shape to this plane in the z direction */
+  private projectShapeToMeanPlane(plane: Plane3dByOriginAndUnitNormal): Point3d[] | undefined {
+    if (plane === undefined)
+      {return undefined;}
+
+    const shapeOnPlane: Point3d[] = [];
+    for (const pt of this.points) {
+      const ray = Ray3d.create(pt, Vector3d.create(0, 0, 1));
+      const intersectPt = Point3d.createZero();
+      if (ray.intersectionWithPlane(plane, intersectPt) === undefined)
+        {return undefined;}
+
+      shapeOnPlane.push(intersectPt);
+    }
+    return shapeOnPlane;
+  }
+
+  private async doComputeVolume(viewport: OffScreenViewport, plane: Plane3dByOriginAndUnitNormal): Promise<VolumeInfo | undefined> {
+    await this.waitForAllTilesToRender(viewport);
+    const viewRect = viewport.viewRect;
+    const devicePixelSize = viewport.getPixelSizeAtPoint() * viewport.devicePixelRatio;
+    let volume: VolumeInfo | undefined;
+
+    // Input rect is specified in CSS pixels - convert to device pixels.
+    const deviceRect = new ViewRect(
+      viewport.cssPixelsToDevicePixels(viewRect.left),
+      viewport.cssPixelsToDevicePixels(viewRect.top),
+      viewport.cssPixelsToDevicePixels(viewRect.right),
+      viewport.cssPixelsToDevicePixels(viewRect.bottom)
+    );
+
+    viewport.readPixels(viewRect, Pixel.Selector.GeometryAndDistance, (pixels) => {
+      if (!pixels)
+        return;
+
+      volume = this.computeVolumeNpc(viewport, pixels, devicePixelSize, deviceRect, plane);
+    });
+
+    if (!volume)
+      return undefined;
+
+    volume.pixelCount = deviceRect.width * deviceRect.height;
+    volume.pixelSize = devicePixelSize;
+    volume.area = volume.hitCount * devicePixelSize * devicePixelSize;
+    return volume;
+  }
+
+  /* Compute volume using Npc coordinate. Usually twice as fast than computeVolumeWorld.
+  *  It assumed a Npc to World transform without perspective and top oriented viewport.
+  */
+  private computeVolumeNpc(offViewport: Viewport, pixels: Pixel.Buffer, devicePixelSize: number, deviceRect: ViewRect, plane: Plane3dByOriginAndUnitNormal): VolumeInfo | undefined {
+    // We assume we do not have perspective!
+    const worldToNpc = offViewport.viewingSpace.worldToNpcMap.transform0.asTransform;
+    if (!worldToNpc)
+      return undefined;
+
+    const planeInNpc = plane.cloneTransformed(worldToNpc);
+    if (!planeInNpc)
+      return undefined;
+
+    const worldBottom = offViewport.npcToWorld(Point3d.create(0, 0, 0));
+    const worldTop = offViewport.npcToWorld(Point3d.create(0, 0, 1));
+    const viewBoxHeight = worldTop.distance(worldBottom);
+
+    const volume = new VolumeInfo();
+    for (let line = deviceRect.top; line < deviceRect.bottom; ++line) {
+      for (let column = deviceRect.left; column < deviceRect.right; ++column) {
+        const z = pixels.getPixel(column, line).distanceFraction;
+        if (z <= 0.0)
+          {continue;}  // hole or clipped
+
+        const npcPoint = Point3d.create((column + 0.5) / deviceRect.width,
+          1.0 - (line + 0.5) / deviceRect.height,
+          z);
+
+        const altitude = planeInNpc.altitude(npcPoint);
+        if (altitude > 0) {
+          volume.cut += altitude;
+        } else {
+          volume.fill += -altitude;
+        }
+
+        ++volume.hitCount;
+      }
+    }
+
+    // Convert npc height to meters and apply sample size.
+    volume.cut *= viewBoxHeight * devicePixelSize * devicePixelSize;
+    volume.fill *= viewBoxHeight * devicePixelSize * devicePixelSize;
+    return volume;
+  }
+
+  /** Create a top align viewport, fitted to the range.
+   * @param range The view range in world coordinate.
+   * @param viewRef The view seed.
+   * @param clip Optional clip.
+   * @param nbPixels  The view size in pixels. Aspect ratio of range is preserved so only one axis will have the requested amount
+   * @returns The viewport
+   */
+  public static createElevationViewport(viewAlignedVolume: Range3d, viewRef: ViewState, clip?: ClipVector, nbPixels?: number) {
+    const defaultNbPixels = 1024;
+    const maxNbPixels = 2048;
+    const minPixelSize = .01;
+
+    const rotation = Matrix3d.createStandardWorldToView(StandardViewIndex.Top);
+    const projectExtent = viewRef.iModel.projectExtents;
+    const viewState = SpatialViewState.createBlank(viewRef.iModel, projectExtent.low, projectExtent.high.minus(projectExtent.low), rotation);
+
+    const style = viewState.displayStyle;
+    const viewFlags = style.viewFlags.copy({renderMode: RenderMode.SmoothShade, lighting: false, backgroundMap: false, transparency: false });
+    style.viewFlags = viewFlags; // call to accessor to get the json properties to reflect the changes to ViewFlags
+
+    style.backgroundColor = ColorDef.white;
+
+    // Add Reality Data displayed coming from context share
+    viewRef.displayStyle.forEachRealityModel((model) => {
+      const props: ContextRealityModelProps = {
+        rdSourceKey: model.rdSourceKey,
+        tilesetUrl: model.url,
+        name: model.name,
+        description: model.description,
+      };
+
+      style.attachRealityModel(props);
+    });
+
+    // turn off the ground and sky box in the environment
+    const env = style.environment.clone({displayGround: false, displaySky: false});
+    style.environment = env; // call to accessor to get the json properties to reflect the changes
+
+    if (clip !== undefined)
+      {viewState.setViewClip(clip);}
+
+    viewState.lookAtViewAlignedVolume(viewAlignedVolume);
+
+    const aspectRatio = viewAlignedVolume.xLength() / viewAlignedVolume.yLength();
+    const pixelCount = Math.min(nbPixels ?? defaultNbPixels, maxNbPixels);
+
+    const viewRect = new ViewRect(0.0);
+    if (aspectRatio > 1.0) {
+      viewRect.right = Math.min(pixelCount, viewAlignedVolume.xLength() / minPixelSize);
+      viewRect.bottom = Math.ceil(viewRect.width / aspectRatio);
+    } else {
+      viewRect.bottom = Math.min(pixelCount, viewAlignedVolume.yLength() / minPixelSize);
+      viewRect.right = Math.ceil(viewRect.height * aspectRatio);
+    }
+
+    return OffScreenViewport.create({view: viewState, viewRect});
+  }
+
+  /** Render frame and wait for all tiles to render */
+  private async waitForAllTilesToRender(viewport: OffScreenViewport): Promise<void> {
+    viewport.renderFrame();
+
+    // NB: ToolAdmin loop is not turned on, and this viewport is not tracked by ViewManager - must manually pump tile request scheduler.
+    IModelApp.tileAdmin.process(); // eslint-disable-next-line @itwin/no-internal
+
+    if (this.areAllTilesLoaded(viewport))
+      {return Promise.resolve();}
+
+    await new Promise<void>((resolve: any) => setTimeout(resolve, 100));
+
+    // This viewport isn't added to ViewManager, so it won't be notified (and have its scene invalidated) when new tiles become loaded.
+    viewport.invalidateScene();
+    return this.waitForAllTilesToRender(viewport);
+  }
+
+  private areAllTilesLoaded(viewport: OffScreenViewport): boolean {
+    if (viewport.numRequestedTiles > 0)
+    return false;
+
+    let allLoaded = true;
+    viewport.view.forEachTileTreeRef((ref) => {
+      allLoaded = allLoaded && ref.isLoadingComplete && this.areAllChildTilesLoaded(ref.treeOwner.tileTree?.rootTile);
+    });
+
+    return allLoaded;
+  }
+
+  private areAllChildTilesLoaded(parent?: Tile): boolean {
+    if (!parent)
+      return true;
+    else if ((parent as any)._childrenLoadStatus === TileTreeLoadStatus.Loading  )
+      return false;
+
+    const kids = parent.children;
+    if (!kids)
+      return true;
+
+    for (const kid of kids)
+      {if (!this.areAllChildTilesLoaded(kid))
+        {return false;}}
+
+    return true;
+  }
+}

--- a/packages/itwin/measure-tools/src/measure-tools-react.ts
+++ b/packages/itwin/measure-tools/src/measure-tools-react.ts
@@ -43,6 +43,7 @@ export * from "./tools/MeasureLocationTool";
 export * from "./tools/MeasurePerpendicularTool";
 export * from "./tools/MeasureRadiusTool";
 export * from "./tools/MeasureToolDefinitions";
+export * from "./tools/MeasureVolumeTool";
 
 export * from "./ui-2.0/MeasureToolsUiProvider";
 export * from "./ui-2.0/MeasurementPropertyWidget";

--- a/packages/itwin/measure-tools/src/measurements/VolumeMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/VolumeMeasurement.ts
@@ -332,8 +332,23 @@ export class VolumeMeasurement extends Measurement {
 
     const fPerimeter = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this._polygon.perimeter, lengthSpec);
     const fArea = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this._polygon.area, areaSpec);
-    const fVolume = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._polygon.volume, volumeSpec);
     const fEdgeCount = (this._polygon.points.length - 1).toFixed();
+
+    let fVolume: string = "";
+    let fCut: string = "";
+    let fFill: string = "";
+    if (this._polygon.volume && this._polygon.cut && this._polygon.fill) {
+      fVolume = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._polygon.volume, volumeSpec);
+      fCut = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._polygon.cut, volumeSpec);
+      fFill = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._polygon.fill, volumeSpec);
+    } else {
+      const volume = await this._polygon.recomputeFromPoints();
+      if (volume) {
+        fVolume = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * volume.net, volumeSpec);
+        fCut = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * volume.cut, volumeSpec);
+        fFill = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * volume.fill, volumeSpec);
+      }
+    }
 
     const title = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.toolTitle").replace("{0}", fVolume);
 
@@ -341,13 +356,23 @@ export class VolumeMeasurement extends Measurement {
     MeasurementPropertyHelper.tryAddNameProperty(this, data.properties);
 
     data.properties.push({
-      label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.volume"),
+      label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.net"),
       name: "VolumeMeasurement_Volume",
       value: fVolume,
-      aggregatableValue: volumeSpec !== undefined ? { value: this._polygon.volume, formatSpec: volumeSpec } : undefined,
+      aggregatableValue: volumeSpec && this._polygon.volume ? { value: this._polygon.volume, formatSpec: volumeSpec } : undefined,
     });
 
     data.properties.push(
+      {
+        label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.cut"),
+        name: "VolumeMeasurement_Cut",
+        value: fCut,
+      },
+      {
+        label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.fill"),
+        name: "VolumeMeasurement_Fill",
+        value: fFill,
+      },
       {
         label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.popupArea"),
         name: "VolumeMeasurement_Area",

--- a/packages/itwin/measure-tools/src/measurements/VolumeMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/VolumeMeasurement.ts
@@ -1,0 +1,481 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import type { Id64String } from "@itwin/core-bentley";
+import type { XYZProps } from "@itwin/core-geometry";
+import { Geometry, IModelJson, Point3d, PointString3d, PolygonOps } from "@itwin/core-geometry";
+import type { GeometryStreamProps } from "@itwin/core-common";
+import { BeButtonEvent, type DecorateContext, type GraphicBuilder, type RenderGraphicOwner, type ScreenViewport } from "@itwin/core-frontend";
+import { GraphicType, IModelApp, InputSource, QuantityType } from "@itwin/core-frontend";
+import { StyleSet, WellKnownGraphicStyleType } from "../api/GraphicStyle";
+import type { MeasurementEqualityOptions, MeasurementWidgetData } from "../api/Measurement";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement";
+import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper";
+import type { MeasurementProps } from "../api/MeasurementProps";
+import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet";
+import type { Polygon } from "../api/Polygon";
+import { DistanceMeasurement } from "./DistanceMeasurement";
+import { MeasureTools } from "../MeasureTools";
+import { VolumePolygon } from "../api/VolumePolygon";
+
+/**
+ * Props for serializing a [[VolumeMeasurement]].
+ */
+export interface VolumeMeasurementProps extends MeasurementProps {
+  polygonPoints: XYZProps[];
+}
+
+/** Serializer for a [[VolumeMeasurement]]. */
+export class VolumeMeasurementSerializer extends MeasurementSerializer {
+  public static readonly volumeMeasurementName = "volumeMeasurement";
+
+  public get measurementName(): string {
+    return VolumeMeasurementSerializer.volumeMeasurementName;
+  }
+
+  public isValidType(measurement: Measurement): boolean {
+    return measurement instanceof VolumeMeasurement;
+  }
+
+  public override isValidJSON(json: any): boolean {
+    if (!super.isValidJSON(json) || !json.hasOwnProperty("polygonPoints") || !Array.isArray(json.polygonPoints)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected parseSingle(data: MeasurementProps): Measurement | undefined {
+    if (!this.isValidJSON(data)) return undefined;
+
+    const props = data as VolumeMeasurementProps;
+    return VolumeMeasurement.fromJSON(props);
+  }
+}
+
+/**
+ * Volume measurement. A polygon with formatted volume in a "text pill" at the center.
+ */
+export class VolumeMeasurement extends Measurement {
+  public static override readonly serializer = Measurement.registerSerializer(new VolumeMeasurementSerializer());
+
+  private _polygon: VolumePolygon;
+
+  private _isDynamic: boolean; // No serialize, for dynamics
+  protected _dynamicEdge?: DistanceMeasurement; // No serialize, for dynamics
+
+  private _cachedGraphic?: RenderGraphicOwner;
+
+  public get isDynamic(): boolean {
+    return this._isDynamic;
+  }
+
+  public set isDynamic(isDynamic: boolean) {
+    this._isDynamic = isDynamic;
+    this._polygon.makeSelectable(!isDynamic);
+    this.clearCachedGraphics();
+  }
+
+  public get polygon(): Polygon {
+    return this._polygon;
+  }
+
+  public get polygonPoints(): Point3d[] {
+    return this._polygon.points;
+  }
+
+  public get isValidPolygon(): boolean {
+    if (this.polygonPoints.length < 3) return false;
+
+    const area = Math.abs(PolygonOps.area(this.polygonPoints));
+    if (0 >= area) return false;
+
+    return true;
+  }
+
+  constructor(props?: VolumeMeasurementProps) {
+    super(props);
+
+    this._polygon = new VolumePolygon([], false);
+    this._polygon.textMarker.setMouseButtonHandler(this.handleTextMarkerButtonEvent.bind(this));
+    this._polygon.textMarker.transientHiliteId = this.transientId;
+    this._polygon.makeSelectable(true);
+    this._isDynamic = false;
+
+    if (props) this.readFromJSON(props);
+  }
+
+  protected handleTextMarkerButtonEvent(ev: BeButtonEvent): boolean {
+    if (this.isDynamic) return false;
+
+    void this.onDecorationButtonEvent(MeasurementPickContext.createFromSourceId("Invalid", ev));
+
+    return true;
+  }
+
+  public addPointToDynamicPolygon(ev: BeButtonEvent): boolean {
+    if (!this.isDynamic) return false;
+
+    // Ignore the point if it's the same as the last one
+    if (this.polygonPoints.length > 0 && this.polygonPoints[this.polygonPoints.length - 1].isAlmostEqual(ev.point)) return false;
+
+    this.polygonPoints.push(ev.point.clone());
+    this.clearCachedGraphics();
+
+    // Check if we should close the polygon, if it's last and first points now equal
+    if (ev && this.isSnapToShapeOrigin(ev) && ev.viewport) {
+      this.polygonPoints.pop();
+      this.polygonPoints.push(this.polygonPoints[0].clone()); // Copy first point to close the polygon
+      this.closeDynamicPolygon(ev.viewport);
+      return true;
+    }
+
+    return false;
+  }
+
+  private isSnapToShapeOrigin(ev: BeButtonEvent): boolean {
+    if (ev.viewport === undefined || this.polygonPoints.length < 3) return false;
+
+    const firstPtView = ev.viewport.worldToView(this.polygonPoints[0]);
+    const snapDistanceView = ev.viewport.pixelsFromInches(
+      InputSource.Touch === ev.inputSource ? IModelApp.locateManager.touchApertureInches : IModelApp.locateManager.apertureInches,
+    );
+    const isWithinDistance = firstPtView.distanceXY(ev.viewPoint) <= snapDistanceView;
+    const isAlmostEqual = this.polygonPoints[0].isAlmostEqual(this.polygonPoints[this.polygonPoints.length - 1]);
+    return isWithinDistance || isAlmostEqual;
+  }
+
+  public updateDynamicPolygon(point: Point3d, recompute?: boolean): void {
+    if (!this.isDynamic) return;
+
+    const length = this.polygonPoints.length;
+    if (length === 0) return;
+
+    const start = this.polygonPoints[length - 1];
+    this._dynamicEdge = DistanceMeasurement.create(start, point);
+    if (this.drawingMetadata?.origin) this._dynamicEdge.drawingMetadata = { origin: this.drawingMetadata.origin, worldScale: this.worldScale };
+    this._dynamicEdge.sheetViewId = this.sheetViewId;
+    this._dynamicEdge.viewTarget.copyFrom(this.viewTarget);
+    this._dynamicEdge.style = this.style;
+    this._dynamicEdge.lockStyle = this.lockStyle;
+    this._dynamicEdge.isDynamic = true;
+    this._dynamicEdge.showAxes = false;
+    this._dynamicEdge.displayLabels = this.displayLabels;
+    if (recompute) {
+      this._polygon.recomputeFromPoints();
+    }
+  }
+
+  public closeDynamicPolygon(targetView: ScreenViewport): boolean {
+    if (!this.isDynamic || !this.isValidPolygon) return false;
+
+    this._polygon.recomputeFromPoints(targetView);
+    this._dynamicEdge = undefined;
+    this.isDynamic = false;
+    return true;
+  }
+
+  public override testDecorationHit(pickContext: MeasurementPickContext): boolean {
+    if (this.transientId && this.transientId === pickContext.geomId) return true;
+
+    if (pickContext.buttonEvent && this.displayLabels) return this._polygon.textMarker.pick(pickContext.buttonEvent.viewPoint);
+
+    return false;
+  }
+
+  public override getDecorationGeometry(_pickContext: MeasurementPickContext): GeometryStreamProps | undefined {
+    if (this.polygonPoints.length === 0) return undefined;
+
+    // If dynamic, only want to return the first snap point, because as we're laying out a dynamic polygon we want to be able to snap to itself at the first point
+    if (this.isDynamic) {
+      if (this.polygonPoints.length >= 3) return [IModelJson.Writer.toIModelJson(PointString3d.create(this.polygonPoints[0]))];
+
+      return undefined;
+    }
+
+    return [IModelJson.Writer.toIModelJson(PointString3d.create(this.polygonPoints))];
+  }
+
+  public override async getDecorationToolTip(_pickContext: MeasurementPickContext): Promise<HTMLElement | string> {
+    if (this.isDynamic) return MeasureTools.localization.getLocalizedString("MeasureTools:Measurements.closePolygon");
+
+    return MeasureTools.localization.getLocalizedString("MeasureTools:Measurements.volumeMeasurement");
+  }
+
+  protected getSnapId(): string | undefined {
+    if (!this.transientId) this.transientId = MeasurementSelectionSet.nextTransientId;
+
+    // We participate even during dynamics, so we can snap to the first point to close. But it only makes sense to do so if there are 3 or more points.
+    if (this.isDynamic && this.polygonPoints.length < 3) return undefined;
+
+    return this.transientId;
+  }
+
+  public clearDynamicEdge() {
+    this._dynamicEdge = undefined;
+  }
+
+  public clearCachedGraphics() {
+    if (this._cachedGraphic) {
+      this._cachedGraphic.disposeGraphic();
+      this._cachedGraphic = undefined;
+    }
+  }
+
+  public override onCleanup() {
+    this.clearCachedGraphics();
+  }
+
+  protected override onTransientIdChanged(_prevId: Id64String) {
+    this._polygon.textMarker.transientHiliteId = this.transientId;
+    this.clearCachedGraphics();
+  }
+
+  protected addDynamicSnapGraphic(styleSet: StyleSet, context: DecorateContext): void {
+    if (!this.isDynamic || this.polygonPoints.length === 0) return;
+
+    // Add a graphic just for snapping to the first point if we can
+    const firstPtSnapId = this.getSnapId();
+    if (firstPtSnapId === undefined) return;
+
+    const builder = context.createGraphicBuilder(GraphicType.WorldOverlay, undefined, firstPtSnapId);
+
+    // Make sure it's the same symbology as the polygon drawing code
+    const ev = new BeButtonEvent();
+    IModelApp.toolAdmin.fillEventFromCursorLocation(ev);
+    if (!ev.viewport) {
+      return;
+    }
+    const firstPtView = context.viewport.worldToView(this.polygonPoints[0]);
+    firstPtView.z = 0;
+    const isComplete = this.isSnapToShapeOrigin(ev);
+    const style = styleSet.getGraphicStyle(WellKnownGraphicStyleType.AreaMeasurementDynamic)!.clone();
+    style.lineWidth += 11;
+    const lineColor = isComplete ? context.viewport.hilite.color.tbgr : style.lineColor;
+    style.lineColor = lineColor;
+    style.addStyledPointString(builder, [this.polygonPoints[0]], false);
+    context.addDecorationFromBuilder(builder);
+  }
+
+  public override onDrawingMetadataChanged(): void {
+    this.polygon.worldScale = this.worldScale;
+    this._polygon.recomputeFromPoints();
+  }
+
+  public override decorate(context: DecorateContext): void {
+    super.decorate(context);
+
+    if (this.polygonPoints.length === 0) return;
+
+    const styleTheme = StyleSet.getOrDefault(this.activeStyle);
+    const snapId = !this.isDynamic ? this.getSnapId() : undefined;
+
+    if (this.isDynamic) {
+      this.addDynamicSnapGraphic(styleTheme, context);
+
+      if (this._dynamicEdge) this._dynamicEdge.decorate(context);
+
+      const dynamicGBuilde = context.createGraphicBuilder(GraphicType.WorldOverlay);
+      this.drawDynamicArea(styleTheme, dynamicGBuilde);
+      context.addDecorationFromBuilder(dynamicGBuilde);
+
+      if (!this._cachedGraphic) {
+        const polygonGBuilder = context.createGraphicBuilder(GraphicType.WorldOverlay);
+        this.drawDynamicPolygonShape(styleTheme, polygonGBuilder);
+        this._cachedGraphic = IModelApp.renderSystem.createGraphicOwner(polygonGBuilder.finish());
+      }
+    } else {
+      if (!this._cachedGraphic) {
+        const polygonGBuilder = context.createGraphicBuilder(GraphicType.WorldOverlay, undefined, snapId);
+        this._polygon.addToGraphicBuilder(polygonGBuilder);
+        this._cachedGraphic = IModelApp.renderSystem.createGraphicOwner(polygonGBuilder.finish());
+      }
+    }
+
+    if (this._cachedGraphic) context.addDecoration(GraphicType.WorldOverlay, this._cachedGraphic);
+
+    if (0.0 < this._polygon.area && this.displayLabels) this._polygon.drawTextMarker(context);
+  }
+
+  private drawDynamicArea(styleSet: StyleSet, graphicBuilder: GraphicBuilder): void {
+    if (!this._dynamicEdge || this.polygonPoints.length === 0 || !this.polygon.drawFillArea) return;
+
+    const first = this.polygonPoints[0];
+    const last = this._dynamicEdge.startPointRef;
+    const dynamic = this._dynamicEdge.endPointRef;
+    const pointsOnTemporaryShape = [first, last, dynamic];
+    const style = styleSet.getGraphicStyle(WellKnownGraphicStyleType.AreaMeasurementDynamic)!;
+    style.addStyledShape(graphicBuilder, pointsOnTemporaryShape, false);
+  }
+
+  private drawDynamicPolygonShape(styleSet: StyleSet, graphicBuilder: GraphicBuilder): void {
+    if (this.polygonPoints.length === 0) return;
+
+    // If drawing with fill, use the dynamic style. If not, use the regular style since it'll just be the outline (by default dynamic is lighter in color/transparency)
+    const outlineStyleType = this.polygon.drawFillArea ? WellKnownGraphicStyleType.AreaMeasurementDynamic : WellKnownGraphicStyleType.AreaMeasurement;
+    const style = styleSet.getGraphicStyle(outlineStyleType)!;
+    style.addStyledPointString(graphicBuilder, this.polygonPoints, false);
+    style.addStyledLineString(graphicBuilder, this.polygonPoints, false);
+
+    if (this.polygon.drawFillArea) {
+      const style2 = styleSet.getGraphicStyle(WellKnownGraphicStyleType.AreaMeasurement)!;
+      style2.addStyledShape(graphicBuilder, this.polygonPoints, false);
+    }
+  }
+
+  protected override async getDataForMeasurementWidgetInternal(): Promise<MeasurementWidgetData> {
+    const lengthSpec = await IModelApp.quantityFormatter.getFormatterSpecByQuantityType(QuantityType.LengthEngineering);
+    const areaSpec = await IModelApp.quantityFormatter.getFormatterSpecByQuantityType(QuantityType.Area);
+    const volumeSpec = await IModelApp.quantityFormatter.getFormatterSpecByQuantityType(QuantityType.Volume);
+
+    const fPerimeter = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this._polygon.perimeter, lengthSpec);
+    const fArea = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this._polygon.area, areaSpec);
+    const fVolume = IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.worldScale * this._polygon.volume, volumeSpec);
+    const fEdgeCount = (this._polygon.points.length - 1).toFixed();
+
+    const title = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.toolTitle").replace("{0}", fVolume);
+
+    const data: MeasurementWidgetData = { title, properties: [] };
+    MeasurementPropertyHelper.tryAddNameProperty(this, data.properties);
+
+    data.properties.push({
+      label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.volume"),
+      name: "VolumeMeasurement_Volume",
+      value: fVolume,
+      aggregatableValue: volumeSpec !== undefined ? { value: this._polygon.volume, formatSpec: volumeSpec } : undefined,
+    });
+
+    data.properties.push(
+      {
+        label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.popupArea"),
+        name: "VolumeMeasurement_Area",
+        value: fArea,
+      },
+      {
+        label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.popupPerimeter"),
+        name: "VolumeMeasurement_Perimeter",
+        value: fPerimeter,
+      },
+      {
+        label: MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.popupEdgeCount"),
+        name: "VolumeMeasurement_EdgeCount",
+        value: fEdgeCount,
+      },
+    );
+
+    return data;
+  }
+
+  protected override onStyleChanged(isLock: boolean, _prevStyle: string) {
+    // Make sure polygon uses the active style
+    this._polygon.styleSet = StyleSet.getOrDefault(this.activeStyle);
+    this.clearCachedGraphics();
+
+    // Copy the style to the dynamic edge
+    if (!this._dynamicEdge) return;
+
+    if (isLock) this._dynamicEdge.lockStyle = this.lockStyle;
+    else this._dynamicEdge.style = this.style;
+  }
+
+  protected override onDisplayLabelsToggled() {
+    if (this._dynamicEdge) this._dynamicEdge.displayLabels = this.displayLabels;
+  }
+
+  protected override onLockToggled() {
+    this._polygon.styleSet = StyleSet.getOrDefault(this.activeStyle);
+    this.clearCachedGraphics();
+  }
+
+  public override onDisplayUnitsChanged(): void {
+    this._polygon.recomputeFromPoints();
+  }
+
+  /**
+   * Tests equality with another measurement.
+   * @param other Measurement to test equality for.
+   * @param opts Options for equality testing.
+   * @returns true if the other measurement is equal, false if some property is not the same or if the measurement is not of the same type.
+   */
+  public override equals(other: Measurement, opts?: MeasurementEqualityOptions): boolean {
+    if (!super.equals(other, opts)) return false;
+
+    // Compare data (ignore isDynamic)
+    const tol = opts && opts.tolerance !== undefined ? opts.tolerance : Geometry.smallMetricDistance;
+    const otherVolume = other as VolumeMeasurement;
+    if (!otherVolume || this.polygonPoints.length !== otherVolume.polygonPoints.length) return false;
+
+    const thisPts = this.polygonPoints;
+    const otherPts = otherVolume.polygonPoints;
+
+    for (let i = 0; i < thisPts.length; i++) {
+      const thisPt = thisPts[i];
+      const otherPt = otherPts[i];
+
+      if (!thisPt.isAlmostEqual(otherPt, tol)) return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Copies data from the other measurement into this instance.
+   * @param other Measurement to copy property values from.
+   */
+  protected override copyFrom(other: Measurement) {
+    super.copyFrom(other);
+
+    if (other instanceof VolumeMeasurement) {
+      this.polygon.setPoints(other.polygonPoints, true, true);
+      this.isDynamic = other.isDynamic;
+
+      if (this.isDynamic && other._dynamicEdge) this.updateDynamicPolygon(other._dynamicEdge.endPointRef);
+    }
+  }
+
+  /**
+   * Deserializes properties (if they exist) from the JSON object.
+   * @param json JSON object to read data from.
+   */
+  protected override readFromJSON(json: MeasurementProps) {
+    super.readFromJSON(json);
+
+    const jsonVolume = json as VolumeMeasurementProps;
+    if (jsonVolume.polygonPoints !== undefined) {
+      const pts = new Array<Point3d>();
+      for (const pt of jsonVolume.polygonPoints) pts.push(Point3d.fromJSON(pt));
+
+      this._polygon.setPoints(pts, false, true);
+
+      if (this.isDynamic && this._dynamicEdge) this.updateDynamicPolygon(this._dynamicEdge.endPointRef, true);
+    }
+  }
+
+  /**
+   * Serializes properties to a JSON object.
+   * @param json JSON object to append data to.
+   */
+  protected override writeToJSON(json: MeasurementProps) {
+    super.writeToJSON(json);
+
+    const pts = new Array<XYZProps>();
+    for (const pt of this.polygonPoints) pts.push(pt.toJSON());
+
+    const jsonVolume = json as VolumeMeasurementProps;
+    jsonVolume.polygonPoints = pts;
+  }
+
+  public static create(pts: Point3d[], viewType?: string): VolumeMeasurement {
+    // Don't ned to serialize the points, will just work as is
+    const measurement = new VolumeMeasurement({ polygonPoints: pts });
+    if (viewType) measurement.viewTarget.include(viewType);
+
+    return measurement;
+  }
+
+  public static fromJSON(data: VolumeMeasurementProps): VolumeMeasurement {
+    return new VolumeMeasurement(data);
+  }
+}

--- a/packages/itwin/measure-tools/src/toolmodels/MeasureVolumeToolModel.ts
+++ b/packages/itwin/measure-tools/src/toolmodels/MeasureVolumeToolModel.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { MeasurementToolModel } from "../api/MeasurementToolModel";
+import type { DrawingMetadata } from "../api/Measurement";
+import { VolumeMeasurement } from "../measurements/VolumeMeasurement";
+import type { BeButtonEvent } from "@itwin/core-frontend";
+
+enum State {
+  SetMeasurementViewport,
+  AddPoint,
+}
+
+export class MeasureVolumeToolModel extends MeasurementToolModel<VolumeMeasurement> {
+  public static State = State;
+
+  private _currentState: State;
+  private _currentViewportType?: string;
+  private _currentMeasurement?: VolumeMeasurement;
+
+  constructor() {
+    super();
+    this._currentState = State.SetMeasurementViewport;
+  }
+
+  public get drawingMetadata(): DrawingMetadata | undefined {
+    return this._currentMeasurement?.drawingMetadata;
+  }
+
+  public set drawingMetadata(data: DrawingMetadata | undefined) {
+    if (this._currentMeasurement) this._currentMeasurement.drawingMetadata = data;
+  }
+
+  public set sheetViewId(id: string | undefined) {
+    if (this._currentMeasurement) this._currentMeasurement.sheetViewId = id;
+  }
+
+  public get sheetViewId(): string | undefined {
+    return this._currentMeasurement?.sheetViewId;
+  }
+
+  public get currentState(): State {
+    return this._currentState;
+  }
+
+  public get hasEnoughPoints(): boolean {
+    if (!this._currentMeasurement) return false;
+
+    return this._currentMeasurement.isValidPolygon;
+  }
+
+  public override get dynamicMeasurement(): VolumeMeasurement | undefined {
+    return this._currentMeasurement;
+  }
+
+  public setMeasurementViewport(viewType: string): boolean {
+    if (State.SetMeasurementViewport !== this._currentState) return false;
+
+    this._currentViewportType = viewType;
+    this._currentState = State.AddPoint;
+    return true;
+  }
+
+  public addPoint(viewType: string, ev: BeButtonEvent, isDynamic: boolean): boolean {
+    if (State.AddPoint !== this._currentState) return false;
+
+    if (viewType !== this._currentViewportType!) return false;
+
+    if (undefined === this._currentMeasurement) {
+      if (isDynamic) return false;
+
+      this._currentMeasurement = VolumeMeasurement.create([ev.point], viewType);
+      this._currentMeasurement.isDynamic = true;
+      this.notifyNewMeasurement();
+      return true;
+    }
+
+    if (isDynamic) {
+      this._currentMeasurement.updateDynamicPolygon(ev.point);
+      this.notifyDynamicMeasurementChanged();
+      return true;
+    }
+
+    // &&AG some refactor needed. addPointToDynamicPolygon returns false even when it added a point successfully
+    // returns only true if the polygon has been closed...
+    if (this._currentMeasurement.addPointToDynamicPolygon(ev)) {
+      this.notifyDynamicMeasurementChanged();
+      this.addMeasurementAndReset(this._currentMeasurement);
+    }
+
+    return true;
+  }
+
+  /** Attempts to remove the last point of the current measurement.
+   * * Fails if there is only one point left to prevent an invalid state.
+   */
+  public popMeasurementPoint(): boolean {
+    if (undefined === this._currentMeasurement) return false;
+
+    const polygon = this._currentMeasurement.polygon;
+    if (1 >= polygon.points.length) return false;
+
+    polygon.points.pop();
+    polygon.recomputeFromPoints();
+    this.notifyDynamicMeasurementChanged();
+    return true;
+  }
+
+  public override reset(clearMeasurements: boolean): void {
+    super.reset(clearMeasurements);
+
+    this._currentMeasurement = undefined;
+    this._currentState = State.SetMeasurementViewport;
+  }
+}

--- a/packages/itwin/measure-tools/src/toolmodels/MeasureVolumeToolModel.ts
+++ b/packages/itwin/measure-tools/src/toolmodels/MeasureVolumeToolModel.ts
@@ -103,7 +103,6 @@ export class MeasureVolumeToolModel extends MeasurementToolModel<VolumeMeasureme
     if (1 >= polygon.points.length) return false;
 
     polygon.points.pop();
-    polygon.recomputeFromPoints();
     this.notifyDynamicMeasurementChanged();
     return true;
   }

--- a/packages/itwin/measure-tools/src/tools/MeasureToolDefinitions.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureToolDefinitions.ts
@@ -17,6 +17,7 @@ import { MeasureRadiusTool } from "./MeasureRadiusTool";
 import { ToggleDisplayMeasurementAxesTool } from "./ToggleDisplayMeasurementAxesTool";
 import { MeasureTools } from "../MeasureTools";
 import { ConditionalBooleanValue } from "@itwin/appui-abstract";
+import { MeasureVolumeTool } from "./MeasureVolumeTool";
 
 export class MeasureToolDefinitions {
 
@@ -180,6 +181,19 @@ export class MeasureToolDefinitions {
       ),
       execute: () => {
         void IModelApp.tools.run(MeasurePerpendicularTool.toolId);
+      },
+    });
+  }
+
+  public static getMeasureVolumeToolCommand(enableSheetMeasurements: boolean) {
+    return new ToolItemDef({
+      toolId: MeasureVolumeTool.toolId,
+      iconSpec: MeasureVolumeTool.iconSpec,
+      label: () => MeasureVolumeTool.flyover,
+      tooltip: () => MeasureVolumeTool.description,
+      execute: () => {
+        const tool = new MeasureVolumeTool(enableSheetMeasurements);
+        void tool.run();
       },
     });
   }

--- a/packages/itwin/measure-tools/src/tools/MeasureVolumeTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureVolumeTool.ts
@@ -1,0 +1,254 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { AxisOrder, Matrix3d, Vector3d } from "@itwin/core-geometry";
+import type { DecorateContext, ToolAssistanceInstruction, ToolAssistanceSection } from "@itwin/core-frontend";
+import { AccuDrawHintBuilder, BeButtonEvent, EventHandled, IModelApp, ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod } from "@itwin/core-frontend";
+import { MeasurementToolBase } from "../api/MeasurementTool";
+import { MeasurementViewTarget } from "../api/MeasurementViewTarget";
+import { MeasureAreaToolModel } from "../toolmodels/MeasureAreaToolModel";
+import { MeasureTools } from "../MeasureTools";
+import { SheetMeasurementsHelper } from "../api/SheetMeasurementHelper";
+import type { DrawingMetadata } from "../api/Measurement";
+import { DrawingDataCache } from "../api/DrawingTypeDataCache";
+import type { VolumeMeasurement } from "../measurements/VolumeMeasurement";
+import { MeasureVolumeToolModel } from "../toolmodels/MeasureVolumeToolModel";
+
+export class MeasureVolumeTool extends MeasurementToolBase<VolumeMeasurement, MeasureVolumeToolModel> {
+  public static override toolId = "MeasureTools.MeasureVolume";
+  public static override iconSpec = "icon-measure-area";
+  private _enableSheetMeasurements: boolean;
+
+  public static override get flyover() {
+    return MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.flyover");
+  }
+  public static override get description(): string {
+    return MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.description");
+  }
+  public static override get keyin(): string {
+    return MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureVolume.keyin");
+  }
+
+  constructor(enableSheetMeasurements = false) {
+    super();
+    this._enableSheetMeasurements = enableSheetMeasurements;
+  }
+
+  public async onRestartTool(): Promise<void> {
+    const tool = new MeasureVolumeTool(this._enableSheetMeasurements);
+    if (await tool.run()) return;
+
+    return this.exitTool();
+  }
+
+  public override async onPostInstall(): Promise<void> {
+    await super.onPostInstall();
+  }
+
+  public override async onReinitialize(): Promise<void> {
+    await super.onReinitialize();
+    AccuDrawHintBuilder.deactivate();
+  }
+
+  public override async onUndoPreviousStep(): Promise<boolean> {
+    if (this.toolModel.popMeasurementPoint()) {
+      const ev = new BeButtonEvent();
+      this.getCurrentButtonEvent(ev);
+
+      // Update the dynamic polygon
+      await this.onMouseMotion(ev);
+
+      this._sendHintsToAccuDraw(ev);
+      this.updateToolAssistance();
+      return true;
+    }
+
+    return super.onUndoPreviousStep();
+  }
+
+  public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
+    if (!ev.viewport) return EventHandled.No;
+
+    const viewType = MeasurementViewTarget.classifyViewport(ev.viewport);
+
+    // We only want the sheetMeasurement logic to trigger when the first point is set but it needs to be after the measurement is created
+    // this boolean helps us ensure that this is the case
+    let isFirstPoint = false;
+
+    if (this.toolModel.currentState === MeasureAreaToolModel.State.SetMeasurementViewport) {
+      this.toolModel.setMeasurementViewport(viewType);
+      isFirstPoint = true;
+    }
+
+    this.toolModel.addPoint(viewType, ev, false);
+    await this.sheetMeasurementsDataButtonDown(ev, isFirstPoint);
+    if (!this.toolModel.dynamicMeasurement) {
+      await this.onReinitialize();
+    } else {
+      this._sendHintsToAccuDraw(ev);
+      this.updateToolAssistance();
+    }
+
+    ev.viewport.invalidateDecorations();
+    return EventHandled.Yes;
+  }
+
+  private async sheetMeasurementsDataButtonDown(ev: BeButtonEvent, isFirstPoint: boolean) {
+    if (!ev.viewport) return;
+
+    if (this._enableSheetMeasurements) {
+      if (this.toolModel.drawingMetadata?.drawingId === undefined && ev.viewport.view.id !== undefined && isFirstPoint) {
+        const drawingInfo = await SheetMeasurementsHelper.getDrawingId(this.iModel, ev.viewport.view.id, ev.point);
+        this.toolModel.sheetViewId = ev.viewport.view.id;
+
+        if (drawingInfo?.drawingId !== undefined && drawingInfo.origin !== undefined && drawingInfo.worldScale !== undefined) {
+          const data: DrawingMetadata = {
+            origin: drawingInfo.origin,
+            drawingId: drawingInfo.drawingId,
+            worldScale: drawingInfo.worldScale,
+            extents: drawingInfo.extents,
+          };
+          this.toolModel.drawingMetadata = data;
+        }
+      }
+    }
+  }
+
+  public override isValidLocation(ev: BeButtonEvent, _isButtonEvent: boolean): boolean {
+    if (!this._enableSheetMeasurements) return true;
+
+    if (true !== ev.viewport?.view.isSheetView()) {
+      return true;
+    }
+
+    for (const drawing of DrawingDataCache.getInstance().getSheetDrawingDataForViewport(ev.viewport)) {
+      if (drawing.type !== SheetMeasurementsHelper.DrawingType.CrossSection && drawing.type !== SheetMeasurementsHelper.DrawingType.Plan) {
+        if (SheetMeasurementsHelper.checkIfInDrawing(ev.point, drawing.origin, drawing.extents)) {
+          return false;
+        }
+      }
+    }
+
+    if (
+      this.toolModel.drawingMetadata?.drawingId === undefined ||
+      this.toolModel.drawingMetadata?.origin === undefined ||
+      this.toolModel.drawingMetadata?.extents === undefined
+    )
+      return true;
+
+    return SheetMeasurementsHelper.checkIfInDrawing(ev.point, this.toolModel.drawingMetadata?.origin, this.toolModel.drawingMetadata?.extents);
+  }
+
+  private _sendHintsToAccuDraw(ev: BeButtonEvent): void {
+    const dynamicMeasurement = this.toolModel.dynamicMeasurement;
+    if (undefined === ev.viewport || undefined === dynamicMeasurement) return;
+
+    const points = dynamicMeasurement.polygonPoints;
+    if (0 === points.length) return;
+
+    const hints = new AccuDrawHintBuilder();
+    hints.setOrigin(points[points.length - 1]);
+
+    if (1 === points.length) {
+      hints.setModeRectangular();
+    } else {
+      // Adjust to keep orientation defined by the last 2 points and the surface normal (if any).
+      const snapDetail = IModelApp.accuSnap.getCurrSnapDetail();
+      if (undefined !== snapDetail && undefined !== snapDetail.normal) {
+        const normal = Vector3d.createZero();
+        const xVector = Vector3d.createStartEnd(points[points.length - 2], points[points.length - 1]);
+        const zVector = ev.viewport.view.getZVector();
+        if (zVector.dotProduct(snapDetail.normal) < 0.0) normal.setFrom(snapDetail.normal);
+        else snapDetail.normal.negate(normal);
+
+        const mat = Matrix3d.createRigidFromColumns(xVector, normal, AxisOrder.XZY);
+        if (undefined !== mat) hints.setMatrix(mat);
+      }
+    }
+    hints.sendHints(false);
+    IModelApp.toolAdmin.setCursor(IModelApp.viewManager.crossHairCursor);
+  }
+
+  public override async onResetButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
+    // Remove last point
+    const pop = this.toolModel.popMeasurementPoint();
+    if (pop) {
+      this.toolModel.dynamicMeasurement?.clearCachedGraphics();
+      return EventHandled.Yes;
+    }
+
+    return super.onResetButtonDown(ev);
+  }
+
+  public override async onMouseMotion(ev: BeButtonEvent): Promise<void> {
+    if (!ev.viewport) return;
+
+    const viewType = MeasurementViewTarget.classifyViewport(ev.viewport);
+    if (this.toolModel.addPoint(viewType, ev, true)) ev.viewport.invalidateDecorations();
+  }
+
+  protected createToolModel(): MeasureVolumeToolModel {
+    return new MeasureVolumeToolModel();
+  }
+
+  public override decorate(context: DecorateContext): void {
+    super.decorate(context);
+
+    if (this._enableSheetMeasurements && this.toolModel.drawingMetadata?.origin !== undefined && this.toolModel.drawingMetadata?.extents !== undefined) {
+      context.addDecorationFromBuilder(
+        SheetMeasurementsHelper.getDrawingContourGraphic(context, this.toolModel.drawingMetadata?.origin, this.toolModel.drawingMetadata?.extents),
+      );
+    }
+  }
+
+  protected override updateToolAssistance(): void {
+    const hasPoints = undefined !== this.toolModel.dynamicMeasurement;
+    const hasEnoughPoints = hasPoints && this.toolModel.hasEnoughPoints;
+
+    let promptMainInstruction: string;
+    if (hasEnoughPoints) promptMainInstruction = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.mainInstructionClose");
+    else promptMainInstruction = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.mainInstruction");
+
+    const promptClickTap = MeasureTools.localization.getLocalizedString("MeasureTools:tools.GenericPrompts.acceptPoint");
+
+    let promptRightClick: string;
+    if (hasEnoughPoints) promptRightClick = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.rightClickCloseShape");
+    else if (hasPoints) promptRightClick = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.rightClickClearShape");
+    else promptRightClick = MeasureTools.localization.getLocalizedString("MeasureTools:tools.GenericPrompts.restart");
+
+    const mainInstruction = ToolAssistance.createInstruction(this.iconSpec, promptMainInstruction);
+    const mouseInstructions: ToolAssistanceInstruction[] = [];
+    const touchInstructions: ToolAssistanceInstruction[] = [];
+
+    if (!ToolAssistance.createTouchCursorInstructions(touchInstructions)) {
+      touchInstructions.push(ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchTap, promptClickTap, false, ToolAssistanceInputMethod.Touch));
+      if (hasEnoughPoints) {
+        const tmp = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.oneTouchTapClose");
+        touchInstructions.push(ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchTap, tmp, false, ToolAssistanceInputMethod.Touch));
+      }
+    }
+    mouseInstructions.push(ToolAssistance.createInstruction(ToolAssistanceImage.LeftClick, promptClickTap, false, ToolAssistanceInputMethod.Mouse));
+    if (hasEnoughPoints) {
+      const tmp = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.leftClickClose");
+      mouseInstructions.push(ToolAssistance.createInstruction(ToolAssistanceImage.LeftClick, tmp, false, ToolAssistanceInputMethod.Mouse));
+    }
+    mouseInstructions.push(ToolAssistance.createInstruction(ToolAssistanceImage.RightClick, promptRightClick, false, ToolAssistanceInputMethod.Mouse));
+
+    if (undefined !== this.toolModel.dynamicMeasurement) {
+      const undoPointText = MeasureTools.localization.getLocalizedString("MeasureTools:tools.MeasureArea.undoLastPoint");
+      mouseInstructions.push(this.createMouseUndoInstruction(undoPointText));
+    } else {
+      if (this.toolModel.canUndo) mouseInstructions.push(this.createMouseUndoInstruction());
+      if (this.toolModel.canRedo) mouseInstructions.push(this.createMouseRedoInstruction());
+    }
+
+    const sections: ToolAssistanceSection[] = [
+      ToolAssistance.createSection(mouseInstructions, ToolAssistance.inputsLabel),
+      ToolAssistance.createSection(touchInstructions, ToolAssistance.inputsLabel),
+    ];
+    const instructions = ToolAssistance.createInstructions(mainInstruction, sections);
+    IModelApp.notifications.setToolAssistance(instructions);
+  }
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -78,6 +78,9 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       if (!featureFlags?.hidePerpendicularTool) {
         tools.push(MeasureToolDefinitions.measurePerpendicularToolCommand);
       }
+      if (featureFlags?.showVolumeTool) {
+        tools.push(MeasureToolDefinitions.getMeasureVolumeToolCommand(this._props?.enableSheetMeasurement));
+      }
 
       if (toolbarOrientation === ToolbarOrientation.Vertical) {
         return [


### PR DESCRIPTION
Add Volume measurement tool. Tool is a special case since it is only applicable to meshes so it is off by default and can be enabled with the `showVolumeTool` flag.

![volumeTool](https://github.com/user-attachments/assets/f21827e6-55b4-4d3e-bee4-8edb5f95e270)
