### PR TITLE
Tree widget: Add a mention that `ECSchemaRpcLocater` requires `ECSchemaRpcInterface`

### DIFF
--- a/change/@itwin-tree-widget-react-31b6ae5a-14a7-4851-9df2-2075087576e4.json
+++ b/change/@itwin-tree-widget-react-31b6ae5a-14a7-4851-9df2-2075087576e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add a mention that `ECSchemaRpcLocater` requires `ECSchemaRpcInterface`",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -652,6 +652,8 @@ function getSchemaContext(imodel: IModelConnection) {
 
 <!-- END EXTRACTION -->
 
+Note: Using `ECSchemaRpcLocater` requires the application to support [ECSchemaRpcInterface](https://github.com/iTwin/itwinjs-core/blob/111ab9053f4718896de17bdaeb8de037bad281bd/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts#L14). This means [registering the interface](https://www.itwinjs.org/learning/rpcinterface/#configure-interfaces) and, on the backend, [registering the implementation](https://www.itwinjs.org/learning/rpcinterface/#server-side-configuration) by calling [ECSchemaRpcImpl.register()](https://github.com/iTwin/itwinjs-core/blob/111ab9053f4718896de17bdaeb8de037bad281bd/core/ecschema-rpc/impl/src/ECSchemaRpcImpl.ts#L29).
+
 ## Telemetry
 
 ### Performance tracking


### PR DESCRIPTION
Not everyone knows that `ECSchemaRpcLocater` requires `ECSchemaRpcInterface`...