### PR TITLE
[measure-tools] Prevent drawing measure tools in non-sheet views when sheet measurements are enabled

### DIFF
--- a/change/@itwin-measure-tools-react-0f49ab46-e1dd-4f15-8de4-f15512e8360a.json
+++ b/change/@itwin-measure-tools-react-0f49ab46-e1dd-4f15-8de4-f15512e8360a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
@@ -143,8 +143,12 @@ MeasureAreaToolModel
   }
 
   public override isValidLocation(ev: BeButtonEvent, _isButtonEvent: boolean): boolean {
-    if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
+    if (!this._enableSheetMeasurements)
       return true;
+
+    if (!ev.viewport?.view.isSheetView())
+      return false;
+
 
     if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev, [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan]))
       return false;

--- a/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -132,8 +132,11 @@ MeasureDistanceToolModel
   }
 
   public override isValidLocation(ev: BeButtonEvent, _isButtonEvent: boolean): boolean {
-    if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
+    if (!this._enableSheetMeasurements)
       return true;
+
+    if (!ev.viewport?.view.isSheetView())
+      return false;
 
     if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev, [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan]))
       return false;

--- a/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
@@ -149,8 +149,12 @@ MeasureLocationToolModel
   }
 
   public override isValidLocation(ev: BeButtonEvent, _isButtonEvent: boolean): boolean {
-    if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
+    if (!this._enableSheetMeasurements)
       return true;
+
+    if (!ev.viewport?.view.isSheetView())
+      return false;
+
 
     if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev, [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan]))
       return false;


### PR DESCRIPTION
This makes it so that, when sheet measurements are enabled, they can only be used in sheet views.
It does not affect measurements when sheet measurements are disabled.
Related to https://dev.azure.com/bentleycs/Civil-iTwin/_workitems/edit/1546695