### PR TITLE
Tree widget: Add `filterButtonsVisibility` to `TreeRenderer`

### DIFF
--- a/change/@itwin-tree-widget-react-a6d91926-a46f-4d4e-a79a-d8249b2c20e4.json
+++ b/change/@itwin-tree-widget-react-a6d91926-a46f-4d4e-a79a-d8249b2c20e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `filterButtonsVisibility` prop to `TreeRenderer`. The prop allows to control visibility of hierarchy level filtering buttons in the tree: `show-on-hover` (default) shows them on hover or focus, `hide` only shows them when a node is filtered.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -427,10 +427,10 @@ type TreeProps = Pick<FunctionProps<typeof useIModelTree>, "getFilteredPaths" | 
 };
 
 // @beta
-export function TreeRenderer({ rootNodes, expandNode, onNodeClick, onNodeKeyDown, onNodeDoubleClick, isNodeSelected, onFilterClick, getIcon, getLabel, getSublabel, getHierarchyLevelDetails, checkboxProps, reloadTree, size, enableVirtualization, ...props }: TreeRendererProps): JSX.Element;
+export function TreeRenderer({ rootNodes, expandNode, onNodeClick, onNodeKeyDown, onNodeDoubleClick, isNodeSelected, onFilterClick, getIcon, getLabel, getSublabel, getHierarchyLevelDetails, checkboxProps, filterButtonsVisibility, reloadTree, size, enableVirtualization, ...props }: TreeRendererProps): JSX.Element;
 
 // @beta (undocumented)
-type TreeRendererProps = Pick<TreeNodeRendererProps, "expandNode" | "onNodeClick" | "onNodeKeyDown" | "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "getHierarchyLevelDetails" | "checkboxProps" | "reloadTree"> & Omit<ComponentPropsWithoutRef<typeof Tree_2<RenderedTreeNode>>, "data" | "nodeRenderer" | "getNode"> & {
+type TreeRendererProps = Pick<TreeNodeRendererProps, "expandNode" | "onNodeClick" | "onNodeKeyDown" | "onFilterClick" | "getIcon" | "getLabel" | "getSublabel" | "getHierarchyLevelDetails" | "checkboxProps" | "reloadTree" | "filterButtonsVisibility"> & Omit<ComponentPropsWithoutRef<typeof Tree_2<RenderedTreeNode>>, "data" | "nodeRenderer" | "getNode"> & {
     rootNodes: PresentationTreeNode[];
     isNodeSelected: (nodeId: string) => boolean;
     onNodeDoubleClick?: (node: PresentationHierarchyNode, isSelected: boolean) => void;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
@@ -68,7 +68,7 @@ export type TreeProps = Pick<FunctionProps<typeof useIModelTree>, "getFilteredPa
 
 /**
  * Default tree component that manages tree state and renders using supplied `treeRenderer`.
- * @Beta
+ * @beta
  */
 export function Tree({ getSchemaContext, hierarchyLevelSizeLimit, selectionStorage, imodelAccess: providedIModelAccess, ...props }: TreeProps) {
   const defaultHierarchyLevelSizeLimit = hierarchyLevelSizeLimit ?? 1000;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeRenderer.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeRenderer.tsx
@@ -28,6 +28,7 @@ export type TreeRendererProps = Pick<
   | "getHierarchyLevelDetails"
   | "checkboxProps"
   | "reloadTree"
+  | "filterButtonsVisibility"
 > &
   Omit<ComponentPropsWithoutRef<typeof Tree<RenderedTreeNode>>, "data" | "nodeRenderer" | "getNode"> & {
     /** Tree nodes to render. */
@@ -55,6 +56,7 @@ export function TreeRenderer({
   getSublabel,
   getHierarchyLevelDetails,
   checkboxProps,
+  filterButtonsVisibility,
   reloadTree,
   size,
   enableVirtualization,
@@ -85,6 +87,7 @@ export function TreeRenderer({
           reloadTree={reloadTree}
           className={getSublabel ? "with-description" : "without-description"}
           size={size}
+          filterButtonsVisibility={filterButtonsVisibility}
         />
       );
     },
@@ -99,6 +102,7 @@ export function TreeRenderer({
       getSublabel,
       onFilterClick,
       checkboxProps,
+      filterButtonsVisibility,
       reloadTree,
       size,
     ],


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1174.

Based on https://github.com/iTwin/presentation/pull/840.