### PR TITLE
[measure-tools] Drawing overlap could stop you from creating measurements

### DIFF
--- a/change/@itwin-measure-tools-react-2182f580-8b58-434f-91cb-acb164ac21e8.json
+++ b/change/@itwin-measure-tools-react-2182f580-8b58-434f-91cb-acb164ac21e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "inverted logic from checkAllowedDrawingType",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -163,12 +163,12 @@ export namespace SheetMeasurementsHelper {
     if (!ev.viewport)
       return false;
     for (const drawing of DrawingDataCache.getInstance().getSheetDrawingDataForViewport(ev.viewport)) {
-      if (!allowedDrawingTypes.includes(drawing.type)) {
+      if (allowedDrawingTypes.includes(drawing.type)) {
         if (SheetMeasurementsHelper.checkIfInDrawing(ev.point, drawing.origin, drawing.extents)) {
-          return false;
+          return true;
         }
       }
     }
-    return true;
+    return false;
   }
 }


### PR DESCRIPTION
Previously, we'd check if we were in the area of any invalid drawing for the used tool and prevent the input if there were any drawing region overlapping with the click.
Now, we check if there's any valid drawing instead which stops the bug
related to https://bentleycs.visualstudio.com/Civil-iTwin/_workitems/edit/1547446