### PR TITLE
Fix map layers feature info tool timing bug

### DIFF
--- a/change/@itwin-map-layers-5193bd40-6caf-439c-877f-9f57b5632bdc.json
+++ b/change/@itwin-map-layers-5193bd40-6caf-439c-877f-9f57b5632bdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix timing issue with map layers feature info tool not always being shown",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.tsx
@@ -191,7 +191,7 @@ export function MapLayerManager(props: MapLayerManagerProps) {
     };
 
     return activeViewport.onMapLayerScaleRangeVisibilityChanged.addListener(handleScaleRangeVisibilityChanged);
-  }, [activeViewport, backgroundMapLayers, loadMapLayerSettingsFromViewport, overlayMapLayers]);
+  }, [activeViewport, backgroundMapLayers, overlayMapLayers]);
 
   // Setup onMapImageryChanged events listening.
 
@@ -203,10 +203,13 @@ export function MapLayerManager(props: MapLayerManagerProps) {
       ) {
         loadMapLayerSettingsFromViewport(activeViewport);
       }
-      IModelApp.toolAdmin.dispatchUiSyncEvent(MapLayersSyncUiEventId.MapImageryChanged);
     };
     return activeViewport?.displayStyle.settings.onMapImageryChanged.addListener(handleMapImageryChanged);
   }, [activeViewport, backgroundMapLayers, loadMapLayerSettingsFromViewport, overlayMapLayers]);
+
+  React.useEffect(() => {
+    IModelApp.toolAdmin.dispatchUiSyncEvent(MapLayersSyncUiEventId.MapImageryChanged);
+  }, [backgroundMapLayers, overlayMapLayers]);
 
   const handleProviderStatusChanged = React.useCallback(
     (_args: MapLayerImageryProvider) => {


### PR DESCRIPTION
Map layer info tool doesn't appear on first try and only shows up when a second map layer is added or if the same on is re-added.

Solution:  put dispatchUiSyncEvent(MapLayersSyncUiEventId.MapImageryChanged) into a separate useEffect from where the set state calls are made since they need to happen synchronously

