### PR TITLE
Add support for additional Toolbar items to MeasureToolsUiItemsProvider

### DIFF
--- a/change/@itwin-measure-tools-react-4b81abd1-bc83-46e0-9496-7d4ab99332f6.json
+++ b/change/@itwin-measure-tools-react-4b81abd1-bc83-46e0-9496-7d4ab99332f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for additional Toolbar items to MeasureToolsUiItemsProvider",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "88331924+saaaaaally@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -37,8 +37,7 @@ export interface MeasureToolsUiProviderOptions {
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
   public readonly id = "MeasureToolsUiItemsProvider";
-  private _props: RecursiveRequired<MeasureToolsUiProviderOptions>;
-  private _additionalToolbarItems: ToolItemDef[] = [];
+  private _props: Omit<RecursiveRequired<MeasureToolsUiProviderOptions>, 'additionalToolbarItems'> & { additionalToolbarItems?: ToolItemDef[] };
 
   constructor(props?: MeasureToolsUiProviderOptions) {
     this._props = {
@@ -50,9 +49,8 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       },
       enableSheetMeasurement: props?.enableSheetMeasurement ?? false,
       stageUsageList: props?.stageUsageList ?? [StageUsage.General],
-      additionalToolbarItems: []
+      additionalToolbarItems: props?.additionalToolbarItems
     };
-    this._additionalToolbarItems = props?.additionalToolbarItems ?? [];
   }
 
   public provideToolbarItems(
@@ -82,8 +80,8 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       if (!featureFlags?.hidePerpendicularTool) {
         tools.push(MeasureToolDefinitions.measurePerpendicularToolCommand);
       }
-      if (this._additionalToolbarItems) {
-        tools.push(...this._additionalToolbarItems);
+      if (this._props.additionalToolbarItems) {
+        tools.push(...this._props.additionalToolbarItems);
       }
 
       if (toolbarOrientation === ToolbarOrientation.Vertical) {

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -37,6 +37,7 @@ export interface MeasureToolsUiProviderOptions {
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
   public readonly id = "MeasureToolsUiItemsProvider";
   private _props: RecursiveRequired<MeasureToolsUiProviderOptions>;
+  private _additionalToolbarItems: ToolItemDef[] = [];
 
   constructor(props?: MeasureToolsUiProviderOptions) {
     this._props = {
@@ -49,6 +50,10 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       enableSheetMeasurement: props?.enableSheetMeasurement ?? false,
       stageUsageList: props?.stageUsageList ?? [StageUsage.General],
     };
+  }
+
+  public addAdditionalToolbarItems(toolbarItems: ToolItemDef[]): void {
+    this._additionalToolbarItems = toolbarItems;
   }
 
   public provideToolbarItems(
@@ -77,6 +82,9 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       }
       if (!featureFlags?.hidePerpendicularTool) {
         tools.push(MeasureToolDefinitions.measurePerpendicularToolCommand);
+      }
+      if (this._additionalToolbarItems) {
+        tools.push(...this._additionalToolbarItems);
       }
 
       if (toolbarOrientation === ToolbarOrientation.Vertical) {

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -32,6 +32,7 @@ export interface MeasureToolsUiProviderOptions {
   // If we check for sheet to 3d transformation when measuring in sheets
   enableSheetMeasurement?: boolean;
   stageUsageList?: string[];
+  additionalToolbarItems?: ToolItemDef[];
 }
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
@@ -49,11 +50,9 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       },
       enableSheetMeasurement: props?.enableSheetMeasurement ?? false,
       stageUsageList: props?.stageUsageList ?? [StageUsage.General],
+      additionalToolbarItems: []
     };
-  }
-
-  public addAdditionalToolbarItems(toolbarItems: ToolItemDef[]): void {
-    this._additionalToolbarItems = toolbarItems;
+    this._additionalToolbarItems = props?.additionalToolbarItems ?? [];
   }
 
   public provideToolbarItems(


### PR DESCRIPTION
Added addAdditionalToolbarItems to MeasureToolsUiItemsProvider so that applications can pass in additional measure tools to be displayed at the end of the measure tools list.