### PR TITLE
[measure-tools] Add 'types' field in package.json.

### DIFF
--- a/change/@itwin-measure-tools-react-1ead3fbf-2d2a-41c0-a721-8e0726155d9e.json
+++ b/change/@itwin-measure-tools-react-1ead3fbf-2d2a-41c0-a721-8e0726155d9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add 'types' field in package.json. This fixes some issues for consumers when importing the esm package with moduleResolution: node. (export map support seems flaky in those cases.)",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "3418768+a-gagnon@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/package.json
+++ b/packages/itwin/measure-tools/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/iTwin/viewer-components-react/tree/master/packages/itwin/measure-tools"
   },
   "type": "module",
+  "types": "./lib/measure-tools-react.d.ts",
   "exports": {
     ".": {
       "types": "./lib/measure-tools-react.d.ts",


### PR DESCRIPTION
Add 'types' field in package.json. This fixes some issues for consumers when importing the esm package with moduleResolution: node. (export map support seems flaky in those cases.)