### PR TITLE
Tree widget: Allow custom no data message renderer

### DIFF
--- a/change/@itwin-tree-widget-react-ca9e5304-5fdd-4a5c-a69d-e928f0f97cbd.json
+++ b/change/@itwin-tree-widget-react-ca9e5304-5fdd-4a5c-a69d-e928f0f97cbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add ability to render custom message when tree does not have any data.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -412,7 +412,7 @@ interface TreeWidgetProps {
 }
 
 // @beta
-export function useCategoriesTree({ filter, activeView, onCategoriesFiltered }: UseCategoriesTreeProps): UseCategoriesTreeResult;
+export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, noDataMessage }: UseCategoriesTreeProps): UseCategoriesTreeResult;
 
 // @public
 export function useCategoriesTreeButtonProps({ viewport }: {
@@ -429,6 +429,8 @@ interface UseCategoriesTreeProps {
     // (undocumented)
     filter?: string;
     // (undocumented)
+    noDataMessage?: ReactNode;
+    // (undocumented)
     onCategoriesFiltered?: (categories: CategoryInfo[] | undefined) => void;
 }
 
@@ -441,7 +443,7 @@ interface UseCategoriesTreeResult {
 }
 
 // @beta
-export function useModelsTree({ activeView, filter, hierarchyConfig, visibilityHandlerOverrides, getFilteredPaths, onModelsFiltered, selectionPredicate: nodeTypeSelectionPredicate, }: UseModelsTreeProps): UseModelsTreeResult;
+export function useModelsTree({ activeView, filter, hierarchyConfig, visibilityHandlerOverrides, getFilteredPaths, onModelsFiltered, selectionPredicate: nodeTypeSelectionPredicate, noDataMessage, }: UseModelsTreeProps): UseModelsTreeResult;
 
 // @public
 export function useModelsTreeButtonProps({ imodel, viewport }: {
@@ -468,6 +470,8 @@ interface UseModelsTreeProps {
     }) => Promise<HierarchyFilteringPath[]>;
     // (undocumented)
     hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;
+    // (undocumented)
+    noDataMessage?: ReactNode;
     // (undocumented)
     onModelsFiltered?: (modelIds: Id64String[] | undefined) => void;
     selectionPredicate?: (props: {

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -47,7 +47,7 @@ export const CategoriesTreeComponent: {
 };
 
 // @public (undocumented)
-interface CategoriesTreeComponentProps extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "noDataMessage"> {
+interface CategoriesTreeComponentProps extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "emptyTreeContent"> {
     headerButtons?: Array<(props: CategoriesTreeHeaderButtonProps) => React.ReactNode>;
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
@@ -64,7 +64,7 @@ interface CategoriesTreeHeaderButtonProps extends TreeToolbarButtonProps {
 type CategoriesTreeHeaderButtonType = (props: CategoriesTreeHeaderButtonProps) => React.ReactElement | null;
 
 // @beta (undocumented)
-type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<VisibilityTreeRendererProps, "actions"> & UseCategoriesTreeProps & {
+type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> & Pick<VisibilityTreeRendererProps, "actions"> & UseCategoriesTreeProps & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -135,7 +135,7 @@ export const ExternalSourcesTreeComponent: {
 };
 
 // @beta (undocumented)
-interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProps, "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
+interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProps, "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "emptyTreeContent"> {
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
     // (undocumented)
@@ -143,7 +143,7 @@ interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProp
 }
 
 // @beta (undocumented)
-type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<BaseTreeRendererProps, "actions"> & {
+type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> & Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -207,7 +207,7 @@ export const IModelContentTreeComponent: {
 };
 
 // @beta (undocumented)
-interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
+interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "emptyTreeContent"> {
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
     // (undocumented)
@@ -215,7 +215,7 @@ interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "
 }
 
 // @beta (undocumented)
-type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<BaseTreeRendererProps, "actions"> & {
+type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> & Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -243,7 +243,7 @@ export const ModelsTreeComponent: {
 };
 
 // @public (undocumented)
-interface ModelsTreeComponentProps extends Pick<ModelsTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "selectionPredicate" | "hierarchyConfig" | "visibilityHandlerOverrides" | "getFilteredPaths" | "filter" | "noDataMessage"> {
+interface ModelsTreeComponentProps extends Pick<ModelsTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "selectionPredicate" | "hierarchyConfig" | "visibilityHandlerOverrides" | "getFilteredPaths" | "filter" | "emptyTreeContent"> {
     headerButtons?: Array<(props: ModelsTreeHeaderButtonProps) => React.ReactNode>;
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
@@ -267,7 +267,7 @@ interface ModelsTreeHierarchyConfiguration {
 }
 
 // @beta (undocumented)
-type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<VisibilityTreeRendererProps, "actions"> & UseModelsTreeProps & {
+type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> & Pick<VisibilityTreeRendererProps, "actions"> & UseModelsTreeProps & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -366,7 +366,7 @@ type TreeProps = Pick<FunctionProps<typeof useIModelTree>, "getFilteredPaths" | 
     treeRenderer: (treeProps: Required<Pick<BaseTreeRendererProps, "rootNodes" | "expandNode" | "getLabel" | "onFilterClick" | "selectNodes" | "selectionMode" | "isNodeSelected" | "getHierarchyLevelDetails" | "getLabel">>) => ReactNode;
     imodelAccess?: FunctionProps<typeof useIModelTree>["imodelAccess"];
     hierarchyLevelSizeLimit?: number;
-    noDataMessage?: ReactNode;
+    emptyTreeContent?: ReactNode;
     onReload?: () => void;
     highlight?: HighlightInfo;
 };
@@ -412,7 +412,7 @@ interface TreeWidgetProps {
 }
 
 // @beta
-export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, noDataMessage }: UseCategoriesTreeProps): UseCategoriesTreeResult;
+export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, emptyTreeContent }: UseCategoriesTreeProps): UseCategoriesTreeResult;
 
 // @public
 export function useCategoriesTreeButtonProps({ viewport }: {
@@ -427,9 +427,9 @@ interface UseCategoriesTreeProps {
     // (undocumented)
     activeView: Viewport;
     // (undocumented)
-    filter?: string;
+    emptyTreeContent?: ReactNode;
     // (undocumented)
-    noDataMessage?: ReactNode;
+    filter?: string;
     // (undocumented)
     onCategoriesFiltered?: (categories: CategoryInfo[] | undefined) => void;
 }
@@ -437,13 +437,13 @@ interface UseCategoriesTreeProps {
 // @beta (undocumented)
 interface UseCategoriesTreeResult {
     // (undocumented)
-    categoriesTreeProps: Pick<VisibilityTreeProps, "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "noDataMessage">;
+    categoriesTreeProps: Pick<VisibilityTreeProps, "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "emptyTreeContent">;
     // (undocumented)
     rendererProps: Required<Pick<VisibilityTreeRendererProps, "getIcon" | "getSublabel">>;
 }
 
 // @beta
-export function useModelsTree({ activeView, filter, hierarchyConfig, visibilityHandlerOverrides, getFilteredPaths, onModelsFiltered, selectionPredicate: nodeTypeSelectionPredicate, noDataMessage, }: UseModelsTreeProps): UseModelsTreeResult;
+export function useModelsTree({ activeView, filter, hierarchyConfig, visibilityHandlerOverrides, getFilteredPaths, onModelsFiltered, selectionPredicate: nodeTypeSelectionPredicate, emptyTreeContent, }: UseModelsTreeProps): UseModelsTreeResult;
 
 // @public
 export function useModelsTreeButtonProps({ imodel, viewport }: {
@@ -459,6 +459,8 @@ interface UseModelsTreeProps {
     // (undocumented)
     activeView: Viewport;
     // (undocumented)
+    emptyTreeContent?: ReactNode;
+    // (undocumented)
     filter?: string;
     // (undocumented)
     getFilteredPaths?: (props: {
@@ -470,8 +472,6 @@ interface UseModelsTreeProps {
     }) => Promise<HierarchyFilteringPath[]>;
     // (undocumented)
     hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;
-    // (undocumented)
-    noDataMessage?: ReactNode;
     // (undocumented)
     onModelsFiltered?: (modelIds: Id64String[] | undefined) => void;
     selectionPredicate?: (props: {
@@ -485,7 +485,7 @@ interface UseModelsTreeProps {
 // @beta (undocumented)
 interface UseModelsTreeResult {
     // (undocumented)
-    modelsTreeProps: Pick<VisibilityTreeProps, "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "noDataMessage" | "selectionPredicate">;
+    modelsTreeProps: Pick<VisibilityTreeProps, "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "emptyTreeContent" | "selectionPredicate">;
     // (undocumented)
     rendererProps: Required<Pick<VisibilityTreeRendererProps, "getIcon">>;
 }

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -47,7 +47,7 @@ export const CategoriesTreeComponent: {
 };
 
 // @public (undocumented)
-interface CategoriesTreeComponentProps extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter"> {
+interface CategoriesTreeComponentProps extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "noDataMessage"> {
     headerButtons?: Array<(props: CategoriesTreeHeaderButtonProps) => React.ReactNode>;
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
@@ -64,7 +64,7 @@ interface CategoriesTreeHeaderButtonProps extends TreeToolbarButtonProps {
 type CategoriesTreeHeaderButtonType = (props: CategoriesTreeHeaderButtonProps) => React.ReactElement | null;
 
 // @beta (undocumented)
-type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> & Pick<VisibilityTreeRendererProps, "actions"> & UseCategoriesTreeProps & {
+type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<VisibilityTreeRendererProps, "actions"> & UseCategoriesTreeProps & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -135,7 +135,7 @@ export const ExternalSourcesTreeComponent: {
 };
 
 // @beta (undocumented)
-interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProps, "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode"> {
+interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProps, "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
     // (undocumented)
@@ -143,7 +143,7 @@ interface ExternalSourcesTreeComponentProps extends Pick<ExternalSourcesTreeProp
 }
 
 // @beta (undocumented)
-type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> & Pick<BaseTreeRendererProps, "actions"> & {
+type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -207,7 +207,7 @@ export const IModelContentTreeComponent: {
 };
 
 // @beta (undocumented)
-interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode"> {
+interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
     // (undocumented)
@@ -215,7 +215,7 @@ interface IModelContentTreeComponentProps extends Pick<IModelContentTreeProps, "
 }
 
 // @beta (undocumented)
-type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> & Pick<BaseTreeRendererProps, "actions"> & {
+type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };
@@ -243,7 +243,7 @@ export const ModelsTreeComponent: {
 };
 
 // @public (undocumented)
-interface ModelsTreeComponentProps extends Pick<ModelsTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "selectionPredicate" | "hierarchyConfig" | "visibilityHandlerOverrides" | "getFilteredPaths" | "filter"> {
+interface ModelsTreeComponentProps extends Pick<ModelsTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "selectionPredicate" | "hierarchyConfig" | "visibilityHandlerOverrides" | "getFilteredPaths" | "filter" | "noDataMessage"> {
     headerButtons?: Array<(props: ModelsTreeHeaderButtonProps) => React.ReactNode>;
     // (undocumented)
     onFeatureUsed?: (feature: string) => void;
@@ -267,7 +267,7 @@ interface ModelsTreeHierarchyConfiguration {
 }
 
 // @beta (undocumented)
-type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> & Pick<VisibilityTreeRendererProps, "actions"> & UseModelsTreeProps & {
+type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> & Pick<VisibilityTreeRendererProps, "actions"> & UseModelsTreeProps & {
     hierarchyLevelConfig?: {
         sizeLimit?: number;
     };

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
@@ -30,11 +30,13 @@ export function CategoriesTree({
   hierarchyLevelConfig,
   selectionMode,
   onCategoriesFiltered,
+  noDataMessage,
 }: CategoriesTreeProps) {
   const { categoriesTreeProps, rendererProps } = useCategoriesTree({
     filter,
     activeView,
     onCategoriesFiltered,
+    noDataMessage,
   });
 
   return (

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
@@ -12,7 +12,7 @@ import type { UseCategoriesTreeProps } from "./UseCategoriesTree.js";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 
 /** @beta */
-export type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
+export type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> &
   Pick<VisibilityTreeRendererProps, "actions"> &
   UseCategoriesTreeProps & {
     hierarchyLevelConfig?: {
@@ -30,13 +30,13 @@ export function CategoriesTree({
   hierarchyLevelConfig,
   selectionMode,
   onCategoriesFiltered,
-  noDataMessage,
+  emptyTreeContent,
 }: CategoriesTreeProps) {
   const { categoriesTreeProps, rendererProps } = useCategoriesTree({
     filter,
     activeView,
     onCategoriesFiltered,
-    noDataMessage,
+    emptyTreeContent,
   });
 
   return (

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTree.tsx
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { VisibilityTree } from "../common/components/VisibilityTree.js";
-import type { VisibilityTreeRendererProps } from "../common/components/VisibilityTreeRenderer.js";
 import { VisibilityTreeRenderer } from "../common/components/VisibilityTreeRenderer.js";
 import { useCategoriesTree } from "./UseCategoriesTree.js";
 
+import type { VisibilityTreeRendererProps } from "../common/components/VisibilityTreeRenderer.js";
 import type { UseCategoriesTreeProps } from "./UseCategoriesTree.js";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 
 /** @beta */
-export type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> &
+export type CategoriesTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<VisibilityTreeRendererProps, "actions"> &
   UseCategoriesTreeProps & {
     hierarchyLevelConfig?: {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeComponent.tsx
@@ -19,7 +19,7 @@ import type { CategoriesTreeHeaderButtonProps, CategoriesTreeHeaderButtonType } 
 
 /** @public */
 interface CategoriesTreeComponentProps
-  extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "noDataMessage"> {
+  extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "emptyTreeContent"> {
   /**
    * Renderers of header buttons. Defaults to:
    * ```ts

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeComponent.tsx
@@ -19,7 +19,7 @@ import type { CategoriesTreeHeaderButtonProps, CategoriesTreeHeaderButtonType } 
 
 /** @public */
 interface CategoriesTreeComponentProps
-  extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter"> {
+  extends Pick<CategoriesTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "filter" | "noDataMessage"> {
   /**
    * Renderers of header buttons. Defaults to:
    * ```ts

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
@@ -7,11 +7,13 @@ import { useCallback, useMemo, useState } from "react";
 import { Text } from "@itwin/itwinui-react/bricks";
 import { HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
 import { TreeWidget } from "../../../TreeWidget.js";
+import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
 import { FilterLimitExceededError } from "../common/TreeErrors.js";
 import { useTelemetryContext } from "../common/UseTelemetryContext.js";
 import { CategoriesTreeDefinition } from "./CategoriesTreeDefinition.js";
 import { CategoriesVisibilityHandler } from "./CategoriesVisibilityHandler.js";
 
+import type { ReactNode} from "react";
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 import type { Viewport } from "@itwin/core-frontend";
@@ -28,6 +30,7 @@ export interface UseCategoriesTreeProps {
   activeView: Viewport;
   onCategoriesFiltered?: (categories: CategoryInfo[] | undefined) => void;
   filter?: string;
+  noDataMessage?: ReactNode;
 }
 
 /** @beta */
@@ -43,7 +46,7 @@ interface UseCategoriesTreeResult {
  * Custom hook to create and manage state for the categories tree.
  * @beta
  */
-export function useCategoriesTree({ filter, activeView, onCategoriesFiltered }: UseCategoriesTreeProps): UseCategoriesTreeResult {
+export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, noDataMessage }: UseCategoriesTreeProps): UseCategoriesTreeResult {
   const [filteringError, setFilteringError] = useState<CategoriesTreeFilteringError | undefined>();
   const visibilityHandlerFactory = useCallback(() => {
     const visibilityHandler = new CategoriesVisibilityHandler({
@@ -95,7 +98,7 @@ export function useCategoriesTree({ filter, activeView, onCategoriesFiltered }: 
       getHierarchyDefinition,
       getFilteredPaths,
       visibilityHandlerFactory,
-      noDataMessage: getNoDataMessage(filter ?? "", filteringError),
+      noDataMessage: getNoDataMessage(filter, filteringError, noDataMessage),
       highlight: filter ? { text: filter } : undefined,
     },
     rendererProps: {
@@ -134,14 +137,17 @@ function getCategories(paths: HierarchyFilteringPaths): CategoryInfo[] | undefin
   }));
 }
 
-function getNoDataMessage(filter: string, error?: CategoriesTreeFilteringError) {
+function getNoDataMessage(filter?: string, error?: CategoriesTreeFilteringError, noDataMessage?: React.ReactNode) {
   if (error) {
     return <Text>{TreeWidget.translate(`categoriesTree.filtering.${error}`)}</Text>;
   }
   if (filter) {
     return <Text>{TreeWidget.translate("categoriesTree.filtering.noMatches", { filter })}</Text>;
   }
-  return undefined;
+  if (noDataMessage) {
+    return noDataMessage;
+  }
+  return <NoDataRenderer icon={categoryIcon} />;
 }
 
 const categoryIcon = new URL("@itwin/itwinui-icons/tree-category.svg", import.meta.url).href;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
@@ -7,13 +7,13 @@ import { useCallback, useMemo, useState } from "react";
 import { Text } from "@itwin/itwinui-react/bricks";
 import { HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
 import { TreeWidget } from "../../../TreeWidget.js";
-import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
+import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { FilterLimitExceededError } from "../common/TreeErrors.js";
 import { useTelemetryContext } from "../common/UseTelemetryContext.js";
 import { CategoriesTreeDefinition } from "./CategoriesTreeDefinition.js";
 import { CategoriesVisibilityHandler } from "./CategoriesVisibilityHandler.js";
 
-import type { ReactNode} from "react";
+import type { ReactNode } from "react";
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 import type { Viewport } from "@itwin/core-frontend";
@@ -30,14 +30,14 @@ export interface UseCategoriesTreeProps {
   activeView: Viewport;
   onCategoriesFiltered?: (categories: CategoryInfo[] | undefined) => void;
   filter?: string;
-  noDataMessage?: ReactNode;
+  emptyTreeContent?: ReactNode;
 }
 
 /** @beta */
 interface UseCategoriesTreeResult {
   categoriesTreeProps: Pick<
     VisibilityTreeProps,
-    "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "noDataMessage"
+    "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "emptyTreeContent"
   >;
   rendererProps: Required<Pick<VisibilityTreeRendererProps, "getIcon" | "getSublabel">>;
 }
@@ -46,7 +46,7 @@ interface UseCategoriesTreeResult {
  * Custom hook to create and manage state for the categories tree.
  * @beta
  */
-export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, noDataMessage }: UseCategoriesTreeProps): UseCategoriesTreeResult {
+export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, emptyTreeContent }: UseCategoriesTreeProps): UseCategoriesTreeResult {
   const [filteringError, setFilteringError] = useState<CategoriesTreeFilteringError | undefined>();
   const visibilityHandlerFactory = useCallback(() => {
     const visibilityHandler = new CategoriesVisibilityHandler({
@@ -98,7 +98,7 @@ export function useCategoriesTree({ filter, activeView, onCategoriesFiltered, no
       getHierarchyDefinition,
       getFilteredPaths,
       visibilityHandlerFactory,
-      noDataMessage: getNoDataMessage(filter, filteringError, noDataMessage),
+      emptyTreeContent: getEmptyTreeContentComponent(filter, filteringError, emptyTreeContent),
       highlight: filter ? { text: filter } : undefined,
     },
     rendererProps: {
@@ -137,17 +137,17 @@ function getCategories(paths: HierarchyFilteringPaths): CategoryInfo[] | undefin
   }));
 }
 
-function getNoDataMessage(filter?: string, error?: CategoriesTreeFilteringError, noDataMessage?: React.ReactNode) {
+function getEmptyTreeContentComponent(filter?: string, error?: CategoriesTreeFilteringError, emptyTreeContent?: React.ReactNode) {
   if (error) {
     return <Text>{TreeWidget.translate(`categoriesTree.filtering.${error}`)}</Text>;
   }
   if (filter) {
     return <Text>{TreeWidget.translate("categoriesTree.filtering.noMatches", { filter })}</Text>;
   }
-  if (noDataMessage) {
-    return noDataMessage;
+  if (emptyTreeContent) {
+    return emptyTreeContent;
   }
-  return <NoDataRenderer icon={categoryIcon} />;
+  return <EmptyTreeContent icon={categoryIcon} />;
 }
 
 const categoryIcon = new URL("@itwin/itwinui-icons/tree-category.svg", import.meta.url).href;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/EmptyTreeContent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/EmptyTreeContent.tsx
@@ -6,12 +6,12 @@
 import { Icon, Text } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../../../TreeWidget.js";
 
-interface NoDataRendererProps {
+interface EmptyTreeContentProps {
   icon?: string;
 }
 
 /** @internal */
-export function NoDataRenderer({ icon }: NoDataRendererProps) {
+export function EmptyTreeContent({ icon }: EmptyTreeContentProps) {
   return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "0.75rem", gap: "0.5rem", flexDirection: "column" }}>
       {icon ? <Icon size="large" href={icon} /> : null}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/NoDataRenderer.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/NoDataRenderer.tsx
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Icon, Text } from "@itwin/itwinui-react/bricks";
+import { TreeWidget } from "../../../../TreeWidget.js";
+
+interface NoDataRendererProps {
+  icon?: string;
+}
+
+/** @internal */
+export function NoDataRenderer({ icon }: NoDataRendererProps) {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "0.75rem", gap: "0.5rem", flexDirection: "column" }}>
+      {icon ? <Icon size="large" href={icon} /> : null}
+      <Text style={{ textAlign: "center" }}>{TreeWidget.translate("baseTree.dataIsNotAvailable")}</Text>
+    </div>
+  );
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
@@ -5,21 +5,21 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { BeEvent } from "@itwin/core-bentley";
-import { Spinner, Text } from "@itwin/itwinui-react/bricks";
+import { Spinner } from "@itwin/itwinui-react/bricks";
 import { SchemaMetadataContextProvider } from "@itwin/presentation-components";
 import { useIModelUnifiedSelectionTree } from "@itwin/presentation-hierarchies-react";
 import { UnifiedSelectionContextProvider } from "@itwin/unified-selection-react";
-import { TreeWidget } from "../../../../TreeWidget.js";
 import { useHierarchiesLocalization } from "../UseHierarchiesLocalization.js";
 import { useHierarchyLevelFiltering } from "../UseHierarchyFiltering.js";
 import { useIModelChangeListener } from "../UseIModelChangeListener.js";
 import { useNodeHighlighting } from "../UseNodeHighlighting.js";
 import { useReportingAction, useTelemetryContext } from "../UseTelemetryContext.js";
 import { createIModelAccess } from "../Utils.js";
-import type { BaseTreeRendererProps } from "./BaseTreeRenderer.js";
 import { Delayed } from "./Delayed.js";
+import { NoDataRenderer } from "./NoDataRenderer.js";
 import { ProgressOverlay } from "./ProgressOverlay.js";
 
+import type { BaseTreeRendererProps } from "./BaseTreeRenderer.js";
 import type { MarkRequired } from "@itwin/core-bentley";
 import type { FunctionProps } from "../Utils.js";
 import type { ReactNode } from "react";
@@ -27,6 +27,7 @@ import type { IModelConnection } from "@itwin/core-frontend";
 import type { SchemaContext } from "@itwin/ecschema-metadata";
 import type { PresentationHierarchyNode, SelectionStorage, useIModelTree, useSelectionHandler } from "@itwin/presentation-hierarchies-react";
 import type { HighlightInfo } from "../UseNodeHighlighting.js";
+
 /** @beta */
 export type TreeProps = Pick<FunctionProps<typeof useIModelTree>, "getFilteredPaths" | "getHierarchyDefinition"> &
   Partial<Pick<FunctionProps<typeof useSelectionHandler>, "selectionMode">> & {
@@ -165,7 +166,7 @@ function TreeImpl({
   if (rootNodes.length === 0 && !isLoading) {
     return (
       <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", width: "100%", height: "100%" }}>
-        {noDataMessage ? noDataMessage : <Text>{TreeWidget.translate("baseTree.dataIsNotAvailable")}</Text>}
+        {noDataMessage ? noDataMessage : <NoDataRenderer />}
       </div>
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/Tree.tsx
@@ -16,7 +16,7 @@ import { useNodeHighlighting } from "../UseNodeHighlighting.js";
 import { useReportingAction, useTelemetryContext } from "../UseTelemetryContext.js";
 import { createIModelAccess } from "../Utils.js";
 import { Delayed } from "./Delayed.js";
-import { NoDataRenderer } from "./NoDataRenderer.js";
+import { EmptyTreeContent } from "./EmptyTreeContent.js";
 import { ProgressOverlay } from "./ProgressOverlay.js";
 
 import type { BaseTreeRendererProps } from "./BaseTreeRenderer.js";
@@ -65,8 +65,8 @@ export type TreeProps = Pick<FunctionProps<typeof useIModelTree>, "getFilteredPa
     imodelAccess?: FunctionProps<typeof useIModelTree>["imodelAccess"];
     /** Size limit that should be applied on each hierarchy level. Default to `1000`. */
     hierarchyLevelSizeLimit?: number;
-    /** Message that should be renderer if there are no tree nodes. */
-    noDataMessage?: ReactNode;
+    /** Component that should be renderer if there are no tree nodes. */
+    emptyTreeContent?: ReactNode;
     /** Callback that this invoked when tree reloads. */
     onReload?: () => void;
     /** Options for highlighting node labels. */
@@ -95,7 +95,7 @@ function TreeImpl({
   imodel,
   imodelAccess,
   treeName,
-  noDataMessage,
+  emptyTreeContent,
   getFilteredPaths,
   defaultHierarchyLevelSizeLimit,
   getHierarchyDefinition,
@@ -166,7 +166,7 @@ function TreeImpl({
   if (rootNodes.length === 0 && !isLoading) {
     return (
       <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", width: "100%", height: "100%" }}>
-        {noDataMessage ? noDataMessage : <NoDataRenderer />}
+        {emptyTreeContent ? emptyTreeContent : <EmptyTreeContent />}
       </div>
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
+import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
 import { ExternalSourcesTreeComponent } from "./ExternalSourcesTreeComponent.js";
@@ -15,7 +15,7 @@ import type { BaseTreeRendererProps } from "../common/components/BaseTreeRendere
 import type { TreeProps } from "../common/components/Tree.js";
 
 /** @beta */
-export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
+export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> &
   Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
       sizeLimit?: number;
@@ -26,7 +26,7 @@ export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaCont
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps) {
   return (
     <Tree
-      noDataMessage={<NoDataRenderer icon={documentIcon} />}
+      emptyTreeContent={<EmptyTreeContent icon={documentIcon} />}
       {...props}
       treeName={ExternalSourcesTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -13,7 +13,7 @@ import type { BaseTreeRendererProps } from "../common/components/BaseTreeRendere
 import type { TreeProps } from "../common/components/Tree.js";
 import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 /** @beta */
-export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> &
+export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
       sizeLimit?: number;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -4,14 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
 import { ExternalSourcesTreeComponent } from "./ExternalSourcesTreeComponent.js";
 import { ExternalSourcesTreeDefinition } from "./ExternalSourcesTreeDefinition.js";
 
+import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 import type { BaseTreeRendererProps } from "../common/components/BaseTreeRenderer.js";
 import type { TreeProps } from "../common/components/Tree.js";
-import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
+
 /** @beta */
 export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<BaseTreeRendererProps, "actions"> & {
@@ -24,6 +26,7 @@ export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaCont
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps) {
   return (
     <Tree
+      noDataMessage={<NoDataRenderer icon={documentIcon} />}
       {...props}
       treeName={ExternalSourcesTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
@@ -14,7 +14,7 @@ import type { ExternalSourcesTreeProps } from "./ExternalSourcesTree.js";
 interface ExternalSourcesTreeComponentProps
   extends Pick<
     ExternalSourcesTreeProps,
-    "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"
+    "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "emptyTreeContent"
   > {
   onPerformanceMeasured?: (featureId: string, duration: number) => void;
   onFeatureUsed?: (feature: string) => void;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTreeComponent.tsx
@@ -12,7 +12,10 @@ import { ExternalSourcesTree } from "./ExternalSourcesTree.js";
 import type { ExternalSourcesTreeProps } from "./ExternalSourcesTree.js";
 /** @beta */
 interface ExternalSourcesTreeComponentProps
-  extends Pick<ExternalSourcesTreeProps, "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode"> {
+  extends Pick<
+    ExternalSourcesTreeProps,
+    "getSchemaContext" | "selectionStorage" | "selectionMode" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"
+  > {
   onPerformanceMeasured?: (featureId: string, duration: number) => void;
   onFeatureUsed?: (feature: string) => void;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -14,7 +14,7 @@ import type { BaseTreeRendererProps } from "../common/components/BaseTreeRendere
 import type { TreeProps } from "../common/components/Tree.js";
 import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 /** @beta */
-export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> &
+export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
       sizeLimit?: number;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
+import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
 import { IModelContentTreeComponent } from "./IModelContentTreeComponent.js";
@@ -16,7 +16,7 @@ import type { BaseTreeRendererProps } from "../common/components/BaseTreeRendere
 import type { TreeProps } from "../common/components/Tree.js";
 
 /** @beta */
-export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
+export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> &
   Pick<BaseTreeRendererProps, "actions"> & {
     hierarchyLevelConfig?: {
       sizeLimit?: number;
@@ -27,7 +27,7 @@ export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContex
 export function IModelContentTree(props: IModelContentTreeProps) {
   return (
     <Tree
-      noDataMessage={<NoDataRenderer icon={modelIcon} />}
+      emptyTreeContent={<EmptyTreeContent icon={modelIcon} />}
       {...props}
       treeName={IModelContentTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -4,15 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
 import { IModelContentTreeComponent } from "./IModelContentTreeComponent.js";
 import { IModelContentTreeDefinition } from "./IModelContentTreeDefinition.js";
 import { IModelContentTreeIdsCache } from "./internal/IModelContentTreeIdsCache.js";
 
+import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 import type { BaseTreeRendererProps } from "../common/components/BaseTreeRenderer.js";
 import type { TreeProps } from "../common/components/Tree.js";
-import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
+
 /** @beta */
 export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<BaseTreeRendererProps, "actions"> & {
@@ -25,6 +27,7 @@ export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContex
 export function IModelContentTree(props: IModelContentTreeProps) {
   return (
     <Tree
+      noDataMessage={<NoDataRenderer icon={modelIcon} />}
       {...props}
       treeName={IModelContentTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
@@ -12,7 +12,7 @@ import { IModelContentTree } from "./IModelContentTree.js";
 import type { IModelContentTreeProps } from "./IModelContentTree.js";
 /** @beta */
 interface IModelContentTreeComponentProps
-  extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
+  extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "emptyTreeContent"> {
   onPerformanceMeasured?: (featureId: string, duration: number) => void;
   onFeatureUsed?: (feature: string) => void;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTreeComponent.tsx
@@ -12,7 +12,7 @@ import { IModelContentTree } from "./IModelContentTree.js";
 import type { IModelContentTreeProps } from "./IModelContentTree.js";
 /** @beta */
 interface IModelContentTreeComponentProps
-  extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode"> {
+  extends Pick<IModelContentTreeProps, "getSchemaContext" | "selectionStorage" | "hierarchyLevelConfig" | "selectionMode" | "noDataMessage"> {
   onPerformanceMeasured?: (featureId: string, duration: number) => void;
   onFeatureUsed?: (feature: string) => void;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { VisibilityTree } from "../common/components/VisibilityTree.js";
-import type { VisibilityTreeRendererProps } from "../common/components/VisibilityTreeRenderer.js";
 import { VisibilityTreeRenderer } from "../common/components/VisibilityTreeRenderer.js";
 import { useModelsTree } from "./UseModelsTree.js";
 
+import type { VisibilityTreeRendererProps } from "../common/components/VisibilityTreeRenderer.js";
 import type { UseModelsTreeProps } from "./UseModelsTree.js";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 /** @beta */
-export type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode"> &
+export type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
   Pick<VisibilityTreeRendererProps, "actions"> &
   UseModelsTreeProps & {
     hierarchyLevelConfig?: {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
@@ -11,7 +11,7 @@ import type { VisibilityTreeRendererProps } from "../common/components/Visibilit
 import type { UseModelsTreeProps } from "./UseModelsTree.js";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
 /** @beta */
-export type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "noDataMessage"> &
+export type ModelsTreeProps = Pick<VisibilityTreeProps, "imodel" | "getSchemaContext" | "selectionStorage" | "selectionMode" | "emptyTreeContent"> &
   Pick<VisibilityTreeRendererProps, "actions"> &
   UseModelsTreeProps & {
     hierarchyLevelConfig?: {
@@ -34,7 +34,7 @@ export function ModelsTree({
   getFilteredPaths,
   onModelsFiltered,
   actions,
-  noDataMessage,
+  emptyTreeContent,
 }: ModelsTreeProps) {
   const { modelsTreeProps, rendererProps } = useModelsTree({
     activeView,
@@ -44,7 +44,7 @@ export function ModelsTree({
     getFilteredPaths,
     onModelsFiltered,
     selectionPredicate,
-    noDataMessage,
+    emptyTreeContent,
   });
 
   return (

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTree.tsx
@@ -34,6 +34,7 @@ export function ModelsTree({
   getFilteredPaths,
   onModelsFiltered,
   actions,
+  noDataMessage,
 }: ModelsTreeProps) {
   const { modelsTreeProps, rendererProps } = useModelsTree({
     activeView,
@@ -43,6 +44,7 @@ export function ModelsTree({
     getFilteredPaths,
     onModelsFiltered,
     selectionPredicate,
+    noDataMessage,
   });
 
   return (

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -40,7 +40,7 @@ interface ModelsTreeComponentProps
     | "visibilityHandlerOverrides"
     | "getFilteredPaths"
     | "filter"
-    | "noDataMessage"
+    | "emptyTreeContent"
   > {
   /**
    * Renderers of header buttons. Defaults to:

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -40,6 +40,7 @@ interface ModelsTreeComponentProps
     | "visibilityHandlerOverrides"
     | "getFilteredPaths"
     | "filter"
+    | "noDataMessage"
   > {
   /**
    * Renderers of header buttons. Defaults to:

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -8,7 +8,7 @@ import { Anchor, Text } from "@itwin/itwinui-react/bricks";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { HierarchyNodeIdentifier, HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { TreeWidget } from "../../../TreeWidget.js";
-import { NoDataRenderer } from "../common/components/NoDataRenderer.js";
+import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { useFocusedInstancesContext } from "../common/FocusedInstancesContext.js";
 import { FilterLimitExceededError } from "../common/TreeErrors.js";
 import { useIModelChangeListener } from "../common/UseIModelChangeListener.js";
@@ -18,7 +18,7 @@ import { ModelsTreeNode } from "./internal/ModelsTreeNode.js";
 import { createModelsTreeVisibilityHandler } from "./internal/ModelsTreeVisibilityHandler.js";
 import { defaultHierarchyConfiguration, ModelsTreeDefinition } from "./ModelsTreeDefinition.js";
 
-import type { ReactNode} from "react";
+import type { ReactNode } from "react";
 import type { GroupingHierarchyNode, HierarchyFilteringPath, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { Id64String } from "@itwin/core-bentley";
 import type { ECClassHierarchyInspector, InstanceKey } from "@itwin/presentation-shared";
@@ -46,14 +46,14 @@ export interface UseModelsTreeProps {
    * When not supplied, all nodes are selectable.
    */
   selectionPredicate?: (props: { node: PresentationHierarchyNode; type: "subject" | "model" | "category" | "element" | "elements-class-group" }) => boolean;
-  noDataMessage?: ReactNode;
+  emptyTreeContent?: ReactNode;
 }
 
 /** @beta */
 interface UseModelsTreeResult {
   modelsTreeProps: Pick<
     VisibilityTreeProps,
-    "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "noDataMessage" | "selectionPredicate"
+    "treeName" | "getHierarchyDefinition" | "getFilteredPaths" | "visibilityHandlerFactory" | "highlight" | "emptyTreeContent" | "selectionPredicate"
   >;
   rendererProps: Required<Pick<VisibilityTreeRendererProps, "getIcon">>;
 }
@@ -70,7 +70,7 @@ export function useModelsTree({
   getFilteredPaths,
   onModelsFiltered,
   selectionPredicate: nodeTypeSelectionPredicate,
-  noDataMessage,
+  emptyTreeContent,
 }: UseModelsTreeProps): UseModelsTreeResult {
   const [filteringError, setFilteringError] = useState<ModelsTreeFilteringError | undefined>(undefined);
   const hierarchyConfiguration = useMemo<ModelsTreeHierarchyConfiguration>(
@@ -208,7 +208,7 @@ export function useModelsTree({
       visibilityHandlerFactory,
       getHierarchyDefinition,
       getFilteredPaths: getPaths,
-      noDataMessage: getNoDataMessage(filter, filteringError, noDataMessage),
+      emptyTreeContent: getEmptyTreeContentComponent(filter, filteringError, emptyTreeContent),
       highlight: filter ? { text: filter } : undefined,
       selectionPredicate: nodeSelectionPredicate,
     },
@@ -251,7 +251,7 @@ async function getModels(paths: HierarchyFilteringPath[], idsCache: ModelsTreeId
   return [...targetModels, ...matchingModels];
 }
 
-function getNoDataMessage(filter?: string, error?: ModelsTreeFilteringError, noDataMessage?: React.ReactNode) {
+function getEmptyTreeContentComponent(filter?: string, error?: ModelsTreeFilteringError, emptyTreeContent?: React.ReactNode) {
   if (isInstanceFocusError(error)) {
     return <InstanceFocusError error={error!} />;
   }
@@ -261,10 +261,10 @@ function getNoDataMessage(filter?: string, error?: ModelsTreeFilteringError, noD
   if (filter) {
     return <Text>{TreeWidget.translate("modelsTree.filtering.noMatches", { filter })}</Text>;
   }
-  if (noDataMessage) {
-    return noDataMessage;
+  if (emptyTreeContent) {
+    return emptyTreeContent;
   }
-  return <NoDataRenderer icon={modelIcon} />;
+  return <EmptyTreeContent icon={modelIcon} />;
 }
 
 function isFilterError(error: ModelsTreeFilteringError | undefined) {


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1195

Added ability to supply custom no data renderer. Also updated default no data renderer to renderer icon and added some padding.

![ModelsTree](https://github.com/user-attachments/assets/37ccc855-3404-4e5b-b30f-c3e952157c0f)
![CategoriesTree](https://github.com/user-attachments/assets/062cd4b9-2ee2-4594-b6e5-0aaf61b2fc0b)
![IModelContentTree](https://github.com/user-attachments/assets/48967f27-ecb8-43cd-859c-c5759ff553b5)
![ExternalSourcesTree](https://github.com/user-attachments/assets/0f1a2e50-649a-413d-81bd-77a4d5f2ee23)

