### PR TITLE
[Tree-widget]: added missing tooltips

### DIFF
--- a/packages/itwin/tree-widget/src/components/tree-header/TreeHeader.tsx
+++ b/packages/itwin/tree-widget/src/components/tree-header/TreeHeader.tsx
@@ -183,7 +183,7 @@ function HeaderButtons(props: PropsWithChildren<HeaderButtonsProps>) {
           }
           className="tree-header-button-dropdown-container"
         >
-          <IconButton title={TreeWidget.translate("header.dropdownMore")} styleType="borderless" size={props.size}>
+          <IconButton label={TreeWidget.translate("header.dropdownMore")} styleType="borderless" size={props.size}>
             <SvgMore />
           </IconButton>
         </DropdownMenu>

--- a/packages/itwin/tree-widget/src/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -66,7 +66,7 @@ export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
     <IconButton
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
-      title={TreeWidget.translate("categoriesTree.buttons.showAll.tooltip")}
+      label={TreeWidget.translate("categoriesTree.buttons.showAll.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-showall`);
         void showAllCategories(
@@ -86,7 +86,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
     <IconButton
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
-      title={TreeWidget.translate("categoriesTree.buttons.hideAll.tooltip")}
+      label={TreeWidget.translate("categoriesTree.buttons.hideAll.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-hideall`);
         void hideAllCategories(
@@ -104,7 +104,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
 export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
   return (
     <IconButton
-      title={TreeWidget.translate("categoriesTree.buttons.invert.tooltip")}
+      label={TreeWidget.translate("categoriesTree.buttons.invert.tooltip")}
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
       onClick={() => {

--- a/packages/itwin/tree-widget/src/components/trees/common/components/TreeNodeCheckbox.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/common/components/TreeNodeCheckbox.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import cx from "classnames";
-import { Checkbox } from "@itwin/itwinui-react";
+import { Checkbox, Tooltip } from "@itwin/itwinui-react";
 import { isPresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 
 import type { PresentationHierarchyNode, RenderedTreeNode } from "@itwin/presentation-hierarchies-react";
@@ -40,19 +40,21 @@ export function TreeNodeCheckbox({ node, onCheckboxClicked, getCheckboxState, ..
 
   const checkboxState = getCheckboxState(node);
   return (
-    <Checkbox
-      {...props}
-      className={cx("tw-tree-node-checkbox", props.className)}
-      checked={checkboxState.state === "on"}
-      onClick={(e) => {
-        e.stopPropagation();
-      }}
-      onChange={(e) => {
-        onCheckboxClicked(node, e.currentTarget.checked);
-      }}
-      indeterminate={checkboxState.state === "partial"}
-      disabled={checkboxState.isDisabled}
-      title={checkboxState.tooltip}
-    />
+    <Tooltip content={checkboxState.tooltip} placement="left">
+      <Checkbox
+        {...props}
+        className={cx("tw-tree-node-checkbox", props.className)}
+        checked={checkboxState.state === "on"}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        onChange={(e) => {
+          onCheckboxClicked(node, e.currentTarget.checked);
+        }}
+        indeterminate={checkboxState.state === "partial"}
+        disabled={checkboxState.isDisabled}
+        title={checkboxState.tooltip}
+      />
+    </Tooltip>
   );
 }

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { SvgCursorClick, SvgVisibilityHalf, SvgVisibilityHide, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
-import { Button, IconButton } from "@itwin/itwinui-react";
+import { Button, IconButton, Tooltip } from "@itwin/itwinui-react";
 import { TreeWidget } from "../../../TreeWidget";
 import { useFocusedInstancesContext } from "../common/FocusedInstancesContext";
 import { areAllModelsVisible, hideAllModels, invertAllModels, showAllModels, toggleModels } from "./internal/ModelsTreeVisibilityHandler";
@@ -112,7 +112,7 @@ export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
     <IconButton
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
-      title={TreeWidget.translate("modelsTree.buttons.showAll.tooltip")}
+      label={TreeWidget.translate("modelsTree.buttons.showAll.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-showall");
         void showAllModels(
@@ -132,7 +132,7 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
     <IconButton
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
-      title={TreeWidget.translate("modelsTree.buttons.hideAll.tooltip")}
+      label={TreeWidget.translate("modelsTree.buttons.hideAll.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-hideall");
         void hideAllModels(
@@ -152,7 +152,7 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
     <IconButton
       size={props.density === "enlarged" ? "large" : "small"}
       styleType="borderless"
-      title={TreeWidget.translate("modelsTree.buttons.invert.tooltip")}
+      label={TreeWidget.translate("modelsTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-invert");
         void invertAllModels(
@@ -180,19 +180,21 @@ export function View2DButton(props: ModelsTreeHeaderButtonProps) {
   }, [models2d, props.viewport]);
 
   return (
-    <Button
-      size={props.density === "enlarged" ? "large" : "small"}
-      styleType="borderless"
-      title={TreeWidget.translate("modelsTree.buttons.toggle2d.tooltip")}
-      onClick={() => {
-        props.onFeatureUsed?.("models-tree-view2d");
-        void toggleModels(models2d, is2dToggleActive, props.viewport);
-      }}
-      disabled={models2d.length === 0}
-      endIcon={is2dToggleActive ? <SvgVisibilityShow /> : <SvgVisibilityHide />}
-    >
-      {TreeWidget.translate("modelsTree.buttons.toggle2d.label")}
-    </Button>
+    <Tooltip content={TreeWidget.translate("modelsTree.buttons.toggle2d.tooltip")}>
+      <Button
+        size={props.density === "enlarged" ? "large" : "small"}
+        styleType="borderless"
+        title={TreeWidget.translate("modelsTree.buttons.toggle2d.tooltip")}
+        onClick={() => {
+          props.onFeatureUsed?.("models-tree-view2d");
+          void toggleModels(models2d, is2dToggleActive, props.viewport);
+        }}
+        disabled={models2d.length === 0}
+        endIcon={is2dToggleActive ? <SvgVisibilityShow /> : <SvgVisibilityHide />}
+      >
+        {TreeWidget.translate("modelsTree.buttons.toggle2d.label")}
+      </Button>
+    </Tooltip>
   );
 }
 
@@ -210,33 +212,35 @@ export function View3DButton(props: ModelsTreeHeaderButtonProps) {
   }, [models3d, props.viewport]);
 
   return (
-    <Button
-      size={props.density === "enlarged" ? "large" : "small"}
-      styleType="borderless"
-      title={TreeWidget.translate("modelsTree.buttons.toggle3d.tooltip")}
-      onClick={() => {
-        props.onFeatureUsed?.("models-tree-view3d");
-        void toggleModels(models3d, is3dToggleActive, props.viewport);
-      }}
-      disabled={models3d.length === 0}
-      endIcon={is3dToggleActive ? <SvgVisibilityShow /> : <SvgVisibilityHide />}
-    >
-      {TreeWidget.translate("modelsTree.buttons.toggle3d.label")}
-    </Button>
+    <Tooltip content={TreeWidget.translate("modelsTree.buttons.toggle3d.tooltip")}>
+      <Button
+        size={props.density === "enlarged" ? "large" : "small"}
+        styleType="borderless"
+        title={TreeWidget.translate("modelsTree.buttons.toggle3d.tooltip")}
+        onClick={() => {
+          props.onFeatureUsed?.("models-tree-view3d");
+          void toggleModels(models3d, is3dToggleActive, props.viewport);
+        }}
+        disabled={models3d.length === 0}
+        endIcon={is3dToggleActive ? <SvgVisibilityShow /> : <SvgVisibilityHide />}
+      >
+        {TreeWidget.translate("modelsTree.buttons.toggle3d.label")}
+      </Button>
+    </Tooltip>
   );
 }
 
 /** @public */
 export function ToggleInstancesFocusButton({ density, onFeatureUsed }: { density?: "default" | "enlarged"; onFeatureUsed?: (feature: string) => void }) {
   const { enabled, toggle } = useFocusedInstancesContext();
-  const title = enabled
+  const label = enabled
     ? TreeWidget.translate("modelsTree.buttons.toggleFocusMode.disable.tooltip")
     : TreeWidget.translate("modelsTree.buttons.toggleFocusMode.enable.tooltip");
   return (
     <IconButton
       styleType="borderless"
       size={density === "enlarged" ? "large" : "small"}
-      title={title}
+      label={label}
       onClick={() => {
         onFeatureUsed?.("models-tree-instancesfocus");
         toggle();


### PR DESCRIPTION
Added missing tooltips:
2D button
![image](https://github.com/user-attachments/assets/571263cd-eee5-408a-9975-8ea4589781a2)
3D button
![image](https://github.com/user-attachments/assets/55dc2de4-5072-4873-b0c9-66aba76817f0)
Visibility icon
![image](https://github.com/user-attachments/assets/ce0fabfb-0b44-41f5-80de-a538ebc7c935)
Visibility icons tooltip is placed to the left of the icon with the intention of the tooltip not blocking other icons.
