### PR TITLE
Property grid: Allow creating multiple property widgets by supplying different widget ids

### DIFF
--- a/apps/test-viewer/src/components/ViewerOptions.tsx
+++ b/apps/test-viewer/src/components/ViewerOptions.tsx
@@ -3,9 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { createContext, useContext, useState } from "react";
-import { StatusBarSection } from "@itwin/appui-react";
-import { SvgSelection, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
+import { createContext, useContext, useEffect, useState } from "react";
+import { StatusBarSection, useActiveIModelConnection } from "@itwin/appui-react";
+import { TransientIdSequence } from "@itwin/core-bentley";
+import { SvgSelection, SvgVisibilityShow, SvgZoomInCircular } from "@itwin/itwinui-icons-react";
 import { IconButton, Select } from "@itwin/itwinui-react";
 import { Presentation } from "@itwin/presentation-frontend";
 
@@ -64,6 +65,18 @@ export const statusBarActionsProvider: UiItemsProvider = {
       content: <SelectionScopeSelectorButton />,
       itemPriority: 3,
       section: StatusBarSection.Left,
+    },
+    {
+      id: `addTransientElementToSelectionButton`,
+      content: <AddTransientElementToSelectionButton />,
+      itemPriority: 4,
+      section: StatusBarSection.Left,
+    },
+    {
+      id: `selectedElementsCount`,
+      content: <SelectedElementsCountField />,
+      itemPriority: 1,
+      section: StatusBarSection.Right,
     },
   ],
 };
@@ -143,3 +156,27 @@ const scopes = {
     label: "Category",
   },
 };
+
+function AddTransientElementToSelectionButton() {
+  const [sequence] = useState(new TransientIdSequence());
+  const imodel = useActiveIModelConnection();
+  const onClick = () => {
+    imodel?.selectionSet.add(sequence.getNext());
+  };
+  return (
+    <IconButton label="Add transient element to selection" styleType="borderless" onClick={onClick}>
+      <SvgZoomInCircular />
+    </IconButton>
+  );
+}
+
+function SelectedElementsCountField() {
+  const imodel = useActiveIModelConnection();
+  const [count, setCount] = useState(imodel?.selectionSet.size ?? 0);
+  useEffect(() => {
+    return imodel?.selectionSet.onChanged.addListener(() => {
+      setCount(imodel.selectionSet.size);
+    });
+  }, [imodel]);
+  return `Selected elements: ${count}`;
+}

--- a/change/@itwin-property-grid-react-134b7ed8-408b-435b-8c98-3087d14a2167.json
+++ b/change/@itwin-property-grid-react-134b7ed8-408b-435b-8c98-3087d14a2167.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Introduce `widgetId` prop for `createPropertyWidget` to allow creating multiple property grid widgets in an application.",
+  "packageName": "@itwin/property-grid-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/property-grid/api/property-grid-react.api.md
+++ b/packages/itwin/property-grid/api/property-grid-react.api.md
@@ -216,7 +216,9 @@ export interface PropertyGridUiItemsProviderProps {
 export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
 
 // @public
-export type PropertyGridWidgetProps = PropertyGridComponentProps & ({
+export type PropertyGridWidgetProps = PropertyGridComponentProps & {
+    widgetId?: string;
+} & ({
     shouldShow?: (selection: Readonly<KeySet>) => boolean;
     selectionStorage?: never;
 } | {

--- a/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
@@ -29,7 +29,7 @@ import type { PropertyGridComponentProps } from "./PropertyGridComponent.js";
  */
 export function createPropertyGrid(propertyGridProps: PropertyGridWidgetProps): Widget {
   return {
-    id: "vcr:PropertyGridComponent",
+    id: propertyGridProps.widgetId ?? PropertyGridWidgetId,
     label: PropertyGridManager.translate("widget-label"),
     icon: <SvgInfoCircular />,
     defaultState: WidgetState.Hidden,
@@ -44,7 +44,9 @@ export function createPropertyGrid(propertyGridProps: PropertyGridWidgetProps): 
 }
 
 /**
- * Id of the property grid widget created by `createPropertyGrid`.
+ * Default id for the property grid widget created by `createPropertyGrid`, if a custom on
+ * is not supplied through `widgetId` prop.
+ *
  * @public
  */
 export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
@@ -99,11 +101,18 @@ export class PropertyGridUiItemsProvider implements UiItemsProvider {
 }
 
 /**
- * Props for creating `PropertyGridWidget`.
+ * Props for `createPropertyGrid`.
  * @public
  */
-export type PropertyGridWidgetProps = PropertyGridComponentProps &
-  (
+export type PropertyGridWidgetProps = PropertyGridComponentProps & {
+  /**
+   * A custom id to use for the created widget. Should be supplied when creating multiple property grid widgets to
+   * make sure they don't conflict with each other in AppUI system.
+   *
+   * Defaults to `PropertyGridWidgetId`.
+   */
+  widgetId?: string;
+} & (
     | {
         /**
          * Predicate indicating if the widget should be shown for the current selection set.
@@ -128,9 +137,9 @@ export type PropertyGridWidgetProps = PropertyGridComponentProps &
 
 /** Component that renders `PropertyGridComponent` an hides/shows widget based on `UnifiedSelection`. */
 // eslint-disable-next-line deprecation/deprecation
-function PropertyGridWidget({ shouldShow, ...props }: PropertyGridWidgetProps) {
+function PropertyGridWidget({ shouldShow, widgetId, ...props }: PropertyGridWidgetProps) {
   const ref = usePropertyGridTransientState<HTMLDivElement>();
-  const widgetDef = useSpecificWidgetDef(PropertyGridWidgetId);
+  const widgetDef = useSpecificWidgetDef(widgetId ?? PropertyGridWidgetId);
   const selectionStorage = props.selectionStorage;
   const { selectionChange } = useSelectionHandler({ selectionStorage });
 


### PR DESCRIPTION
Consumer was trying to have two property grid widgets and only one of them worked due to widget id conflicts in AppUI system.