### PR TITLE
Tree widget: Show visibility action button in partial state

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
@@ -52,7 +52,7 @@ export function createVisibilityAction({
       action: () => {
         onVisibilityButtonClick(node, state.state);
       },
-      show: state.state === "hidden" ? true : undefined,
+      show: state.state !== "visible" ? true : undefined,
       icon: getIcon(),
     };
   };


### PR DESCRIPTION
https://github.com/iTwin/viewer-components-react/issues/1201 states the button should be displayed in partial state too