### PR TITLE
Reduce e2e tests logs during build

### DIFF
--- a/test-viewer.Dockerfile
+++ b/test-viewer.Dockerfile
@@ -27,4 +27,4 @@ RUN git init
 RUN git commit -m"Initial" --allow-empty
 
 # Build test-viewer and its dependencies
-RUN pnpm lage build --to test-viewer --no-cache
+RUN pnpm lage build --to test-viewer --no-cache --grouped


### PR DESCRIPTION
Reduces lage output produced during build that adds a lot of noise to CI pipeline logs