### PR TITLE
Fix context popup measurement toolbar

### DIFF
--- a/change/@itwin-measure-tools-react-6d3db761-bca1-4eaa-92ad-628ceaf37393.json
+++ b/change/@itwin-measure-tools-react-6d3db761-bca1-4eaa-92ad-628ceaf37393.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Switch to mouse click event to close popup toolbar since new toolbar buttons need to use mouse down event to execute callback functions.",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/widgets/PopupToolbar.tsx
+++ b/packages/itwin/measure-tools/src/widgets/PopupToolbar.tsx
@@ -24,7 +24,7 @@ export const PopupToolbar: React.FC<PopupToolbarProps> = ({ items, onClose }: Po
     }
   }, [isClosing, onClose]);
 
-  const handleMouseDown = useCallback(() => {
+  const handleClick = useCallback(() => {
     if (!isClosing && onClose) {
       onClose();
       setIsClosing(true);
@@ -32,15 +32,15 @@ export const PopupToolbar: React.FC<PopupToolbarProps> = ({ items, onClose }: Po
   }, [isClosing, onClose]);
 
   useEffect(() => {
-    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("click", handleClick);
     document.addEventListener("wheel", handleMouseWheel);
 
     return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("click", handleClick);
       document.removeEventListener("wheel", handleMouseWheel);
       setIsClosing(false);
     };
-  }, [handleMouseWheel, handleMouseDown]);
+  }, [handleMouseWheel, handleClick]);
 
   return <div ref={ref}>
     <Toolbar items={items}/>


### PR DESCRIPTION
Measurement tools context popup toolbar is no longer receiving mouse down event to execute tool callback functions.

Solution:
Change event listener that closes popup toolbar to listen for click event instead of mouse down.  This allows the toolbar button to receive the mouse down event.

![image](https://github.com/user-attachments/assets/e17a625f-6c06-48b4-8b2e-275e079792c3)
