### PR TITLE
Bugfix/missing geolocation in widget

### DIFF
--- a/change/@itwin-measure-tools-react-8086d62b-e081-44c6-9f87-62461d0985cc.json
+++ b/change/@itwin-measure-tools-react-8086d62b-e081-44c6-9f87-62461d0985cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix missing geo location information for location measurement in widget.",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "3418768+a-gagnon@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
@@ -306,7 +306,7 @@ export class LocationMeasurement extends Measurement {
       value: fCoordinates,
     });
 
-    if (this._geoLocation && this.drawingMetadata?.sheetToWorldTransform !== undefined)
+    if (this._geoLocation && this.drawingMetadata?.sheetToWorldTransform === undefined)
       data.properties.push({
         label: MeasureTools.localization.getLocalizedString(
           "MeasureTools:tools.MeasureLocation.latLong"


### PR DESCRIPTION
Change the logic in LocationMeasurement.getDataForMeasurementWidgetInternal such that we properly show the geo location information, unless the location comes from a sheet view.

Fixes #1051