### PR TITLE
[measurement-tools] (RE) expose a callback that allows the application to determine whether to show or hide the measurement tools.

### DIFF
--- a/apps/test-viewer/package.json
+++ b/apps/test-viewer/package.json
@@ -33,7 +33,7 @@
     "@itwin/map-layers-auth": "^4.9.5",
     "@itwin/map-layers-formats": "^4.9.5",
     "@itwin/measure-tools-react": "workspace:*",
-    "@itwin/oidc-signin-tool": "^4.3.6",
+    "@itwin/oidc-signin-tool": "^4.3.7",
     "@itwin/one-click-lca-react": "workspace:*",
     "@itwin/presentation-common": "^4.9.5",
     "@itwin/presentation-components": "^5.6.0",

--- a/apps/test-viewer/pnpm-lock.yaml
+++ b/apps/test-viewer/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: workspace:*
         version: file:../../packages/itwin/measure-tools(fktcpd52643grq4v7oscdk4y5i)
       '@itwin/oidc-signin-tool':
-        specifier: ^4.3.6
-        version: 4.3.6(@itwin/core-bentley@4.9.5)(@itwin/core-geometry@4.9.5)
+        specifier: ^4.3.7
+        version: 4.3.7(@itwin/core-bentley@4.9.5)(@itwin/core-geometry@4.9.5)
       '@itwin/one-click-lca-react':
         specifier: workspace:*
         version: file:../../packages/itwin/one-click-lca-widget(@itwin/appui-abstract@4.9.5(@itwin/core-bentley@4.9.5))(@itwin/appui-react@4.17.2(37oclppqg5ffimsurufjbfgbdm))(@itwin/core-frontend@4.9.5(@itwin/appui-abstract@4.9.5(@itwin/core-bentley@4.9.5))(@itwin/core-bentley@4.9.5)(@itwin/core-common@4.9.5(@itwin/core-bentley@4.9.5)(@itwin/core-geometry@4.9.5))(@itwin/core-geometry@4.9.5)(@itwin/core-orbitgt@4.9.5)(@itwin/core-quantity@4.9.5(@itwin/core-bentley@4.9.5))(inversify@6.0.3)(reflect-metadata@0.1.14))(@itwin/core-react@4.17.2(@itwin/appui-abstract@4.9.5(@itwin/core-bentley@4.9.5))(@itwin/core-bentley@4.9.5)(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -546,8 +546,8 @@ packages:
   '@itwin/components-react@4.17.2':
     resolution: {integrity: sha512-EaElyMpBb/cZcJ5N6jjCd06Lv4zzkuD2g83+C3z129uAuTzmvpvHQwd3JnIiYVKWPhc9YefJaWgZpgNwQO/bhQ==}
     peerDependencies:
-      '@itwin/appui-abstract': workspace:*
-      '@itwin/core-bentley': workspace:*
+      '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
+      '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       '@itwin/core-react': ^4.17.2
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
@@ -598,8 +598,8 @@ packages:
   '@itwin/core-react@4.17.2':
     resolution: {integrity: sha512-wXAiFoBrBYEY82JTn0waUcVecpz11SesXxd8zgwl56JAdEJm8aTQx09zm6dbZHC6miBAOgwZqF5IzVzBJZGHGw==}
     peerDependencies:
-      '@itwin/appui-abstract': workspace:*
-      '@itwin/core-bentley': workspace:*
+      '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
+      '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
 
@@ -664,13 +664,13 @@ packages:
   '@itwin/imodel-components-react@4.17.2':
     resolution: {integrity: sha512-Wj2BfE2h3xIbaiM8KBt/dOuMoVmYhR+FtLS2T0U4VqhoK1E5QtNZqTMPNuyCF7NlfIXX9x0Bg7ZS8nw26vPaZw==}
     peerDependencies:
-      '@itwin/appui-abstract': workspace:*
+      '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
       '@itwin/components-react': ^4.17.2
-      '@itwin/core-bentley': workspace:*
-      '@itwin/core-common': workspace:*
-      '@itwin/core-frontend': workspace:*
-      '@itwin/core-geometry': workspace:*
-      '@itwin/core-quantity': workspace:*
+      '@itwin/core-bentley': ^3.7.0 || ^4.0.0
+      '@itwin/core-common': ^3.7.0 || ^4.0.0
+      '@itwin/core-frontend': ^3.7.0 || ^4.0.0
+      '@itwin/core-geometry': ^3.7.0 || ^4.0.0
+      '@itwin/core-quantity': ^3.7.0 || ^4.0.0
       '@itwin/core-react': ^4.17.2
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
@@ -801,8 +801,8 @@ packages:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
 
-  '@itwin/oidc-signin-tool@4.3.6':
-    resolution: {integrity: sha512-DUOZNzrueGkz9qoAGAjDnQGrArMsHaHdaG2Tyvp6F9GsgjeAn1YYW+PfnIokm/ihjK7eFURznPEtKzORO4olXw==}
+  '@itwin/oidc-signin-tool@4.3.7':
+    resolution: {integrity: sha512-II5l7FxpgLQUbrzvCQfuul3uq3boH6XZwyb57BsgF6uvjSekAuvAVo2CkR5vlx57sWtM+thsEwiZ4xUMPe7Cmw==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
 
@@ -3803,7 +3803,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@itwin/oidc-signin-tool@4.3.6(@itwin/core-bentley@4.9.5)(@itwin/core-geometry@4.9.5)':
+  '@itwin/oidc-signin-tool@4.3.7(@itwin/core-bentley@4.9.5)(@itwin/core-geometry@4.9.5)':
     dependencies:
       '@itwin/certa': 4.9.5
       '@itwin/core-bentley': 4.9.5

--- a/change/@itwin-measure-tools-react-66b88556-194d-4f31-b347-d8ce936c5233.json
+++ b/change/@itwin-measure-tools-react-66b88556-194d-4f31-b347-d8ce936c5233.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "provide a callback to allow the application to decide whether to show or hide the measurement tools",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "thanh.duong@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -19,9 +19,6 @@ import { MeasurementPropertyWidget, MeasurementPropertyWidgetId } from "./Measur
 import { IModelApp } from "@itwin/core-frontend";
 import type { ScreenViewport } from "@itwin/core-frontend";
 
-// Note: measure tools cannot pick geometry when a sheet view is active to snap to and therefore must be hidden
-//  to avoid giving the user the impression they should work
-const isSheetViewActive = () => !!IModelApp.viewManager.selectedView?.view?.isSheetView();
 
 export interface MeasureToolsUiProviderOptions {
   itemPriority?: number;
@@ -36,6 +33,8 @@ export interface MeasureToolsUiProviderOptions {
   // Called in the isValidLocation to filter viewports the tool can be used into
   allowedViewportCallback?: (vp: ScreenViewport) => boolean;
   additionalToolbarItems?: ToolItemDef[];
+  // Check if the measurement tools should be visible or hidden
+  isHiddenCallback?: (activeViewport?: ScreenViewport) => boolean;
 }
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
@@ -53,7 +52,8 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       enableSheetMeasurement: props?.enableSheetMeasurement ?? false,
       stageUsageList: props?.stageUsageList ?? [StageUsage.General],
       allowedViewportCallback: props?.allowedViewportCallback ?? ((_vp: ScreenViewport) => {return true}),
-      additionalToolbarItems: props?.additionalToolbarItems
+      additionalToolbarItems: props?.additionalToolbarItems,
+      isHiddenCallback: props?.isHiddenCallback ?? ((_activeViewport?: ScreenViewport) => false),
     };
   }
 
@@ -67,6 +67,7 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
       const featureFlags = MeasureTools.featureFlags;
       const tools: ToolItemDef[] = [];
       const callback = this._props.allowedViewportCallback as (vp: ScreenViewport) => boolean;
+      const isHiddenCallbackFunc = this._props.isHiddenCallback as (activeViewport?: ScreenViewport) => boolean;
       if (!featureFlags?.hideDistanceTool) {
         tools.push(MeasureToolDefinitions.getMeasureDistanceToolCommand(callback, this._props.enableSheetMeasurement));
       }
@@ -102,8 +103,8 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
             {
               groupPriority: this._props.groupPriority,
               isHidden: new ConditionalBooleanValue(
-                isSheetViewActive,
-                [SyncUiEventId.ViewStateChanged],
+                () => isHiddenCallbackFunc(IModelApp.viewManager.selectedView),
+                [SyncUiEventId.ActiveViewportChanged, SyncUiEventId.ViewStateChanged],
               ),
             },
           ),
@@ -117,8 +118,9 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
             MeasureToolDefinitions.clearMeasurementsToolCommand,
             {
               isHidden: new ConditionalBooleanValue(
-                () => isSheetViewActive() || !MeasurementUIEvents.isClearMeasurementButtonVisible,
+                () => !MeasurementUIEvents.isClearMeasurementButtonVisible,
                 [
+                  SyncUiEventId.ActiveViewportChanged,
                   SyncUiEventId.ViewStateChanged,
                   MeasurementSyncUiEventId.MeasurementSelectionSetChanged,
                   MeasurementSyncUiEventId.DynamicMeasurementChanged,


### PR DESCRIPTION
The measuring tools have supported measurement on sheet views since PR [837](https://github.com/iTwin/viewer-components-react/pull/837). As a result, the changes made in PR [336](https://github.com/iTwin/viewer-components-react/pull/336), which disabled the measurement tools when a sheet view is active, need to be revised accordingly.

This PR introduces a callback that allows the application to determine whether to show or hide the measurement tools. Additionally, the tools now listen to the `SyncUiEventId.ActiveViewportChanged` event to update their visibility when the user changes the active view in a multi-view frontstage.

**This is an attempt at doing @thanhbinh-d #1069 to validate if the issue is with org membership.**