### PR TITLE
Sheets are not required to have jsonProperties

### DIFF
--- a/change/@itwin-measure-tools-react-91002d1a-dbe4-4cf7-afe1-74db1b4035a2.json
+++ b/change/@itwin-measure-tools-react-91002d1a-dbe4-4cf7-afe1-74db1b4035a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sheets are not required to have jsonProperties",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "30239292+Ellord207@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -4,12 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ColorDef, QueryBinder } from "@itwin/core-common";
+import type { BeButtonEvent, DecorateContext, GraphicBuilder, HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
 import { GraphicType, IModelApp } from "@itwin/core-frontend";
-import { Point2d, Point3d, Transform } from "@itwin/core-geometry";
+import { Point3d } from "@itwin/core-geometry";
+import { Transform } from "@itwin/core-geometry";
+import { Point2d } from "@itwin/core-geometry";
+import type { DrawingMetadata } from "./Measurement.js";
 import { DrawingDataCache } from "./DrawingTypeDataCache.js";
 
-import type { BeButtonEvent, DecorateContext, GraphicBuilder, HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
-import type { DrawingMetadata } from "./Measurement.js";
 export namespace SheetMeasurementsHelper {
 
   /** This maps directly to the viewType field found in the schema on BisCore.viewAttachment */
@@ -138,8 +140,8 @@ export namespace SheetMeasurementsHelper {
     for await (const row of iter) {
       const highX = row[3].X - row[2].X;
       const highY = row[3].Y - row[2].Y;
-      const jsonProp = row[4] && JSON.parse(row[4]);
-      if (jsonProp && jsonProp.civilimodelconn) {
+      const jsonProp = JSON.parse(row[4]);
+      if (jsonProp.civilimodelconn) {
         const origin = new Point2d(row[1].X, row[1].Y);
         const extents = new Point2d(highX, highY);
         const viewType = jsonProp.civilimodelconn.viewType;

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -140,8 +140,8 @@ export namespace SheetMeasurementsHelper {
     for await (const row of iter) {
       const highX = row[3].X - row[2].X;
       const highY = row[3].Y - row[2].Y;
-      const jsonProp = JSON.parse(row[4]);
-      if (jsonProp.civilimodelconn) {
+      const jsonProp = row[4] && JSON.parse(row[4]);
+      if (jsonProp && jsonProp.civilimodelconn) {
         const origin = new Point2d(row[1].X, row[1].Y);
         const extents = new Point2d(highX, highY);
         const viewType = jsonProp.civilimodelconn.viewType;

--- a/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/itwin/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -4,14 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ColorDef, QueryBinder } from "@itwin/core-common";
-import type { BeButtonEvent, DecorateContext, GraphicBuilder, HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
 import { GraphicType, IModelApp } from "@itwin/core-frontend";
-import { Point3d } from "@itwin/core-geometry";
-import { Transform } from "@itwin/core-geometry";
-import { Point2d } from "@itwin/core-geometry";
-import type { DrawingMetadata } from "./Measurement.js";
+import { Point2d, Point3d, Transform } from "@itwin/core-geometry";
 import { DrawingDataCache } from "./DrawingTypeDataCache.js";
 
+import type { BeButtonEvent, DecorateContext, GraphicBuilder, HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import type { DrawingMetadata } from "./Measurement.js";
 export namespace SheetMeasurementsHelper {
 
   /** This maps directly to the viewType field found in the schema on BisCore.viewAttachment */
@@ -140,8 +138,8 @@ export namespace SheetMeasurementsHelper {
     for await (const row of iter) {
       const highX = row[3].X - row[2].X;
       const highY = row[3].Y - row[2].Y;
-      const jsonProp = JSON.parse(row[4]);
-      if (jsonProp.civilimodelconn) {
+      const jsonProp = row[4] && JSON.parse(row[4]);
+      if (jsonProp && jsonProp.civilimodelconn) {
         const origin = new Point2d(row[1].X, row[1].Y);
         const extents = new Point2d(highX, highY);
         const viewType = jsonProp.civilimodelconn.viewType;


### PR DESCRIPTION
There is a bug causing a crash whenever a non-civil sheet is open.

JSON.parse is throwing an error when the jsonProperties on a sheet model are undefined.  This matches the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#exceptions) since `undefined` is not a valid string.

The tests are not passing for me on master.  I am unfamiliar with this repository, and not sure how to test my change locally.  I could provide an iModel with data to test.