### PR TITLE
Bump e2e tests' timeout to 2 hours

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -38,6 +38,7 @@ jobs:
   - job: Run_e2e_tests
     displayName: "Run e2e tests"
     condition: succeeded()
+    timeoutInMinutes: 120
     workspace:
       clean: all
 


### PR DESCRIPTION
https://github.com/iTwin/viewer-components-react/issues/1048

Looks like we've recently been on the limit and started to sometimes exceed it. For the time being I'm increasing the timeout, but will need to look into speeding up the job.