### PR TITLE
Remove map layers feature info tech preview badges

### DIFF
--- a/change/@itwin-map-layers-2a682bd6-44ff-4576-8ec6-55bfb0a983f2.json
+++ b/change/@itwin-map-layers-2a682bd6-44ff-4576-8ec6-55bfb0a983f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove map layers feature info tech preview badges",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
+++ b/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { BadgeType, ConditionalBooleanValue } from "@itwin/appui-abstract";
+import { ConditionalBooleanValue } from "@itwin/appui-abstract";
 import type { ToolbarItem, UiItemsProvider } from "@itwin/appui-react";
 import {
   StagePanelLocation,
@@ -63,7 +63,6 @@ export const getMapFeatureInfoToolItemDef = (): ToolItemDef =>
     execute: async () => {
       await IModelApp.tools.run(MapFeatureInfoTool.toolId);
     },
-    badgeType: BadgeType.TechnicalPreview,
     isHidden: new ConditionalBooleanValue(() => {
       // Hide the MapFeatureInfoTool if the Map Layers toggle is off or no ArcGISFeature layers are active
       return !isMapFeatureInfoSupported();
@@ -106,7 +105,6 @@ export class FeatureInfoUiItemsProvider implements UiItemsProvider {
         icon: <SvgMapInfo />,
         content: <MapFeatureInfoWidget featureInfoOpts={this._featureInfoOpts} />,
         defaultState: WidgetState.Hidden,
-        badge: BadgeType.TechnicalPreview,
       });
     }
 

--- a/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.tsx
@@ -7,10 +7,8 @@
 import "./MapUrlDialog.scss";
 import * as React from "react";
 import { IModelApp } from "@itwin/core-frontend";
-import { SvgTechnicalPreviewMini } from "@itwin/itwinui-icons-color-react";
 import type { SelectOption } from "@itwin/itwinui-react";
-import { Icon, LabeledSelect, MenuItem } from "@itwin/itwinui-react";
-import { MapLayersUI } from "../../mapLayers";
+import { LabeledSelect, MenuItem } from "@itwin/itwinui-react";
 import type { MapTypesOptions } from "../Interfaces";
 
 // TODO:
@@ -56,7 +54,7 @@ export function SelectMapFormat(props: SelectMapFormatProps) {
     }
 
     if (IModelApp.mapLayerFormatRegistry.isRegistered(MAP_TYPES.arcGisFeature)) {
-      formats.push({ value: MAP_TYPES.arcGisFeature, label: MAP_TYPES.arcGisFeature, id: "techPreview" });
+      formats.push({ value: MAP_TYPES.arcGisFeature, label: MAP_TYPES.arcGisFeature });
     }
 
     return formats;
@@ -80,21 +78,7 @@ export function SelectMapFormat(props: SelectMapFormatProps) {
       disabled={props.disabled}
       onChange={handleOnChange}
       size="small"
-      itemRenderer={(option) => (
-        <MenuItem
-          badge={
-            option.id?.includes("techPreview") ? (
-              <div title={MapLayersUI.translate("Labels.TechPreviewBadgeTooltip")} className="map-layer-source-select-previewBadge">
-                <Icon size="small">
-                  <SvgTechnicalPreviewMini />
-                </Icon>
-              </div>
-            ) : undefined
-          }
-        >
-          {option.label}
-        </MenuItem>
-      )}
+      itemRenderer={(option) => <MenuItem>{option.label}</MenuItem>}
     />
   );
 }


### PR DESCRIPTION
This feature is now ready for GA so am removing all tech preview badges.

![image](https://github.com/user-attachments/assets/0d48a404-9157-4bb6-bf54-982195e8e8d8)

![image](https://github.com/user-attachments/assets/8425dbde-b76e-4ce0-8cfd-33b07d7cbeb7)
