### PR TITLE
[measurement-tools] Fix Measure Distance Tool: Incorrect distance, rise, and slope calculations in sheets with vertical exaggeration

### DIFF
--- a/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/itwin/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -128,7 +128,7 @@ MeasureDistanceToolModel
         this.toolModel.sheetViewId = ev.viewport.view.id;
 
         if (drawingInfo?.drawingId !== undefined && drawingInfo.origin !== undefined && drawingInfo.worldScale !== undefined) {
-          const data: DrawingMetadata = { origin: drawingInfo.origin, drawingId: drawingInfo.drawingId, worldScale: drawingInfo.worldScale, extents: drawingInfo.extents};
+          const data: DrawingMetadata = { origin: drawingInfo.origin, drawingId: drawingInfo.drawingId, worldScale: drawingInfo.worldScale, extents: drawingInfo.extents, sheetToWorldTransform: drawingInfo.sheetToWorldTransform, sheetToProfileTransform: drawingInfo.sheetToProfileTransform};
           this.toolModel.drawingMetadata = data;
         }
       }


### PR DESCRIPTION
**Issue**
Since PR [837](https://github.com/iTwin/viewer-components-react/pull/837/files#diff-d0b21a1bea2aaf8f9c4133a0e4cc6c3d72c124e07fded3206e3efae28639a68c), the `MeasureDistanceTool` has supported scaling measurements in sheet drawings to represent real-world distances instead of sheet distances.

However, it did not account for the vertical exaggeration factor, causing incorrect calculations for:
- Distance
- Vertical distance (Rise)
- Slope

**Solution**
To ensure accurate calculations, the start and end points are transformed into 3D world coordinates using sheetToWorldTransform before computing:
- Direct distance (point-to-point 3D distance)
- Horizontal distance (Run)
- Vertical distance (Rise)
- Slope

This fix only applies to sheet drawings with vertical exaggeration and does not impact distance calculations in 3D world views.

**Demonstration**
![Screenshot 2025-02-12 at 4 00 50 PM](https://github.com/user-attachments/assets/4d0637c1-6c53-41f3-8bdb-811f1ec4a6e8)
