### PR TITLE
Tree widget: Support more than 100 instances when showing subtree of ModelsTree

### DIFF
--- a/change/@itwin-tree-widget-react-4216334d-fac2-4f16-b7c0-1d6a55313d8b.json
+++ b/change/@itwin-tree-widget-react-4216334d-fac2-4f16-b7c0-1d6a55313d8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add support for more than 100 instance keys when filtering ModelsTree",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -88,6 +88,7 @@ interface ModelsTreeInstanceKeyPathsFromTargetItemsProps {
   idsCache: ModelsTreeIdsCache;
   targetItems: Array<InstanceKey | ElementsGroupInfo>;
   hierarchyConfig: ModelsTreeHierarchyConfiguration;
+  limit?: number | "unbounded";
 }
 
 interface ModelsTreeInstanceKeyPathsFromInstanceLabelProps {
@@ -717,9 +718,10 @@ async function createInstanceKeyPathsFromTargetItems({
   imodelAccess,
   hierarchyConfig,
   idsCache,
+  limit,
 }: ModelsTreeInstanceKeyPathsFromTargetItemsProps): Promise<HierarchyFilteringPath[]> {
-  if (targetItems.length > MAX_FILTERING_INSTANCE_KEY_COUNT) {
-    throw new FilterLimitExceededError(MAX_FILTERING_INSTANCE_KEY_COUNT);
+  if (limit !== "unbounded" && targetItems.length > (limit ?? MAX_FILTERING_INSTANCE_KEY_COUNT)) {
+    throw new FilterLimitExceededError(limit ?? MAX_FILTERING_INSTANCE_KEY_COUNT);
   }
   const ids = {
     models: new Array<Id64String>(),

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/UseModelsTree.tsx
@@ -129,6 +129,7 @@ export function useModelsTree({ activeView, filter, hierarchyConfig, visibilityH
                 imodelAccess,
                 idsCache: getModelsTreeIdsCache(),
                 hierarchyConfig: hierarchyConfiguration,
+                limit: "unbounded",
               }),
           });
         } catch (e) {


### PR DESCRIPTION
Removed instance keys limit when custom `getFilteredPaths` function is used to show sub tree of ModelsTree. Any limit can be applied in `getFilteredPaths` implementation if necessary by throwing `FilterLimitExceededError`.