### PR TITLE
Tree widget: Use `.Id` for navigation properties in ECSQL queries

### DIFF
--- a/apps/learning-snippets/package.json
+++ b/apps/learning-snippets/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@itwin/presentation-learning-snippets",
+  "name": "learning-snippets",
   "version": "0.0.0",
-  "description": "Learning snippets for ReadMes",
+  "description": "Learning snippets for documentation",
   "private": true,
   "scripts": {
     "build": "npm run link:deps && tsc",

--- a/change/@itwin-tree-widget-react-5890c301-d1a0-44fa-a060-2aa5355b91f2.json
+++ b/change/@itwin-tree-widget-react-5890c301-d1a0-44fa-a060-2aa5355b91f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update ECSQL queries to always use `.Id` suffix when querying navigation properties - that substantially improves query performance.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/IModelContentTreeDefinition.ts
@@ -144,7 +144,7 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
             WHERE
-              this.Parent IS NULL
+              this.Parent.Id IS NULL
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
           `,
         },
@@ -408,7 +408,7 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               WHERE
                 this.Category.Id IN (${categoryIds.map(() => "?").join(",")})
                 AND this.Model.Id IN (${modelIds.map(() => "?").join(",")})
-                AND this.Parent IS NULL
+                AND this.Parent.Id IS NULL
                 ${whereClause ? `AND ${whereClause}` : ""}
                 ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
             `,
@@ -455,7 +455,7 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
             WHERE
-              this.Parent IS NULL
+              this.Parent.Id IS NULL
               AND this.Model.Id IN (${modelIds.map(() => "?").join(",")})
               ${whereClause ? `AND ${whereClause}` : ""}
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}

--- a/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/internal/IModelContentTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/components/trees/imodel-content-tree/internal/IModelContentTreeIdsCache.ts
@@ -182,12 +182,12 @@ export class IModelContentTreeIdsCache {
     const query = /* sql */ `
       SELECT Model.Id modelId, Category.Id categoryId
       FROM BisCore.GeometricElement3d
-      WHERE Parent IS NULL
+      WHERE Parent.Id IS NULL
       GROUP BY Model.Id, Category.Id
       UNION ALL
       SELECT Model.Id modelId, Category.Id categoryId
       FROM BisCore.GeometricElement2d
-      WHERE Parent IS NULL
+      WHERE Parent.Id IS NULL
       GROUP BY Model.Id, Category.Id
     `;
     for await (const row of this._queryExecutor.createQueryReader({ ecsql: query }, { rowFormat: "ECSqlPropertyNames", limit: "unbounded" })) {

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -222,7 +222,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
             WHERE
-              this.Parent IS NULL
+              this.Parent.Id IS NULL
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
           `,
         },
@@ -416,7 +416,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 WHERE
                   element.Model.Id IN (${modelIds.map(() => "?").join(",")})
                   AND element.Category.Id = +this.ECInstanceId
-                  AND element.Parent IS NULL
+                  AND element.Parent.Id IS NULL
               )
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
           `,
@@ -483,7 +483,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             WHERE
               this.Category.Id IN (${categoryIds.map(() => "?").join(",")})
               AND this.Model.Id IN (${modelIds.map(() => "?").join(",")})
-              AND this.Parent IS NULL
+              AND this.Parent.Id IS NULL
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
           `,
           bindings: [...categoryIds.map((id) => ({ type: "id", value: id })), ...modelIds.map((id) => ({ type: "id", value: id }))] as ECSqlBinding[],
@@ -642,7 +642,7 @@ function createGeometricElementInstanceKeyPaths(
         FROM ${hierarchyConfig.elementClassSpecification} e
         WHERE
           e.ECClassId IS (${groupingNode.key.className})
-          AND ${parent.type === "element" ? bind("e.Parent.Id", parent.ids) : `e.Parent IS NULL AND ${bind("e.Category.Id", parent.ids)} AND ${bind("e.Model.Id", parent.modelIds)}`}
+          AND ${parent.type === "element" ? bind("e.Parent.Id", parent.ids) : `e.Parent.Id IS NULL AND ${bind("e.Category.Id", parent.ids)} AND ${bind("e.Model.Id", parent.modelIds)}`}
         `,
     );
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -240,7 +240,7 @@ export class ModelsTreeIdsCache {
     const query = /* sql */ `
       SELECT Model.Id modelId, Category.Id categoryId
       FROM ${this._hierarchyConfig.elementClassSpecification}
-      WHERE Parent IS NULL
+      WHERE Parent.Id IS NULL
       GROUP BY modelId, categoryId
     `;
     for await (const row of this._queryExecutor.createQueryReader({ ecsql: query }, { rowFormat: "ECSqlPropertyNames", limit: "unbounded" })) {
@@ -311,7 +311,7 @@ export class ModelsTreeIdsCache {
               WHERE
                 Model.Id = ?
                 AND Category.Id = ?
-                AND Parent IS NULL
+                AND Parent.Id IS NULL
 
               UNION ALL
 


### PR DESCRIPTION
Apply query modifications based on this: https://github.com/iTwin/imodel-native/issues/912.