### PR TITLE
[Tree-widget]: visibility icon tooltip empty content fix

### DIFF
--- a/change/@itwin-tree-widget-react-c5e52e86-ebe6-439d-a0c6-1a895dd61a3a.json
+++ b/change/@itwin-tree-widget-react-c5e52e86-ebe6-439d-a0c6-1a895dd61a3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Node visibility button will no longer generate an empty tooltip, when tooltip content is empty.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "43886789+MartynasStrazdas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-c5e52e86-ebe6-439d-a0c6-1a895dd61a3a.json
+++ b/change/@itwin-tree-widget-react-c5e52e86-ebe6-439d-a0c6-1a895dd61a3a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Node visibility button will no longer generate an empty tooltip, when tooltip content is empty.",
+  "comment": "Fix visibility button with no content rendering empty tooltip.",
   "packageName": "@itwin/tree-widget-react",
   "email": "43886789+MartynasStrazdas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/src/components/trees/common/components/TreeNodeCheckbox.tsx
+++ b/packages/itwin/tree-widget/src/components/trees/common/components/TreeNodeCheckbox.tsx
@@ -40,7 +40,7 @@ export function TreeNodeCheckbox({ node, onCheckboxClicked, getCheckboxState, ..
 
   const checkboxState = getCheckboxState(node);
   return (
-    <Tooltip content={checkboxState.tooltip} placement="left">
+    <TooltipWrapper content={checkboxState.tooltip}>
       <Checkbox
         {...props}
         className={cx("tw-tree-node-checkbox", props.className)}
@@ -55,6 +55,16 @@ export function TreeNodeCheckbox({ node, onCheckboxClicked, getCheckboxState, ..
         disabled={checkboxState.isDisabled}
         aria-label={checkboxState.tooltip}
       />
+    </TooltipWrapper>
+  );
+}
+
+function TooltipWrapper({ content, children }: { content?: string; children?: React.ReactNode }) {
+  return !!content ? (
+    <Tooltip content={content} placement="left">
+      {children}
     </Tooltip>
+  ) : (
+    <>{children}</>
   );
 }


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1116
Visibility icon tooltip will no longer render when tooltip content is undefined.
https://github.com/user-attachments/assets/3c4383d2-ee89-4c29-877a-f7958f2217ec

The black background on icons is caused by them being disabled, removing it might cause confusion as then it will look very similar to when visibility is turned off.