### PR TITLE
Tree widget: Bump `presentation` package dependencies

### DIFF
--- a/change/@itwin-tree-widget-react-9e938ba5-ad82-41ac-8ba6-820647628d17.json
+++ b/change/@itwin-tree-widget-react-9e938ba5-ad82-41ac-8ba6-820647628d17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump `presentation` package dependencies for bug fixes and orders of magnitude hierarchy filtering performance improvement.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -65,10 +65,10 @@
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@itwin/presentation-core-interop": "^1.0.0",
-    "@itwin/presentation-hierarchies": "^1.0.0",
-    "@itwin/presentation-hierarchies-react": "^1.0.0",
+    "@itwin/presentation-hierarchies": "^1.1.0",
+    "@itwin/presentation-hierarchies-react": "^1.0.1",
     "@itwin/presentation-shared": "^1.0.0",
-    "@itwin/unified-selection": "^1.0.0",
+    "@itwin/unified-selection": "^1.0.1",
     "classnames": "^2.3.1",
     "react-error-boundary": "^4.0.10",
     "rxjs": "^7.8.1"

--- a/packages/itwin/tree-widget/pnpm-lock.yaml
+++ b/packages/itwin/tree-widget/pnpm-lock.yaml
@@ -21,17 +21,17 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(@itwin/core-bentley@4.9.1)(@itwin/core-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1))(@itwin/core-geometry@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1))(@itwin/ecschema-metadata@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1)))
       '@itwin/presentation-hierarchies':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.1.0
+        version: 1.1.0
       '@itwin/presentation-hierarchies-react':
-        specifier: ^1.0.0
-        version: 1.0.0(@itwin/itwinui-react@3.14.0(@types/react@18.0.34)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+        specifier: ^1.0.1
+        version: 1.0.1(@itwin/itwinui-react@3.14.0(@types/react@18.0.34)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@itwin/presentation-shared':
         specifier: ^1.0.0
         version: 1.0.0
       '@itwin/unified-selection':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       classnames:
         specifier: ^2.3.1
         version: 2.3.1
@@ -830,8 +830,8 @@ packages:
       '@itwin/ecschema-metadata': ^4.9.1
       '@itwin/presentation-common': ^4.9.1
 
-  '@itwin/presentation-hierarchies-react@1.0.0':
-    resolution: {integrity: sha512-PriPyN5YW83x50OsTMuh/5th2owdaJyCpTTpcoIQj6JWmGyWr9BWG/DwY8ASs3b5xWQKcmIVp0h0HQylA//Y6w==}
+  '@itwin/presentation-hierarchies-react@1.0.1':
+    resolution: {integrity: sha512-ZkT2bUEXIkbmsIAUP7iaalUcnkkNEUom4nUNWLI1hy85NLUH5EJYWnF+uIBeJPE6i3OjB4+m8xVVCntu0TDPdQ==}
     peerDependencies:
       '@itwin/itwinui-react': ^3.0.0
       react: ^17.0.0 || ^18.0.0
@@ -840,8 +840,8 @@ packages:
       '@itwin/itwinui-react':
         optional: true
 
-  '@itwin/presentation-hierarchies@1.0.0':
-    resolution: {integrity: sha512-S8zzMgU1tZpZLqEpP+00Hy4vPAvRBclKH8W8oqEQoPMnZKyW7j0H4XJv5lPwDSkGriXA5UmFPaK9rmtg3yQZqw==}
+  '@itwin/presentation-hierarchies@1.1.0':
+    resolution: {integrity: sha512-61hbT3NR11KupwlLCSnBRS/+sgrx/mUTguYezhF5v1QmeBRDHLbECMaJcZH0eRGmBrH1ECqVxsY8Jf2/seo6wg==}
 
   '@itwin/presentation-shared@1.0.0':
     resolution: {integrity: sha512-j/ZBBFTneAxOxl+036g9X+lC083hnqHMc9IKgYuoy8YIZUIqTtAh6au1U9d93tsxYHkNbcXnU+ykXUq2Z9TJNA==}
@@ -862,8 +862,8 @@ packages:
   '@itwin/unified-selection@0.1.0':
     resolution: {integrity: sha512-1Pe2i3sw5dK4h394uC5wTRWvnXxeBZGv+t9LcG7tQr2L+l0Hv+Ryo5+yTN34kABEhMe2UwSHnBRU8jOGsiorIQ==}
 
-  '@itwin/unified-selection@1.0.0':
-    resolution: {integrity: sha512-VIvt8+aOr8rjN80OALFSEvxDP2oShzDj9sjS7+FDV5NgRW0uRN6xgud+fwCICSQ+JspsH4SECL9kgc4Xj5UM+A==}
+  '@itwin/unified-selection@1.0.1':
+    resolution: {integrity: sha512-xYC5/pB4f8mDRtpTAfnRDJKJ20NnKFtUX9Qbx40DXhMDYLhbD3V0VhkDUFqJwp/Q0ys4kbumWxHO2ThNGBKjkw==}
 
   '@itwin/webgl-compatibility@4.9.1':
     resolution: {integrity: sha512-majxZafOM7vVsnWLhtcQu5UgTpQ1yPwZ1oONHJHdXU1jDa1hFFy1mac6qUJxbYSyfJByI6uMIPsbRV6fnjSYvw==}
@@ -4752,7 +4752,7 @@ snapshots:
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13(typescript@5.3.3)
-      typedoc-plugin-merge-modules: 5.1.0(typedoc@0.25.13(typescript@5.0.2))
+      typedoc-plugin-merge-modules: 5.1.0(typedoc@0.25.13(typescript@5.3.3))
       typescript: 5.3.3
       wtfnode: 0.9.1
       yargs: 17.7.2
@@ -5094,14 +5094,14 @@ snapshots:
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0(rxjs@7.8.1)
 
-  '@itwin/presentation-hierarchies-react@1.0.0(@itwin/itwinui-react@3.14.0(@types/react@18.0.34)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
+  '@itwin/presentation-hierarchies-react@1.0.1(@itwin/itwinui-react@3.14.0(@types/react@18.0.34)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
       '@itwin/core-bentley': 4.9.1
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      '@itwin/presentation-hierarchies': 1.0.0
+      '@itwin/presentation-hierarchies': 1.1.0
       '@itwin/presentation-shared': 1.0.0
-      '@itwin/unified-selection': 1.0.0
+      '@itwin/unified-selection': 1.0.1
       classnames: 2.5.1
       immer: 10.1.1
       react: 18.0.0
@@ -5111,7 +5111,7 @@ snapshots:
     optionalDependencies:
       '@itwin/itwinui-react': 3.14.0(@types/react@18.0.34)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
 
-  '@itwin/presentation-hierarchies@1.0.0':
+  '@itwin/presentation-hierarchies@1.1.0':
     dependencies:
       '@itwin/core-bentley': 4.9.1
       '@itwin/core-common': 4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1)
@@ -5150,7 +5150,7 @@ snapshots:
 
   '@itwin/unified-selection@0.1.0': {}
 
-  '@itwin/unified-selection@1.0.0':
+  '@itwin/unified-selection@1.0.1':
     dependencies:
       '@itwin/core-bentley': 4.9.1
       '@itwin/presentation-shared': 1.0.0
@@ -8861,7 +8861,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-merge-modules@5.1.0(typedoc@0.25.13(typescript@5.0.2)):
+  typedoc-plugin-merge-modules@5.1.0(typedoc@0.25.13(typescript@5.3.3)):
     dependencies:
       typedoc: 0.25.13(typescript@5.3.3)
 

--- a/packages/itwin/tree-widget/src/test/trees/common/FocusedInstancesContext.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/common/FocusedInstancesContext.test.tsx
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import type { GroupingHierarchyNode } from "@itwin/presentation-hierarchies";
 import { createStorage } from "@itwin/unified-selection";
 import { useFocusedInstancesContext } from "../../../components/trees/common/FocusedInstancesContext";
 import { FocusedInstancesContextProvider } from "../../../components/trees/common/FocusedInstancesContextProvider";
 import { act, createAsyncIterator, renderHook, waitFor } from "../../TestUtils";
 
+import type { GroupingHierarchyNode } from "@itwin/presentation-hierarchies";
 import type { PropsWithChildren } from "react";
+
 async function collectKeys<T>(loader?: () => AsyncIterableIterator<T>): Promise<T[]> {
   const items: T[] = [];
   if (!loader) {
@@ -81,7 +82,7 @@ describe("FocusedInstancesContext", () => {
 
     await waitFor(async () => {
       const instanceKeys = await collectKeys(result.current.loadFocusedItems);
-      expect(instanceKeys).to.containSubset([{ className: "Schema:Class", id: "0x1" }]);
+      expect(instanceKeys).to.containSubset([{ className: "Schema.Class", id: "0x1" }]);
     });
   });
 


### PR DESCRIPTION
Consume changes from this release: https://github.com/iTwin/presentation/pull/731#issue-2570267603