### PR TITLE
Fix property grid always showing "There are no properties containing non-empty values" message, when initial render is made with hidden empty values

### DIFF
--- a/change/@itwin-property-grid-react-8a45f28f-060b-43dd-bc0c-9dc53f269e61.json
+++ b/change/@itwin-property-grid-react-8a45f28f-060b-43dd-bc0c-9dc53f269e61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix property grid always showing \"There are no properties containing non-empty values\" message, when initial render is made with hidden empty values.",
+  "packageName": "@itwin/property-grid-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
+++ b/packages/itwin/property-grid/src/components/FilteringPropertyGrid.tsx
@@ -89,7 +89,7 @@ export function FilteringPropertyGrid({ filterer, dataProvider, autoExpandChildC
 }
 
 const emptyDataProvider: IPropertyDataProvider = {
-  getData: async () => emptyPropertyData,
+  getData: /* istanbul ignore next */ async () => emptyPropertyData,
   onDataChanged: new BeEvent(),
 };
 const emptyPropertyData: PropertyData = {


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/1131.

The decision to render the "no properties" message vs the actual properties was made based on filter matches count. However, the count was only updated on data provider change, which doesn't happen on selection change - in that case only the `onDataChanged` event is raised. Initially we have an empty source provider, so the count is resolved to `0` and afterwards, on selection changes, it was never updated.