### PR TITLE
[measure-tools] Show tooltip when using sheet measurement on wrong drawing type

### DIFF
--- a/change/@itwin-measure-tools-react-5c21c471-24f9-460e-b7a0-e068a1d59aff.json
+++ b/change/@itwin-measure-tools-react-5c21c471-24f9-460e-b7a0-e068a1d59aff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added helper functions and tooltip",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
+++ b/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
@@ -148,5 +148,16 @@
   "MeasurementGroupButton": {
     "label": "Measurement",
     "tooltip": "Measurement Tools"
+  },
+  "SheetMeasurementTooltip": {
+    "MeasurementNames": {
+      "Profile": "Profile",
+      "CrossSection": "Cross Section",
+      "Plan": "Plan"
+    },
+    "OneMeasurementInvalid": "This measurement can only be used on {{drawingName}} drawings",
+    "MoreMeasurementsInvalidHead": "This measurement can only be used on {{drawingName}}",
+    "MoreMeasurementsInvalidMiddle": ", {{drawingName}}",
+    "MoreMeasurementsInvalidLast": " and {{drawingName}} drawings"
   }
 }

--- a/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
+++ b/packages/itwin/measure-tools/public/locales/en/MeasureTools.json
@@ -155,6 +155,7 @@
       "CrossSection": "Cross Section",
       "Plan": "Plan"
     },
+    "NoAllowedDrawingTypes": "No allowed drawing types were set for this measurement tool",
     "OneMeasurementInvalid": "This measurement can only be used on {{drawingName}} drawings",
     "MoreMeasurementsInvalidHead": "This measurement can only be used on {{drawingName}}",
     "MoreMeasurementsInvalidMiddle": ", {{drawingName}}",

--- a/packages/itwin/measure-tools/src/api/MeasurementTool.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementTool.ts
@@ -356,7 +356,7 @@ export abstract class MeasurementToolBase<
     if (!this._enableSheetMeasurements) {
       return defaultToolTip(hit);
     } else {
-      return SheetMeasurementsHelper.getSheetErrorToolTipText(hit, this.allowedDrawingTypes, defaultToolTip);
+      return SheetMeasurementsHelper.getSheetToolTipText(hit, this.allowedDrawingTypes, defaultToolTip);
     }
   }
 

--- a/packages/itwin/measure-tools/src/api/MeasurementTool.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementTool.ts
@@ -29,6 +29,7 @@ import type { Feature } from "./FeatureTracking";
 import { FeatureTracking } from "./FeatureTracking";
 import type { Measurement } from "./Measurement";
 import type { MeasurementToolModel } from "./MeasurementToolModel";
+import { SheetMeasurementsHelper } from "./SheetMeasurementHelper";
 
 /** Interface for any interactive tool that creates measurements. */
 export interface MeasurementTool {
@@ -196,6 +197,8 @@ export abstract class MeasurementToolBase<
   private _toolModel: ToolModel;
   private _selectionHolder: SelectionHolder;
 
+  protected _enableSheetMeasurements: boolean;
+
   public get measurements(): ReadonlyArray<Measurement> {
     return this._toolModel.measurements;
   }
@@ -216,9 +219,14 @@ export abstract class MeasurementToolBase<
     return true;
   }
 
+  protected get allowedDrawingTypes(): SheetMeasurementsHelper.DrawingType[] {
+    return [];
+  }
+
   constructor() {
     super();
 
+    this._enableSheetMeasurements = false;
     this._toolModel = this.createToolModel();
     this._toolModel.synchMeasurementsWithSelectionSet = true; // Sync by default
     this._selectionHolder = new SelectionHolder();
@@ -337,14 +345,19 @@ export abstract class MeasurementToolBase<
     return this._toolModel.getDecorationGeometry(hit);
   }
 
-  public override async getToolTip(
-    hit: HitDetail
-  ): Promise<HTMLElement | string> {
-    const toolTip = await this._toolModel.getToolTip(hit);
+  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
+    const defaultToolTip = async (hit: HitDetail) => {
+      const toolTip = await this._toolModel.getToolTip(hit);
 
-    if (toolTip === "") return super.getToolTip(hit);
+      if (toolTip === "") return super.getToolTip(hit);
 
-    return toolTip;
+      return toolTip;
+    }
+    if (!this._enableSheetMeasurements) {
+      return defaultToolTip(hit);
+    } else {
+      return SheetMeasurementsHelper.getSheetErrorToolTipText(hit, this.allowedDrawingTypes, defaultToolTip);
+    }
   }
 
   public override decorate(context: DecorateContext): void {

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -192,9 +192,6 @@ export namespace SheetMeasurementsHelper {
     if (allowedDrawingTypesList.length < 1) {
       return "";
     }
-    if (allowedDrawingTypesList.length === 1) {
-      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.OneMeasurementInvalid", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
-    }
     if (allowedDrawingTypesList.length > 1){
       let result = IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidHead", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
       for (let i = 1; i < allowedDrawingTypesList.length - 1; i++) {
@@ -203,6 +200,6 @@ export namespace SheetMeasurementsHelper {
       result = result + IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidLast", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[allowedDrawingTypesList.length - 1])});
       return result;
     }
-    return "";
+    return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.OneMeasurementInvalid", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
   }
 }

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -174,11 +174,11 @@ export namespace SheetMeasurementsHelper {
 
   function getNameFromDrawingType(type: SheetMeasurementsHelper.DrawingType): string  {
     if (type === SheetMeasurementsHelper.DrawingType.CrossSection) {
-      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MeasurementNames.CrossSection");
+      return IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MeasurementNames.CrossSection");
     } else if (type === SheetMeasurementsHelper.DrawingType.Plan) {
-      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MeasurementNames.Plan");
+      return IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MeasurementNames.Plan");
     } else if (type === SheetMeasurementsHelper.DrawingType.Profile) {
-      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MeasurementNames.Profile");
+      return IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MeasurementNames.Profile");
     } else {
       return "";
     }
@@ -190,16 +190,16 @@ export namespace SheetMeasurementsHelper {
     }
 
     if (allowedDrawingTypesList.length < 1) {
-      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.NoAllowedDrawingTypes");;
+      return IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.NoAllowedDrawingTypes");;
     }
     if (allowedDrawingTypesList.length > 1){
-      let result = IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidHead", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
+      let result = IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MoreMeasurementsInvalidHead", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
       for (let i = 1; i < allowedDrawingTypesList.length - 1; i++) {
-        result = result + IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidMiddle", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[i])});
+        result = result + IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MoreMeasurementsInvalidMiddle", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[i])});
       }
-      result = result + IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidLast", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[allowedDrawingTypesList.length - 1])});
+      result = result + IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.MoreMeasurementsInvalidLast", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[allowedDrawingTypesList.length - 1])});
       return result;
     }
-    return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.OneMeasurementInvalid", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
+    return IModelApp.localization.getLocalizedString("MeasureTools:SheetMeasurementTooltip.OneMeasurementInvalid", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});
   }
 }

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -190,7 +190,7 @@ export namespace SheetMeasurementsHelper {
     }
 
     if (allowedDrawingTypesList.length < 1) {
-      return "";
+      return IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.NoAllowedDrawingTypes");;
     }
     if (allowedDrawingTypesList.length > 1){
       let result = IModelApp.localization.getLocalizedString("CivilReviewTools:SheetMeasurementTooltip.MoreMeasurementsInvalidHead", { drawingName: getNameFromDrawingType(allowedDrawingTypesList[0])});

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -184,7 +184,7 @@ export namespace SheetMeasurementsHelper {
     }
   }
 
-  export async function getSheetErrorToolTipText(hit: HitDetail, allowedDrawingTypesList: SheetMeasurementsHelper.DrawingType[], defaultToolTip:(hit: HitDetail) => Promise<HTMLElement | string>): Promise<string | HTMLElement> {
+  export async function getSheetToolTipText(hit: HitDetail, allowedDrawingTypesList: SheetMeasurementsHelper.DrawingType[], defaultToolTip:(hit: HitDetail) => Promise<HTMLElement | string>): Promise<string | HTMLElement> {
     if (SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, allowedDrawingTypesList)) {
       return defaultToolTip(hit);
     }

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ColorDef, QueryBinder } from "@itwin/core-common";
-import type { BeButtonEvent, DecorateContext, GraphicBuilder, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import type { BeButtonEvent, DecorateContext, GraphicBuilder, HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
 import { GraphicType, IModelApp } from "@itwin/core-frontend";
 import { Point3d } from "@itwin/core-geometry";
 import { Transform } from "@itwin/core-geometry";
@@ -184,7 +184,11 @@ export namespace SheetMeasurementsHelper {
     }
   }
 
-  export function getToolTipText(allowedDrawingTypesList: SheetMeasurementsHelper.DrawingType[]): string {
+  export async function getSheetErrorToolTipText(hit: HitDetail, allowedDrawingTypesList: SheetMeasurementsHelper.DrawingType[], defaultToolTip:(hit: HitDetail) => Promise<HTMLElement | string>): Promise<string | HTMLElement> {
+    if (SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, allowedDrawingTypesList)) {
+      return defaultToolTip(hit);
+    }
+
     if (allowedDrawingTypesList.length < 1) {
       return "";
     }

--- a/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureAreaTool.ts
@@ -37,8 +37,9 @@ MeasureAreaToolModel
   public static override toolId = "MeasureTools.MeasureArea";
   public static override iconSpec = "icon-measure-2d";
 
-  private _enableSheetMeasurements: boolean;
-  private static _allowedDrawingTypes = [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  protected override get allowedDrawingTypes(): SheetMeasurementsHelper.DrawingType[] {
+    return [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  }
 
   public static override get flyover() {
     return MeasureTools.localization.getLocalizedString(
@@ -149,21 +150,13 @@ MeasureAreaToolModel
     if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
       return true;
 
-    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, MeasureAreaTool._allowedDrawingTypes))
+    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, this.allowedDrawingTypes))
       return false;
 
     if (this.toolModel.drawingMetadata?.drawingId === undefined || this.toolModel.drawingMetadata?.origin === undefined || this.toolModel.drawingMetadata?.extents === undefined)
       return true;
 
     return SheetMeasurementsHelper.checkIfInDrawing(ev.point, this.toolModel.drawingMetadata?.origin, this.toolModel.drawingMetadata?.extents);
-  }
-
-  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
-    if (!this._enableSheetMeasurements || SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, MeasureAreaTool._allowedDrawingTypes)) {
-      return super.getToolTip(hit);
-    } else {
-      return SheetMeasurementsHelper.getToolTipText(MeasureAreaTool._allowedDrawingTypes);
-    }
   }
 
   private _sendHintsToAccuDraw(ev: BeButtonEvent): void {

--- a/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -6,6 +6,7 @@
 import type {
   BeButtonEvent,
   DecorateContext,
+  HitDetail,
   ToolAssistanceInstruction,
   ToolAssistanceSection,
 } from "@itwin/core-frontend";
@@ -38,7 +39,9 @@ MeasureDistanceToolModel
   private static readonly useMultiPointPropertyName = "useMultiPoint";
 
   private _useMultiPointMeasurement: boolean = false;
+
   private _enableSheetMeasurements: boolean;
+  private static _allowedDrawingTypes = [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
 
   public static override get flyover() {
     return MeasureTools.localization.getLocalizedString(
@@ -135,13 +138,21 @@ MeasureDistanceToolModel
     if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
       return true;
 
-    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev, [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan]))
+    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, MeasureDistanceTool._allowedDrawingTypes))
       return false;
 
     if (this.toolModel.drawingMetadata?.drawingId === undefined || this.toolModel.drawingMetadata?.origin === undefined || this.toolModel.drawingMetadata?.extents === undefined)
       return true;
 
     return SheetMeasurementsHelper.checkIfInDrawing(ev.point, this.toolModel.drawingMetadata?.origin, this.toolModel.drawingMetadata?.extents);
+  }
+
+  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
+    if (!this._enableSheetMeasurements || SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, MeasureDistanceTool._allowedDrawingTypes)) {
+      return super.getToolTip(hit);
+    } else {
+      return SheetMeasurementsHelper.getToolTipText(MeasureDistanceTool._allowedDrawingTypes);
+    }
   }
 
   public override decorate(context: DecorateContext): void {

--- a/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -40,8 +40,9 @@ MeasureDistanceToolModel
 
   private _useMultiPointMeasurement: boolean = false;
 
-  private _enableSheetMeasurements: boolean;
-  private static _allowedDrawingTypes = [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  protected override get allowedDrawingTypes(): SheetMeasurementsHelper.DrawingType[] {
+    return [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  }
 
   public static override get flyover() {
     return MeasureTools.localization.getLocalizedString(
@@ -138,21 +139,13 @@ MeasureDistanceToolModel
     if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
       return true;
 
-    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, MeasureDistanceTool._allowedDrawingTypes))
+    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, this.allowedDrawingTypes))
       return false;
 
     if (this.toolModel.drawingMetadata?.drawingId === undefined || this.toolModel.drawingMetadata?.origin === undefined || this.toolModel.drawingMetadata?.extents === undefined)
       return true;
 
     return SheetMeasurementsHelper.checkIfInDrawing(ev.point, this.toolModel.drawingMetadata?.origin, this.toolModel.drawingMetadata?.extents);
-  }
-
-  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
-    if (!this._enableSheetMeasurements || SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, MeasureDistanceTool._allowedDrawingTypes)) {
-      return super.getToolTip(hit);
-    } else {
-      return SheetMeasurementsHelper.getToolTipText(MeasureDistanceTool._allowedDrawingTypes);
-    }
   }
 
   public override decorate(context: DecorateContext): void {

--- a/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
@@ -45,8 +45,9 @@ MeasureLocationToolModel
   public static override iconSpec = "icon-measure-location";
   private static readonly useDynamicMeasurementPropertyName = "useDynamicMeasurement";
 
-  private _enableSheetMeasurements: boolean;
-  private static _allowedDrawingTypes = [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  protected override get allowedDrawingTypes(): SheetMeasurementsHelper.DrawingType[] {
+    return [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
+  }
 
   private static _isUserNotifiedOfGeolocationFailure = false;
   private _useDynamicMeasurement: boolean = false;
@@ -155,18 +156,10 @@ MeasureLocationToolModel
     if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
       return true;
 
-    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, MeasureLocationTool._allowedDrawingTypes))
+    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, this.allowedDrawingTypes))
       return false;
 
     return true;
-  }
-
-  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
-    if (!this._enableSheetMeasurements || SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, MeasureLocationTool._allowedDrawingTypes)) {
-      return super.getToolTip(hit);
-    } else {
-      return SheetMeasurementsHelper.getToolTipText(MeasureLocationTool._allowedDrawingTypes);
-    }
   }
 
   protected async requestSnap(

--- a/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureLocationTool.ts
@@ -8,6 +8,7 @@ import { Vector3d } from "@itwin/core-geometry";
 import { IModelError } from "@itwin/core-common";
 import type {
   BeButtonEvent,
+  HitDetail,
   ToolAssistanceInstruction,
   ToolAssistanceSection,
 } from "@itwin/core-frontend";
@@ -43,7 +44,9 @@ MeasureLocationToolModel
   public static override toolId = "MeasureTools.MeasureLocation";
   public static override iconSpec = "icon-measure-location";
   private static readonly useDynamicMeasurementPropertyName = "useDynamicMeasurement";
+
   private _enableSheetMeasurements: boolean;
+  private static _allowedDrawingTypes = [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan];
 
   private static _isUserNotifiedOfGeolocationFailure = false;
   private _useDynamicMeasurement: boolean = false;
@@ -152,10 +155,18 @@ MeasureLocationToolModel
     if (!this._enableSheetMeasurements || !ev.viewport?.view.isSheetView())
       return true;
 
-    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev, [SheetMeasurementsHelper.DrawingType.CrossSection, SheetMeasurementsHelper.DrawingType.Plan]))
+    if (!SheetMeasurementsHelper.checkIfAllowedDrawingType(ev.viewport, ev.point, MeasureLocationTool._allowedDrawingTypes))
       return false;
 
     return true;
+  }
+
+  public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string> {
+    if (!this._enableSheetMeasurements || SheetMeasurementsHelper.checkIfAllowedDrawingType(hit.viewport, hit.hitPoint, MeasureLocationTool._allowedDrawingTypes)) {
+      return super.getToolTip(hit);
+    } else {
+      return SheetMeasurementsHelper.getToolTipText(MeasureLocationTool._allowedDrawingTypes);
+    }
   }
 
   protected async requestSnap(


### PR DESCRIPTION
Added tooltip to convey to user which drawings can take the measurement he's trying to use when using sheet measurements.
![TooltipSheetMeas](https://github.com/user-attachments/assets/bb12fca8-e2e6-4a59-b367-7ac1e9e76b16)
