### PR TITLE
Tree widget: Use default imports for svg

### DIFF
--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -41,7 +41,6 @@ import type { TreeDefinition } from "@itwin/tree-widget-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { ClientPrefix } from "@itwin/grouping-mapping-widget";
 import type { UiItemsProvider } from "@itwin/appui-react";
-import type { ComponentPropsWithRef } from "react";
 
 export interface UiProvidersConfig {
   initialize: () => Promise<void>;

--- a/change/@itwin-tree-widget-react-9d2dccff-032c-47bb-bcc0-9bb27169f7e4.json
+++ b/change/@itwin-tree-widget-react-9d2dccff-032c-47bb-bcc0-9bb27169f7e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use default import for importing svg.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -168,7 +168,7 @@ interface FocusedInstancesContext {
 export function FocusedInstancesContextProvider({ selectionStorage, imodelKey, children, }: PropsWithChildren<{
     selectionStorage: SelectionStorage;
     imodelKey: string;
-}>): JSX.Element;
+}>): JSX_2.Element;
 
 // @beta (undocumented)
 type FunctionProps<THook extends (props: any) => any> = Parameters<THook>[0];

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -60,8 +60,6 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@itwin/itwinui-icons-react": "^2.9.0",
-    "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@itwin/presentation-core-interop": "^1.3.0",
     "@itwin/presentation-hierarchies": "^1.4.1",
     "@itwin/presentation-hierarchies-react": "2.0.0-alpha.6",

--- a/packages/itwin/tree-widget/pnpm-lock.yaml
+++ b/packages/itwin/tree-widget/pnpm-lock.yaml
@@ -12,12 +12,6 @@ importers:
 
   .:
     dependencies:
-      '@itwin/itwinui-icons-react':
-        specifier: ^2.9.0
-        version: 2.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@itwin/itwinui-illustrations-react':
-        specifier: ^2.1.0
-        version: 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-core-interop':
         specifier: ^1.3.0
         version: 1.3.0(@itwin/core-bentley@4.10.2)(@itwin/core-common@4.10.2(@itwin/core-bentley@4.10.2)(@itwin/core-geometry@4.10.2))(@itwin/core-geometry@4.10.2)(@itwin/core-quantity@4.10.2(@itwin/core-bentley@4.10.2))(@itwin/ecschema-metadata@4.10.2(@itwin/core-bentley@4.10.2)(@itwin/core-quantity@4.10.2(@itwin/core-bentley@4.10.2)))

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/TreeWidgetUiItemsProvider.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/TreeWidgetUiItemsProvider.tsx
@@ -7,7 +7,8 @@ import "./TreeWidgetUiItemsProvider.css";
 import { useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { StagePanelLocation, StagePanelSection, useTransientState } from "@itwin/appui-react";
-import { SvgHierarchyTree } from "@itwin/itwinui-icons-react";
+import hierarchyTreeSvg from "@itwin/itwinui-icons/hierarchy-tree.svg";
+import { Icon } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../TreeWidget.js";
 import { ErrorState } from "./tree-header/ErrorState.js";
 import { TreeWidgetComponentImpl } from "./TreeWidgetComponentImpl.js";
@@ -15,7 +16,6 @@ import { TreeWidgetComponentImpl } from "./TreeWidgetComponentImpl.js";
 import type { Ref } from "react";
 import type { Widget } from "@itwin/appui-react";
 import type { TreeDefinition } from "./TreeWidgetComponentImpl.js";
-
 /**
  * Props for `createWidget`.
  * @public
@@ -43,7 +43,7 @@ export function createTreeWidget(props: TreeWidgetProps): Widget {
   return {
     id: "tree-widget-react:trees",
     label: TreeWidget.translate("widget.label"),
-    icon: <SvgHierarchyTree />,
+    icon: <Icon href={hierarchyTreeSvg} />,
     layouts: {
       standard: {
         section: StagePanelSection.Start,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/ErrorState.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/ErrorState.tsx
@@ -3,18 +3,17 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import errorSvg from "@itwin/itwinui-icons/status-error.svg";
 import { Button, Icon, Text } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../TreeWidget.js";
 
 import type { FallbackProps } from "react-error-boundary";
 
-const errorIcon = new URL("@itwin/itwinui-icons/status-error.svg", import.meta.url).href;
-
 /** @internal */
 export function ErrorState({ resetErrorBoundary }: FallbackProps) {
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", gap: "0.5rem" }}>
-      <Icon href={errorIcon} size="large" />
+      <Icon href={errorSvg} size="large" />
       <Text>{TreeWidget.translate("errorState.description")}</Text>
       <Button onClick={resetErrorBoundary}>{TreeWidget.translate("errorState.retryButtonLabel")}</Button>
     </div>

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/SearchBox.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/SearchBox.tsx
@@ -5,11 +5,10 @@
 
 import "./SearchBox.css";
 import { useEffect, useRef, useState } from "react";
+import dismissSvg from "@itwin/itwinui-icons/dismiss.svg";
+import searchSvg from "@itwin/itwinui-icons/search.svg";
 import { IconButton, TextBox } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../TreeWidget.js";
-
-const searchIcon = new URL("@itwin/itwinui-icons/search.svg", import.meta.url).href;
-const dismissIcon = new URL("@itwin/itwinui-icons/dismiss.svg", import.meta.url).href;
 
 interface DebouncedSearchBoxProps {
   isOpened: boolean;
@@ -40,7 +39,7 @@ export function DebouncedSearchBox({ isOpened, onSearch, setIsOpened, delay, cla
       className={"tw-search-box-button"}
       variant={"ghost"}
       label={TreeWidget.translate("header.searchBox.searchForSomething")}
-      icon={searchIcon}
+      icon={searchSvg}
       onClick={() => {
         setIsOpened(true);
         setInputValue("");
@@ -55,7 +54,7 @@ export function DebouncedSearchBox({ isOpened, onSearch, setIsOpened, delay, cla
         className={"tw-search-box-button"}
         variant={"ghost"}
         label={TreeWidget.translate("header.searchBox.close")}
-        icon={dismissIcon}
+        icon={dismissSvg}
         onClick={() => {
           setIsOpened(false);
           setInputValue(undefined);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -5,6 +5,9 @@
 
 import { useMemo, useState } from "react";
 import { useAsyncValue } from "@itwin/components-react";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
+import visibilityInvertSvg from "@itwin/itwinui-icons/visibilty-invert.svg";
 import { IconButton } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../../TreeWidget.js";
 import { hideAllCategories, invertAllCategories, loadCategoriesFromViewport, showAllCategories } from "../common/CategoriesVisibilityUtils.js";
@@ -12,10 +15,6 @@ import { hideAllCategories, invertAllCategories, loadCategoriesFromViewport, sho
 import type { CategoryInfo } from "../common/CategoriesVisibilityUtils.js";
 import type { TreeToolbarButtonProps } from "../../tree-header/SelectableTree.js";
 import type { Viewport } from "@itwin/core-frontend";
-
-const visibilityShowIcon = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
-const visibilityHideIcon = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
-const visibilityInvertIcon = new URL("@itwin/itwinui-icons/visibilty-invert.svg", import.meta.url).href;
 
 /**
  * Props that get passed to `CategoriesTreeComponent` header button renderer.
@@ -76,7 +75,7 @@ export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
           props.viewport,
         );
       }}
-      icon={visibilityShowIcon}
+      icon={visibilityShowSvg}
     />
   );
 }
@@ -94,7 +93,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
           props.viewport,
         );
       }}
-      icon={visibilityHideIcon}
+      icon={visibilityHideSvg}
     />
   );
 }
@@ -109,7 +108,7 @@ export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
         props.onFeatureUsed?.(`categories-tree-invert`);
         void invertAllCategories(props.categories, props.viewport);
       }}
-      icon={visibilityInvertIcon}
+      icon={visibilityInvertSvg}
     />
   );
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
@@ -5,6 +5,9 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { assert } from "@itwin/core-bentley";
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import subcategorySvg from "@itwin/itwinui-icons/bis-category-subcategory.svg";
+import definitionContainerSvg from "@itwin/itwinui-icons/bis-definitions-container.svg";
 import { Text } from "@itwin/itwinui-react/bricks";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { HierarchyFilteringPath, HierarchyNodeIdentifier } from "@itwin/presentation-hierarchies";
@@ -189,12 +192,9 @@ function getEmptyTreeContentComponent(filter?: string, error?: CategoriesTreeFil
   if (emptyTreeContent) {
     return emptyTreeContent;
   }
-  return <EmptyTreeContent icon={categoryIcon} />;
+  return <EmptyTreeContent icon={categorySvg} />;
 }
 
-const categoryIcon = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-const subcategoryIcon = new URL("@itwin/itwinui-icons/bis-category-subcategory.svg", import.meta.url).href;
-const definitionContainerIcon = new URL("@itwin/itwinui-icons/bis-definitions-container.svg", import.meta.url).href;
 
 function getIcon(node: PresentationHierarchyNode): string | undefined {
   if (node.extendedData?.imageId === undefined) {
@@ -203,11 +203,11 @@ function getIcon(node: PresentationHierarchyNode): string | undefined {
 
   switch (node.extendedData.imageId) {
     case "icon-layers":
-      return categoryIcon;
+      return categorySvg;
     case "icon-layers-isolate":
-      return subcategoryIcon;
+      return subcategorySvg;
     case "icon-definition-container":
-      return definitionContainerIcon;
+      return definitionContainerSvg;
   }
 
   return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import "./TreeNodeVisibilityButton.css";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityPartialSvg from "@itwin/itwinui-icons/visibility-partial.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
 
 import type { PresentationHierarchyNode, TreeItemAction } from "@itwin/presentation-hierarchies-react";
-
-const visibilityShowIcon = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
-const visibilityHideIcon = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
-const visibilityPartialIcon = new URL("@itwin/itwinui-icons/visibility-partial.svg", import.meta.url).href;
 
 /**
  * Data structure that describes tree node checkbox state.
@@ -40,11 +39,11 @@ export function createVisibilityAction({
     const getIcon = () => {
       switch (state.state) {
         case "visible":
-          return visibilityShowIcon;
+          return visibilityShowSvg;
         case "hidden":
-          return visibilityHideIcon;
+          return visibilityHideSvg;
         case "partial":
-          return visibilityPartialIcon;
+          return visibilityPartialSvg;
       }
     };
     return {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import documentSvg from "@itwin/itwinui-icons/document.svg";
+import ecSchemaSvg from "@itwin/itwinui-icons/selection-children.svg";
 import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
@@ -25,7 +29,7 @@ export type ExternalSourcesTreeProps = Pick<TreeProps, "imodel" | "getSchemaCont
 export function ExternalSourcesTree(props: ExternalSourcesTreeProps) {
   return (
     <Tree
-      emptyTreeContent={<EmptyTreeContent icon={documentIcon} />}
+      emptyTreeContent={<EmptyTreeContent icon={documentSvg} />}
       {...props}
       treeName={ExternalSourcesTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}
@@ -39,11 +43,6 @@ const getDefinitionsProvider: TreeProps["getHierarchyDefinition"] = (props) => {
   return new ExternalSourcesTreeDefinition(props);
 };
 
-const ecSchemaIcon = new URL("@itwin/itwinui-icons/selection-children.svg", import.meta.url).href;
-const elementIcon = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
-const documentIcon = new URL("@itwin/itwinui-icons/document.svg", import.meta.url).href;
-const classIcon = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-
 function getIcon(node: PresentationHierarchyNode): string | undefined {
   if (node.extendedData?.imageId === undefined) {
     return undefined;
@@ -51,13 +50,13 @@ function getIcon(node: PresentationHierarchyNode): string | undefined {
 
   switch (node.extendedData.imageId) {
     case "icon-item":
-      return elementIcon;
+      return elementSvg;
     case "icon-ec-class":
-      return classIcon;
+      return classSvg;
     case "icon-document":
-      return documentIcon;
+      return documentSvg;
     case "icon-ec-schema":
-      return ecSchemaIcon;
+      return ecSchemaSvg;
   }
 
   return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -3,6 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import subjectSvg from "@itwin/itwinui-icons/bis-subject.svg";
+import groupSvg from "@itwin/itwinui-icons/group.svg";
+import modelSvg from "@itwin/itwinui-icons/model-cube.svg";
+import hierarchyTreeSvg from "@itwin/itwinui-icons/selection-children.svg";
 import { EmptyTreeContent } from "../common/components/EmptyTreeContent.js";
 import { Tree } from "../common/components/Tree.js";
 import { TreeRenderer } from "../common/components/TreeRenderer.js";
@@ -26,7 +33,7 @@ export type IModelContentTreeProps = Pick<TreeProps, "imodel" | "getSchemaContex
 export function IModelContentTree(props: IModelContentTreeProps) {
   return (
     <Tree
-      emptyTreeContent={<EmptyTreeContent icon={modelIcon} />}
+      emptyTreeContent={<EmptyTreeContent icon={modelSvg} />}
       {...props}
       treeName={IModelContentTreeComponent.id}
       getHierarchyDefinition={getDefinitionsProvider}
@@ -43,14 +50,6 @@ const getDefinitionsProvider: TreeProps["getHierarchyDefinition"] = ({ imodelAcc
   });
 };
 
-const subjectIcon = new URL("@itwin/itwinui-icons/bis-subject.svg", import.meta.url).href;
-const classIcon = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const modelIcon = new URL("@itwin/itwinui-icons/model-cube.svg", import.meta.url).href;
-const categoryIcon = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-const elementIcon = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
-const hierarchyTreeIcon = new URL("@itwin/itwinui-icons/selection-children.svg", import.meta.url).href;
-const groupIcon = new URL("@itwin/itwinui-icons/group.svg", import.meta.url).href;
-
 function getIcon(node: PresentationHierarchyNode): string | undefined {
   if (node.extendedData?.imageId === undefined) {
     return undefined;
@@ -58,19 +57,19 @@ function getIcon(node: PresentationHierarchyNode): string | undefined {
 
   switch (node.extendedData.imageId) {
     case "icon-layers":
-      return categoryIcon;
+      return categorySvg;
     case "icon-item":
-      return elementIcon;
+      return elementSvg;
     case "icon-ec-class":
-      return classIcon;
+      return classSvg;
     case "icon-folder":
-      return subjectIcon;
+      return subjectSvg;
     case "icon-model":
-      return modelIcon;
+      return modelSvg;
     case "icon-hierarchy-tree":
-      return hierarchyTreeIcon;
+      return hierarchyTreeSvg;
     case "icon-group":
-      return groupIcon;
+      return groupSvg;
   }
 
   return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -4,6 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useEffect, useMemo, useState } from "react";
+import toggle2DSvg from "@itwin/itwinui-icons/2d.svg";
+import toggle3DSvg from "@itwin/itwinui-icons/3d.svg";
+import focusModeSvg from "@itwin/itwinui-icons/cursor-click.svg";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
+import visibilityInvertSvg from "@itwin/itwinui-icons/visibilty-invert.svg";
 import { IconButton } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../../TreeWidget.js";
 import { useFocusedInstancesContext } from "../common/FocusedInstancesContext.js";
@@ -13,13 +19,6 @@ import type { Id64String } from "@itwin/core-bentley";
 import type { GeometricModel3dProps, ModelQueryParams } from "@itwin/core-common";
 import type { IModelConnection, Viewport } from "@itwin/core-frontend";
 import type { TreeToolbarButtonProps } from "../../tree-header/SelectableTree.js";
-
-const visibilityShowIcon = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
-const visibilityHideIcon = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
-const visibilityInvertIcon = new URL("@itwin/itwinui-icons/visibilty-invert.svg", import.meta.url).href;
-const focusModeIcon = new URL("@itwin/itwinui-icons/cursor-click.svg", import.meta.url).href;
-const toggle3DIcon = new URL("@itwin/itwinui-icons/3d.svg", import.meta.url).href;
-const toggle2DIcon = new URL("@itwin/itwinui-icons/2d.svg", import.meta.url).href;
 
 /**
  * Information about a single Model.
@@ -125,7 +124,7 @@ export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
           props.viewport,
         );
       }}
-      icon={visibilityShowIcon}
+      icon={visibilityShowSvg}
     />
   );
 }
@@ -143,7 +142,7 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
           props.viewport,
         );
       }}
-      icon={visibilityHideIcon}
+      icon={visibilityHideSvg}
     />
   );
 }
@@ -161,7 +160,7 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
           props.viewport,
         );
       }}
-      icon={visibilityInvertIcon}
+      icon={visibilityInvertSvg}
     />
   );
 }
@@ -189,7 +188,7 @@ export function View2DButton(props: ModelsTreeHeaderButtonProps) {
       }}
       aria-disabled={models2d.length === 0}
       isActive={is2dToggleActive}
-      icon={toggle2DIcon}
+      icon={toggle2DSvg}
     />
   );
 }
@@ -217,7 +216,7 @@ export function View3DButton(props: ModelsTreeHeaderButtonProps) {
       }}
       aria-disabled={models3d.length === 0}
       isActive={is3dToggleActive}
-      icon={toggle3DIcon}
+      icon={toggle3DSvg}
     />
   );
 }
@@ -240,7 +239,7 @@ export function ToggleInstancesFocusButton({ onFeatureUsed, disabled }: { onFeat
       }}
       aria-disabled={disabled}
       isActive={enabled}
-      icon={focusModeIcon}
+      icon={focusModeSvg}
     />
   );
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -4,6 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import subjectSvg from "@itwin/itwinui-icons/bis-subject.svg";
+import modelSvg from "@itwin/itwinui-icons/model-cube.svg";
 import { Anchor, Text } from "@itwin/itwinui-react/bricks";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { HierarchyNodeIdentifier, HierarchyNodeKey } from "@itwin/presentation-hierarchies";
@@ -264,7 +269,7 @@ function getEmptyTreeContentComponent(filter?: string, error?: ModelsTreeFilteri
   if (emptyTreeContent) {
     return emptyTreeContent;
   }
-  return <EmptyTreeContent icon={modelIcon} />;
+  return <EmptyTreeContent icon={modelSvg} />;
 }
 
 function isFilterError(error: ModelsTreeFilteringError | undefined) {
@@ -281,12 +286,6 @@ function InstanceFocusError({ error }: { error: ModelsTreeFilteringError }) {
   return <Text>{localizedMessage}</Text>;
 }
 
-const subjectIcon = new URL("@itwin/itwinui-icons/bis-subject.svg", import.meta.url).href;
-const classIcon = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const modelIcon = new URL("@itwin/itwinui-icons/model-cube.svg", import.meta.url).href;
-const categoryIcon = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-const elementIcon = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
-
 function getIcon(node: PresentationHierarchyNode): string | undefined {
   if (node.extendedData?.imageId === undefined) {
     return undefined;
@@ -294,15 +293,15 @@ function getIcon(node: PresentationHierarchyNode): string | undefined {
 
   switch (node.extendedData.imageId) {
     case "icon-layers":
-      return categoryIcon;
+      return categorySvg;
     case "icon-item":
-      return elementIcon;
+      return elementSvg;
     case "icon-ec-class":
-      return classIcon;
+      return classSvg;
     case "icon-folder":
-      return subjectIcon;
+      return subjectSvg;
     case "icon-model":
-      return modelIcon;
+      return modelSvg;
   }
 
   return undefined;

--- a/packages/itwin/tree-widget/tsconfig.json
+++ b/packages/itwin/tree-widget/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "lib": ["DOM"]
   },
-  "include": ["src"]
+  "include": ["src", "types.d.ts"]
 }

--- a/packages/itwin/tree-widget/types.d.ts
+++ b/packages/itwin/tree-widget/types.d.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
Use default imports for importing svg until consumers supports importing svg using [import.meta.url](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta)