### PR TITLE
Tree widget: Reduce the number of queries being executed when always/never drawn sets change

### DIFF
--- a/change/@itwin-tree-widget-react-24cc0a5c-1b2f-4569-af89-1440642ca614.json
+++ b/change/@itwin-tree-widget-react-24cc0a5c-1b2f-4569-af89-1440642ca614.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce the number of queries being executed when always/never drawn sets change.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -150,7 +150,7 @@
     "stylelint": "^15.11.0",
     "stylelint-config-standard-scss": "^11.1.0",
     "typemoq": "^2.1.0",
-    "typescript": "~5.0.0",
+    "typescript": "~5.2.0",
     "xmlhttprequest": "^1.8.0"
   },
   "eslintConfig": {

--- a/packages/itwin/tree-widget/pnpm-lock.yaml
+++ b/packages/itwin/tree-widget/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 4.9.1(@itwin/core-backend@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1))(@itwin/core-geometry@4.9.1)(@opentelemetry/api@1.7.0))(@itwin/core-bentley@4.9.1)(@itwin/core-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1))(@itwin/core-geometry@4.9.1)(@itwin/ecschema-metadata@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1)))(@itwin/ecschema-rpcinterface-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1))(@itwin/core-geometry@4.9.1)(@itwin/ecschema-metadata@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1))))
       '@itwin/eslint-plugin':
         specifier: ^4.1.1
-        version: 4.1.1(eslint@8.57.0)(typescript@5.0.2)
+        version: 4.1.1(eslint@8.57.0)(typescript@5.2.2)
       '@itwin/imodel-components-react':
         specifier: ^4.17.0
         version: 4.17.0(kojvgp2et3jwtkdd2r2heiphaq)
@@ -170,10 +170,10 @@ importers:
         version: 3.2.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.16.1
-        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2)
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: ^7.16.1
-        version: 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+        version: 7.16.1(eslint@8.57.0)(typescript@5.2.2)
       chai:
         specifier: ^4.3.7
         version: 4.3.7
@@ -206,13 +206,13 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)
       eslint-plugin-react:
         specifier: ^7.34.4
         version: 7.34.4(eslint@8.57.0)
       eslint-plugin-unused-imports:
         specifier: ^3.2.0
-        version: 3.2.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)
+        version: 3.2.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)
       fast-xml-parser:
         specifier: ^4.3.6
         version: 4.4.1
@@ -263,16 +263,16 @@ importers:
         version: 0.5.6
       stylelint:
         specifier: ^15.11.0
-        version: 15.11.0(typescript@5.0.2)
+        version: 15.11.0(typescript@5.2.2)
       stylelint-config-standard-scss:
         specifier: ^11.1.0
-        version: 11.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.0.2))
+        version: 11.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.2.2))
       typemoq:
         specifier: ^2.1.0
         version: 2.1.0
       typescript:
-        specifier: ~5.0.0
-        version: 5.0.2
+        specifier: ~5.2.0
+        version: 5.2.2
       xmlhttprequest:
         specifier: ^1.8.0
         version: 1.8.0
@@ -4003,9 +4003,9 @@ packages:
     resolution: {integrity: sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==}
     engines: {node: '>=6.0.0'}
 
-  typescript@5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
+  typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.3.3:
@@ -4756,7 +4756,7 @@ snapshots:
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13(typescript@5.3.3)
-      typedoc-plugin-merge-modules: 5.1.0(typedoc@0.25.13(typescript@5.0.2))
+      typedoc-plugin-merge-modules: 5.1.0(typedoc@0.25.13(typescript@5.2.2))
       typescript: 5.3.3
       wtfnode: 0.9.1
       yargs: 17.7.2
@@ -4926,20 +4926,20 @@ snapshots:
       '@itwin/ecschema-metadata': 4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1))
       '@itwin/ecschema-rpcinterface-common': 4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-common@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-geometry@4.9.1))(@itwin/core-geometry@4.9.1)(@itwin/ecschema-metadata@4.9.1(@itwin/core-bentley@4.9.1)(@itwin/core-quantity@4.9.1(@itwin/core-bentley@4.9.1)))
 
-  '@itwin/eslint-plugin@4.1.1(eslint@8.57.0)(typescript@5.0.2)':
+  '@itwin/eslint-plugin@4.1.1(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.0.2(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2)
-      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/eslint-plugin': 7.0.2(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
       eslint: 8.57.0
-      eslint-plugin-deprecation: 2.0.0(eslint@8.57.0)(typescript@5.0.2)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)
+      eslint-plugin-deprecation: 2.0.0(eslint@8.57.0)(typescript@5.2.2)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 48.7.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-prefer-arrow: 1.2.3(eslint@8.57.0)
       eslint-plugin-react: 7.34.4(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
-      typescript: 5.0.2
+      typescript: 5.2.2
       workspace-tools: 0.36.4
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -5489,13 +5489,13 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@typescript-eslint/eslint-plugin@7.0.2(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/eslint-plugin@7.0.2(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 7.0.2
-      '@typescript-eslint/type-utils': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
-      '@typescript-eslint/utils': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/type-utils': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.0.2
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
@@ -5503,53 +5503,53 @@ snapshots:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 7.16.1
-      '@typescript-eslint/type-utils': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
-      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/type-utils': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.16.1
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.0.2
       '@typescript-eslint/types': 7.0.2
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.0.2
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.16.1
       '@typescript-eslint/types': 7.16.1
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5568,27 +5568,27 @@ snapshots:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
 
-  '@typescript-eslint/type-utils@7.0.2(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/type-utils@7.0.2(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.2)
-      '@typescript-eslint/utils': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.2.2)
+      '@typescript-eslint/utils': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.16.1(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/type-utils@7.16.1(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.0.2)
-      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.2.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5598,7 +5598,7 @@ snapshots:
 
   '@typescript-eslint/types@7.16.1': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.0.2)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.2.2)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -5607,13 +5607,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.0.2(typescript@5.0.2)':
+  '@typescript-eslint/typescript-estree@7.0.2(typescript@5.2.2)':
     dependencies:
       '@typescript-eslint/types': 7.0.2
       '@typescript-eslint/visitor-keys': 7.0.2
@@ -5622,13 +5622,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.0.2)':
+  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.2.2)':
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
@@ -5637,46 +5637,46 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.0.2)
+      ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
       eslint: 8.57.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.0.2(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/utils@7.0.2(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 7.0.2
       '@typescript-eslint/types': 7.0.2
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.2.2)
       eslint: 8.57.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.16.1(eslint@8.57.0)(typescript@5.0.2)':
+  '@typescript-eslint/utils@7.16.1(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.16.1
       '@typescript-eslint/types': 7.16.1
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.0.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.2.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -6129,14 +6129,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.0.2):
+  cosmiconfig@8.3.6(typescript@5.2.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
 
   cpx2@3.0.0:
     dependencies:
@@ -6539,37 +6539,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-deprecation@2.0.0(eslint@8.57.0)(typescript@5.0.2):
+  eslint-plugin-deprecation@2.0.0(eslint@8.57.0)(typescript@5.2.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
       eslint: 8.57.0
       tslib: 2.6.2
-      tsutils: 3.21.0(typescript@5.0.2)
-      typescript: 5.0.2
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -6579,7 +6579,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.0.2(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6590,13 +6590,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -6606,7 +6606,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6617,7 +6617,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -6696,12 +6696,12 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0):
+  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.0.2))(eslint@8.57.0)(typescript@5.0.2)
+      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.2.2))(eslint@8.57.0)(typescript@5.2.2)
 
   eslint-rule-composer@0.3.0: {}
 
@@ -8603,42 +8603,42 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  stylelint-config-recommended-scss@13.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.0.2)):
+  stylelint-config-recommended-scss@13.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.2.2)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.4.32)
-      stylelint: 15.11.0(typescript@5.0.2)
-      stylelint-config-recommended: 13.0.0(stylelint@15.11.0(typescript@5.0.2))
-      stylelint-scss: 5.3.2(stylelint@15.11.0(typescript@5.0.2))
+      stylelint: 15.11.0(typescript@5.2.2)
+      stylelint-config-recommended: 13.0.0(stylelint@15.11.0(typescript@5.2.2))
+      stylelint-scss: 5.3.2(stylelint@15.11.0(typescript@5.2.2))
     optionalDependencies:
       postcss: 8.4.32
 
-  stylelint-config-recommended@13.0.0(stylelint@15.11.0(typescript@5.0.2)):
+  stylelint-config-recommended@13.0.0(stylelint@15.11.0(typescript@5.2.2)):
     dependencies:
-      stylelint: 15.11.0(typescript@5.0.2)
+      stylelint: 15.11.0(typescript@5.2.2)
 
-  stylelint-config-standard-scss@11.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.0.2)):
+  stylelint-config-standard-scss@11.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.2.2)):
     dependencies:
-      stylelint: 15.11.0(typescript@5.0.2)
-      stylelint-config-recommended-scss: 13.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.0.2))
-      stylelint-config-standard: 34.0.0(stylelint@15.11.0(typescript@5.0.2))
+      stylelint: 15.11.0(typescript@5.2.2)
+      stylelint-config-recommended-scss: 13.1.0(postcss@8.4.32)(stylelint@15.11.0(typescript@5.2.2))
+      stylelint-config-standard: 34.0.0(stylelint@15.11.0(typescript@5.2.2))
     optionalDependencies:
       postcss: 8.4.32
 
-  stylelint-config-standard@34.0.0(stylelint@15.11.0(typescript@5.0.2)):
+  stylelint-config-standard@34.0.0(stylelint@15.11.0(typescript@5.2.2)):
     dependencies:
-      stylelint: 15.11.0(typescript@5.0.2)
-      stylelint-config-recommended: 13.0.0(stylelint@15.11.0(typescript@5.0.2))
+      stylelint: 15.11.0(typescript@5.2.2)
+      stylelint-config-recommended: 13.0.0(stylelint@15.11.0(typescript@5.2.2))
 
-  stylelint-scss@5.3.2(stylelint@15.11.0(typescript@5.0.2)):
+  stylelint-scss@5.3.2(stylelint@15.11.0(typescript@5.2.2)):
     dependencies:
       known-css-properties: 0.29.0
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.1
       postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
-      stylelint: 15.11.0(typescript@5.0.2)
+      stylelint: 15.11.0(typescript@5.2.2)
 
-  stylelint@15.11.0(typescript@5.0.2):
+  stylelint@15.11.0(typescript@5.2.2):
     dependencies:
       '@csstools/css-parser-algorithms': 2.4.0(@csstools/css-tokenizer@2.2.2)
       '@csstools/css-tokenizer': 2.2.2
@@ -8646,7 +8646,7 @@ snapshots:
       '@csstools/selector-specificity': 3.0.1(postcss-selector-parser@6.0.13)
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 8.3.6(typescript@5.0.2)
+      cosmiconfig: 8.3.6(typescript@5.2.2)
       css-functions-list: 3.2.1
       css-tree: 2.3.1
       debug: 4.3.4(supports-color@8.1.1)
@@ -8775,9 +8775,9 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.4
 
-  ts-api-utils@1.3.0(typescript@5.0.2):
+  ts-api-utils@1.3.0(typescript@5.2.2):
     dependencies:
-      typescript: 5.0.2
+      typescript: 5.2.2
 
   ts-key-enum@2.0.12: {}
 
@@ -8792,10 +8792,10 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsutils@3.21.0(typescript@5.0.2):
+  tsutils@3.21.0(typescript@5.2.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.2
+      typescript: 5.2.2
 
   type-check@0.4.0:
     dependencies:
@@ -8872,7 +8872,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-merge-modules@5.1.0(typedoc@0.25.13(typescript@5.0.2)):
+  typedoc-plugin-merge-modules@5.1.0(typedoc@0.25.13(typescript@5.2.2)):
     dependencies:
       typedoc: 0.25.13(typescript@5.3.3)
 
@@ -8890,7 +8890,7 @@ snapshots:
       lodash: 4.17.21
       postinstall-build: 5.0.3
 
-  typescript@5.0.2: {}
+  typescript@5.2.2: {}
 
   typescript@5.3.3: {}
 

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/UseModelsTree.tsx
@@ -306,6 +306,10 @@ function useCachedVisibility(activeView: Viewport, hierarchyConfig: ModelsTreeHi
   const cacheRef = useRef<ModelsTreeIdsCache>();
   const currentIModelRef = useRef(activeView.iModel);
 
+  const resetModelsTreeIdsCache = () => {
+    cacheRef.current?.[Symbol.dispose]();
+    cacheRef.current = undefined;
+  };
   const getModelsTreeIdsCache = useCallback(() => {
     if (!cacheRef.current) {
       cacheRef.current = new ModelsTreeIdsCache(createECSqlQueryExecutor(currentIModelRef.current), hierarchyConfig);
@@ -321,15 +325,15 @@ function useCachedVisibility(activeView: Viewport, hierarchyConfig: ModelsTreeHi
   useIModelChangeListener({
     imodel: activeView.iModel,
     action: useCallback(() => {
-      cacheRef.current = undefined;
+      resetModelsTreeIdsCache();
       setVisibilityHandlerFactory(() => createVisibilityHandlerFactory(activeView, getModelsTreeIdsCache, overrides, filteredPaths));
     }, [activeView, getModelsTreeIdsCache, overrides, filteredPaths]),
   });
 
   useEffect(() => {
     currentIModelRef.current = activeView.iModel;
-    cacheRef.current = undefined;
     setVisibilityHandlerFactory(() => createVisibilityHandlerFactory(activeView, getModelsTreeIdsCache, overrides, filteredPaths));
+    return () => resetModelsTreeIdsCache();
   }, [activeView, getModelsTreeIdsCache, overrides, filteredPaths]);
 
   return {

--- a/packages/itwin/tree-widget/src/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -417,7 +417,7 @@ class ModelCategoryElementsCountCache {
       return firstValueFrom(result);
     }
 
-    result = new ReplaySubject();
+    result = new ReplaySubject(1);
     this._cache.set(cacheKey, result);
     this._requestsStream.next({ modelId, categoryId });
     return firstValueFrom(result);

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeDefinition.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeDefinition.test.ts
@@ -73,8 +73,9 @@ describe("Models tree", () => {
         const modelingElement = insertPhysicalElement({ builder, userLabel: `modeling element`, modelId: subModel.id, categoryId: category.id });
         return { rootSubject, childSubject, model, category, rootElement1, rootElement2, childElement, modelingElement };
       });
+      using provider = createModelsTreeProvider({ imodel });
       await validateHierarchy({
-        provider: createModelsTreeProvider({ imodel }),
+        provider,
         expect: [
           NodeValidators.createForInstanceNode({
             instanceKeys: [keys.rootSubject],
@@ -173,8 +174,9 @@ describe("Models tree", () => {
           const element = insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
           return { rootSubject, childSubject, model, category, element };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -209,8 +211,9 @@ describe("Models tree", () => {
           const childSubject = insertSubject({ builder, codeValue: "child subject", parentId: rootSubject.id });
           return { rootSubject, childSubject };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -236,8 +239,9 @@ describe("Models tree", () => {
           });
           return { rootSubject, childSubject1, childSubject2, model };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -266,8 +270,9 @@ describe("Models tree", () => {
           insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
           return { rootSubject, childSubject1, childSubject2, model };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -295,8 +300,9 @@ describe("Models tree", () => {
           });
           return { rootSubject, childSubject1, childSubject2, model, category, element };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -379,8 +385,9 @@ describe("Models tree", () => {
           const element2 = insertPhysicalElement({ builder, userLabel: `element1`, modelId: model2.id, categoryId: category.id });
           return { rootSubject, mergedSubject1, mergedSubject2, model1, model2, category, element1, element2 };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -448,8 +455,9 @@ describe("Models tree", () => {
           const element = insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
           return { rootSubject, model, category, element };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -487,8 +495,9 @@ describe("Models tree", () => {
           const element = insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
           return { rootSubject, model, category, element };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -520,8 +529,9 @@ describe("Models tree", () => {
           const element = insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
           return { rootSubject, model, category, element };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -540,8 +550,9 @@ describe("Models tree", () => {
           const model = insertPhysicalSubModel({ builder, modeledElementId: partition.id });
           return { rootSubject, model };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -594,8 +605,9 @@ describe("Models tree", () => {
           const element2 = insertPhysicalElement({ builder, userLabel: `element2`, modelId: model2.id, categoryId: category2.id });
           return { rootSubject, model1, model2, category1, category2, element1, element2 };
         });
+        using provider = createModelsTreeProvider({ imodel });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -630,8 +642,9 @@ describe("Models tree", () => {
           const model = insertPhysicalSubModel({ builder, modeledElementId: partition.id });
           return { rootSubject, model };
         });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { showEmptyModels: true } });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel, hierarchyConfig: { showEmptyModels: true } }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -674,8 +687,9 @@ describe("Models tree", () => {
           const modelingElement = insertPhysicalElement({ builder, userLabel: `modeling element`, modelId: subModel.id, categoryId: category.id });
           return { rootSubject, childSubject, model, category, rootElement1, rootElement2, childElement, modelingElement };
         });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassGrouping: "disable" } });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassGrouping: "disable" } }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -766,8 +780,9 @@ describe("Models tree", () => {
           const modelingElement = insertPhysicalElement({ builder, userLabel: `modeling element`, modelId: subModel.id, categoryId: category.id });
           return { rootSubject, childSubject, model, category, rootElement1, rootElement2, childElement1, childElement2, modelingElement };
         });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassGrouping: "enableWithCounts" } });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassGrouping: "enableWithCounts" } }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -890,11 +905,12 @@ describe("Models tree", () => {
           });
           return { rootSubject, model, category, parentElement1, childElement1, parentElement2, childElement2 };
         });
+        using provider = createModelsTreeProvider({
+          imodel,
+          hierarchyConfig: { elementClassSpecification: keys.parentElement2.className, elementClassGrouping: "disable" },
+        });
         await validateHierarchy({
-          provider: createModelsTreeProvider({
-            imodel,
-            hierarchyConfig: { elementClassSpecification: keys.parentElement2.className, elementClassGrouping: "disable" },
-          }),
+          provider,
           expect: [
             NodeValidators.createForInstanceNode({
               instanceKeys: [keys.rootSubject],
@@ -937,8 +953,9 @@ describe("Models tree", () => {
           const model = insertPhysicalSubModel({ builder, modeledElementId: partition.id });
           return { rootSubject, model };
         });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassSpecification: "BisCore.GeometricElement2d" } });
         await validateHierarchy({
-          provider: createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassSpecification: "BisCore.GeometricElement2d" } }),
+          provider,
           expect: [],
         });
       });

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
@@ -30,7 +30,7 @@ import { createClassGroupingHierarchyNode, createModelsTreeProvider } from "./Ut
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { InstanceKey } from "@itwin/presentation-common";
-import type { HierarchyFilteringPath, HierarchyProvider } from "@itwin/presentation-hierarchies";
+import type { HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
 import type { TestIModelBuilder } from "@itwin/presentation-testing";
 import type { ExpectedHierarchyDef } from "../HierarchyValidation";
 import type { ElementsGroupInfo } from "../../../components/trees/models-tree/ModelsTreeDefinition";
@@ -1631,7 +1631,7 @@ describe("Models tree", () => {
         let expectedHierarchy!: ExpectedHierarchyDef[];
 
         let modelsTreeIdsCache: ModelsTreeIdsCache;
-        let hierarchyProvider: HierarchyProvider;
+        let hierarchyProvider: ReturnType<typeof createModelsTreeProvider>;
         let hierarchyConfig: ModelsTreeHierarchyConfiguration;
 
         before(async function () {
@@ -1651,6 +1651,11 @@ describe("Models tree", () => {
         beforeEach(() => {
           modelsTreeIdsCache = new ModelsTreeIdsCache(createIModelAccess(imodel), hierarchyConfig);
           hierarchyProvider = createModelsTreeProvider({ imodel, filteredNodePaths: instanceKeyPaths, hierarchyConfig });
+        });
+
+        afterEach(() => {
+          modelsTreeIdsCache[Symbol.dispose]();
+          hierarchyProvider.dispose();
         });
 
         after(async function () {
@@ -1710,10 +1715,12 @@ describe("Models tree", () => {
         };
       });
 
+      const imodelAccess = createIModelAccess(imodel);
+      using idsCache = new ModelsTreeIdsCache(imodelAccess, defaultHierarchyConfiguration);
       const actualInstanceKeyPaths = (
         await ModelsTreeDefinition.createInstanceKeyPaths({
-          imodelAccess: createIModelAccess(imodel),
-          idsCache: new ModelsTreeIdsCache(createIModelAccess(imodel), defaultHierarchyConfiguration),
+          imodelAccess,
+          idsCache,
           label: formattedECInstanceId,
           hierarchyConfig: defaultHierarchyConfiguration,
         })
@@ -1741,11 +1748,14 @@ describe("Models tree", () => {
         };
       });
 
+      const imodelAccess = createIModelAccess(imodel);
+      using idsCache = new ModelsTreeIdsCache(imodelAccess, defaultHierarchyConfiguration);
+
       expect(
         (
           await ModelsTreeDefinition.createInstanceKeyPaths({
-            imodelAccess: createIModelAccess(imodel),
-            idsCache: new ModelsTreeIdsCache(createIModelAccess(imodel), defaultHierarchyConfiguration),
+            imodelAccess,
+            idsCache,
             label: "_",
             hierarchyConfig: defaultHierarchyConfiguration,
           })
@@ -1755,8 +1765,8 @@ describe("Models tree", () => {
       expect(
         (
           await ModelsTreeDefinition.createInstanceKeyPaths({
-            imodelAccess: createIModelAccess(imodel),
-            idsCache: new ModelsTreeIdsCache(createIModelAccess(imodel), defaultHierarchyConfiguration),
+            imodelAccess,
+            idsCache,
             label: "%",
             hierarchyConfig: defaultHierarchyConfiguration,
           })
@@ -1766,8 +1776,8 @@ describe("Models tree", () => {
       expect(
         (
           await ModelsTreeDefinition.createInstanceKeyPaths({
-            imodelAccess: createIModelAccess(imodel),
-            idsCache: new ModelsTreeIdsCache(createIModelAccess(imodel), defaultHierarchyConfiguration),
+            imodelAccess,
+            idsCache,
             label: "\\",
             hierarchyConfig: defaultHierarchyConfiguration,
           })

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
@@ -64,7 +64,7 @@ describe("Models tree", () => {
     it("can filter root level", async function () {
       // eslint-disable-next-line deprecation/deprecation
       const imodel = await buildTestIModel(this, async () => {});
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -162,7 +162,7 @@ describe("Models tree", () => {
 
         return { rootSubject, childSubject, model, category };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -259,7 +259,7 @@ describe("Models tree", () => {
         insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category2.id });
         return { rootSubject, model, category1, category2 };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -325,7 +325,7 @@ describe("Models tree", () => {
         const element = insertPhysicalElement({ builder, userLabel: `element`, modelId: model.id, categoryId: category.id });
         return { rootSubject, model, category, element };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -416,7 +416,7 @@ describe("Models tree", () => {
         });
         return { rootSubject, model, category, parentElement, childElement };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -514,7 +514,7 @@ describe("Models tree", () => {
         });
         return { rootSubject, model, category, modeledElement, modelingElement };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -600,7 +600,7 @@ describe("Models tree", () => {
         const aspect = insertExternalSourceAspect({ builder, elementId: element.id, identifier: "test aspect" });
         return { rootSubject, model, category, element, aspect };
       });
-      const provider = createModelsTreeProvider({ imodel });
+      using provider = createModelsTreeProvider({ imodel });
       const parentNode = {
         key: {
           type: "instances" as const,
@@ -678,7 +678,7 @@ describe("Models tree", () => {
 
           return { rootSubject, model };
         });
-        const provider = createModelsTreeProvider({ imodel, hierarchyConfig: { showEmptyModels: true } });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { showEmptyModels: true } });
         const parentNode = {
           key: {
             type: "instances" as const,
@@ -747,7 +747,7 @@ describe("Models tree", () => {
           });
           return { rootSubject, model, category, element1, element2 };
         });
-        const provider = createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassSpecification: keys.element1.className } });
+        using provider = createModelsTreeProvider({ imodel, hierarchyConfig: { elementClassSpecification: keys.element1.className } });
         const parentNode = {
           key: {
             type: "instances" as const,

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -17,6 +17,7 @@ import type {
   GroupingHierarchyNode,
   HierarchyFilteringPath,
   HierarchyNodeKey,
+  HierarchyProvider,
   NonGroupingHierarchyNode,
 } from "@itwin/presentation-hierarchies";
 
@@ -32,7 +33,7 @@ export function createModelsTreeProvider({ imodel, filteredNodePaths, hierarchyC
   const config = { ...defaultHierarchyConfiguration, ...hierarchyConfig };
   const imodelAccess = createIModelAccess(imodel);
   const idsCache = new ModelsTreeIdsCache(imodelAccess, config);
-  return createIModelHierarchyProvider({
+  const provider = createIModelHierarchyProvider({
     imodelAccess,
     hierarchyDefinition: new ModelsTreeDefinition({
       imodelAccess,
@@ -43,6 +44,21 @@ export function createModelsTreeProvider({ imodel, filteredNodePaths, hierarchyC
       ? { filtering: { paths: filteredNodePaths.map((path) => ("path" in path ? path : { path, options: { autoExpand: true } })) } }
       : undefined),
   });
+  const dispose = () => {
+    provider.dispose();
+    idsCache[Symbol.dispose]();
+  };
+  return {
+    hierarchyChanged: provider.hierarchyChanged,
+    getNodes: (props) => provider.getNodes(props),
+    getNodeInstanceKeys: (props) => provider.getNodeInstanceKeys(props),
+    setFormatter: (formatter) => provider.setFormatter(formatter),
+    setHierarchyFilter: (props) => provider.setHierarchyFilter(props),
+    dispose,
+    [Symbol.dispose]() {
+      dispose();
+    },
+  } satisfies HierarchyProvider & { dispose: () => void; [Symbol.dispose]: () => void };
 }
 
 interface IdsCacheMockProps {

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
@@ -31,7 +31,7 @@ describe("ModelsTreeIdsCache", () => {
 
       return [];
     });
-    const cache = createIdsCache(stub);
+    using cache = createIdsCache(stub);
     await expect(cache.getModelElementCount(modelId)).to.eventually.eq(elementIds.length);
     expect(stub).to.have.callCount(2);
     await expect(cache.getModelElementCount(modelId)).to.eventually.eq(elementIds.length);
@@ -43,13 +43,12 @@ describe("ModelsTreeIdsCache", () => {
     const categoryId = "0x2";
     const elementIds = ["0x10", "0x20", "0x30"];
     const stub = sinon.fake((query: string) => {
-      if (query.includes("WHERE Model.Id = ? AND Category.Id = ?")) {
-        return [[elementIds.length]];
+      if (query.includes(`WHERE Parent.Id IS NULL AND (Model.Id = ${modelId} AND Category.Id = ${categoryId})`)) {
+        return [{ modelId, categoryId, elementsCount: elementIds.length }];
       }
-
       throw new Error(`Unexpected query: ${query}`);
     });
-    const cache = createIdsCache(stub);
+    using cache = createIdsCache(stub);
     await expect(cache.getCategoryElementsCount(modelId, categoryId)).to.eventually.eq(elementIds.length);
     expect(stub).to.have.callCount(1);
     await expect(cache.getCategoryElementsCount(modelId, categoryId)).to.eventually.eq(elementIds.length);

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -135,9 +135,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
       it("can call original implementation", async () => {
         let useOriginalImplFlag = false;
         const viewport = createFakeSinonViewport();
+        using idsCache = createIdsCache(viewport.iModel);
         const handler = createModelsTreeVisibilityHandler({
           viewport,
-          idsCache: createIdsCache(viewport.iModel),
+          idsCache,
           overrides: {
             getElementDisplayStatus: async ({ originalImplementation }) => {
               return useOriginalImplFlag ? originalImplementation() : createVisibilityStatus("hidden");
@@ -178,9 +179,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             getSubjectNodeVisibility: sinon.fake.resolves(createVisibilityStatus("visible")),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -636,9 +638,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             getCategoryDisplayStatus: sinon.fake.resolves(createVisibilityStatus("visible")),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -934,9 +937,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             getElementDisplayStatus: sinon.fake.resolves(createVisibilityStatus("visible")),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1069,9 +1073,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             getElementGroupingNodeDisplayStatus: sinon.fake.resolves(createVisibilityStatus("visible")),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1237,9 +1242,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             changeSubjectNodeState: sinon.fake.resolves(undefined),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1408,9 +1414,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             changeCategoryState: sinon.fake.resolves(undefined),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1483,9 +1490,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             changeElementsState: sinon.fake.resolves(undefined),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1636,9 +1644,10 @@ describe("HierarchyBasedVisibilityHandler", () => {
             changeElementGroupingNodeState: sinon.fake.resolves(undefined),
           };
           const viewport = createFakeSinonViewport();
+          using idsCache = createIdsCache(viewport.iModel);
           const handler = createModelsTreeVisibilityHandler({
             viewport,
-            idsCache: createIdsCache(viewport.iModel),
+            idsCache,
             overrides,
             imodelAccess: createFakeIModelAccess(),
           });
@@ -1725,7 +1734,11 @@ describe("HierarchyBasedVisibilityHandler", () => {
         viewRect: new ViewRect(),
       });
       const idsCache = new ModelsTreeIdsCache(imodelAccess, hierarchyConfig);
-      return { imodelAccess, viewport, idsCache };
+      return {
+        imodelAccess,
+        viewport,
+        idsCache,
+      };
     }
 
     function createProvider(props: {
@@ -1745,7 +1758,14 @@ describe("HierarchyBasedVisibilityHandler", () => {
       const commonProps = createCommonProps(imodel, hierarchyConfig);
       const handler = createModelsTreeVisibilityHandler(commonProps);
       const provider = createProvider({ ...commonProps, hierarchyConfig });
-      return { handler, provider, ...commonProps };
+      return {
+        handler,
+        provider,
+        ...commonProps,
+        [Symbol.dispose]() {
+          commonProps.idsCache[Symbol.dispose]();
+        },
+      };
     }
 
     it("by default everything is hidden", async function () {
@@ -1755,7 +1775,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         insertPhysicalElement({ builder, modelId, categoryId });
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await validateHierarchyVisibility({
           provider,
@@ -1779,7 +1800,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         insertPhysicalElement({ builder, modelId, categoryId });
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createSubjectHierarchyNode(IModel.rootSubjectId), true);
         await validateHierarchyVisibility({
@@ -1808,7 +1830,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createModelHierarchyNode(ids.model), true);
         viewport.renderFrame();
@@ -1846,7 +1869,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, hiddenElement: elements[0] };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createModelHierarchyNode(ids.model), true);
         viewport.setNeverDrawn(new Set([ids.hiddenElement]));
@@ -1876,7 +1900,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category, parentElement };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createModelHierarchyNode(ids.model), true);
         viewport.renderFrame();
@@ -1914,7 +1939,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category, elementToShow: elements[0] };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createElementHierarchyNode({ modelId: ids.model, categoryId: ids.category, elementId: ids.elementToShow }), true);
         viewport.renderFrame();
@@ -1958,7 +1984,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category, modelElements, otherModelElements, allElements: [...modelElements, ...otherModelElements] };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         const elementToShow = ids.modelElements[0];
         viewport.setAlwaysDrawn(new Set(ids.allElements));
@@ -2002,7 +2029,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { exclusiveModel, exclusiveElement };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createSubjectHierarchyNode("0x1"), true);
         viewport.setAlwaysDrawn(new Set([ids.exclusiveElement]), true);
@@ -2040,7 +2068,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createCategoryHierarchyNode(ids.model, ids.category), true);
         viewport.renderFrame();
@@ -2070,7 +2099,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createSubjectHierarchyNode(IModel.rootSubjectId), true);
         viewport.changeCategoryDisplay(ids.category, true, true);
@@ -2111,7 +2141,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category, parentElement };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(
           createClassGroupingHierarchyNode({
@@ -2155,7 +2186,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         return { model, category, parentElement };
       });
 
-      const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+      using visibilityTestData = createVisibilityTestData({ imodel });
+      const { handler, provider, viewport } = visibilityTestData;
       await using(handler, async (_) => {
         await handler.changeVisibility(createSubjectHierarchyNode(IModel.rootSubjectId), true);
         viewport.renderFrame();
@@ -2199,7 +2231,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
           insertPhysicalElement({ builder, modelId: model.id, categoryId: childCategory.id, parentId: parentElement.id });
           return { modelId: model.id, parentCategoryId: parentCategory.id, parentElementId: parentElement.id };
         });
-        const { handler, viewport, ...props } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, viewport, ...props } = visibilityTestData;
         const parentCategoryNode = createCategoryHierarchyNode(modelId, parentCategoryId);
 
         await using(handler, async (_) => {
@@ -2231,7 +2264,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
           return { modelId: model.id, categoryId: category.id, elementId: element.id, unrelatedCategoryId: unrelatedParentCategory.id };
         });
-        const { handler, viewport, ...testProps } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, viewport, ...testProps } = visibilityTestData;
         const elementNode = createElementHierarchyNode({ modelId, categoryId, elementId });
 
         await using(handler, async (_) => {
@@ -2279,7 +2313,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("showing category via the selector makes category and all elements visible when it has no always or never drawn elements", async function () {
         const { imodel, firstCategoryId, secondCategoryId, modelId } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.renderFrame();
@@ -2305,7 +2340,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("hiding category via the selector makes category and all elements hidden when it has no always or never drawn elements", async function () {
         const { imodel, firstCategoryId, secondCategoryId, modelId } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.changeCategoryDisplay([firstCategoryId, secondCategoryId], true, true);
@@ -2332,7 +2368,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("hiding category via the selector makes it hidden when it only has never drawn elements", async function () {
         const { imodel, firstCategoryId, modelId, elements1 } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.changeCategoryDisplay(firstCategoryId, true, true);
@@ -2367,7 +2404,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("showing category via the selector makes it visible when it only has always drawn elements", async function () {
         const { imodel, firstCategoryId, secondCategoryId, elements1, modelId } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.changeCategoryDisplay(secondCategoryId, true, true);
@@ -2402,7 +2440,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("model is visible if category is disabled in selector but all category's elements are always drawn", async function () {
         const { imodel, firstCategoryId, secondCategoryId, elements1, modelId } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.changeCategoryDisplay([firstCategoryId, secondCategoryId], true, true);
@@ -2430,7 +2469,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
       it("model is hidden if category is enabled in selector but all category's elements are never drawn", async function () {
         const { imodel, firstCategoryId, elements1, modelId } = await createIModel(this);
-        const { handler, provider, viewport } = createVisibilityTestData({ imodel });
+        using visibilityTestData = createVisibilityTestData({ imodel });
+        const { handler, provider, viewport } = visibilityTestData;
         await using(handler, async (_) => {
           await viewport.addViewedModels(modelId);
           viewport.setNeverDrawn(new Set(elements1));
@@ -2513,7 +2553,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("empty model hidden by default", async function () {
           const { imodel, hierarchyConfig } = await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await validateHierarchyVisibility({
             provider,
@@ -2525,7 +2566,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("showing it makes empty model visible", async function () {
           const { imodel, hierarchyConfig } = await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await using(handler, async (_) => {
             await handler.changeVisibility(node, true);
@@ -2540,7 +2582,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("gets partial when only empty model is visible", async function () {
           const { imodel, hierarchyConfig, emptyModelId } = await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await using(handler, async (_) => {
             await handler.changeVisibility(createModelHierarchyNode(emptyModelId), true);
@@ -2563,7 +2606,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
       describe("model with custom class specification elements", () => {
         it("showing it makes it, all its categories and elements visible", async function () {
           const { imodel, hierarchyConfig, configurationModelId } = await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await using(handler, async (_) => {
             await handler.changeVisibility(createModelHierarchyNode(configurationModelId), true);
@@ -2582,7 +2626,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("gets partial when custom class element is visible", async function () {
           const { imodel, hierarchyConfig, configurationModelId, configurationCategoryId, customClassElement1 } = await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await using(handler, async (_) => {
             await handler.changeVisibility(
@@ -2619,7 +2664,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
         it("gets visible when all custom class elements are visible", async function () {
           const { imodel, hierarchyConfig, configurationModelId, configurationCategoryId, customClassElement1, customClassElement2, nonCustomClassElement } =
             await createHierarchyConfigurationModel(this);
-          const { handler, provider, viewport } = createVisibilityTestData({ imodel, hierarchyConfig });
+          using visibilityTestData = createVisibilityTestData({ imodel, hierarchyConfig });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await using(handler, async (_) => {
             await handler.changeVisibility(
@@ -2675,7 +2721,15 @@ describe("HierarchyBasedVisibilityHandler", () => {
         const handler = createModelsTreeVisibilityHandler({ ...commonProps, filteredPaths: filterPaths });
         const defaultProvider = createProvider({ ...commonProps });
         const filteredProvider = createProvider({ ...commonProps, filterPaths });
-        return { handler, defaultProvider, filteredProvider, ...commonProps };
+        return {
+          handler,
+          defaultProvider,
+          filteredProvider,
+          ...commonProps,
+          [Symbol.dispose]() {
+            commonProps.idsCache[Symbol.dispose]();
+          },
+        };
       }
 
       async function getNodeMatchingPath(provider: HierarchyProvider, identifierPath: InstanceKey[], parentNode?: HierarchyNode): Promise<HierarchyNode> {
@@ -2726,7 +2780,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
             };
           });
 
-          const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+          using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+          const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
           await using(handler, async (_) => {
             const node = await getRootNode(filteredProvider);
             await handler.changeVisibility(node, true);
@@ -2789,7 +2844,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("switches on only filtered hierarchy when root node is clicked", async function () {
           const { imodel, filterPaths, filterTargetElements, ...keys } = await createIModel(this);
-          const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+          using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+          const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
 
           await using(handler, async (_) => {
             const node = await getRootNode(filteredProvider);
@@ -2820,7 +2876,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("switches on only filtered hierarchy when one of the filtered categories is clicked", async function () {
           const { imodel, filterPaths, filteredCategories, filterTargetElements, ...keys } = await createIModel(this);
-          const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+          using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+          const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
 
           await using(handler, async (_) => {
             const pathToCategory = [rootSubjectInstanceKey, keys.model, filteredCategories[0]];
@@ -2890,7 +2947,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("when clicking on root subject turns on category and all its elements", async function () {
           const { imodel, filterPaths } = await createIModel(this);
-          const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+          using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+          const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
 
           await using(handler, async (_) => {
             const node = await getRootNode(filteredProvider);
@@ -2915,7 +2973,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
 
         it("when clicking on one of the categories it turns on only that category", async function () {
           const { imodel, filterPaths, subjectIds, modelIds } = await createIModel(this);
-          const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+          using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+          const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
 
           await using(handler, async (_) => {
             const pathToCategory = filterPaths[0];
@@ -2991,7 +3050,8 @@ describe("HierarchyBasedVisibilityHandler", () => {
           };
         });
 
-        const { handler, viewport, defaultProvider, filteredProvider } = createFilteredVisibilityTestData({ imodel, filterPaths });
+        using visibilityTestData = createFilteredVisibilityTestData({ imodel, filterPaths });
+        const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
 
         await using(handler, async (_) => {
           const node = await getNodeMatchingPath(filteredProvider, pathToFirstElement);


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/1101.

| | Before the change | After the change |
| --- | --- | --- |
| Number of `queryRows` requests | 385 | 1 |
| Total time to update visibility status for all nodes | ~7 s. | ~250 ms. |