### PR TITLE
Setup individual audit

### DIFF
--- a/.pipelines/templates/build-steps.yaml
+++ b/.pipelines/templates/build-steps.yaml
@@ -24,7 +24,7 @@ steps:
   - script: pnpm install --frozen-lockfile
     displayName: pnpm install
 
-  - script: pnpm audit --registry=https://registry.npmjs.org --audit-level=high --production
+  - script: pnpm run audit # TODO: Review if npm registry needs to be added, and --production flag passed through
     displayName: Audit
 
   # - script: pnpm exec prettier . --check

--- a/apps/learning-snippets/package.json
+++ b/apps/learning-snippets/package.json
@@ -11,6 +11,7 @@
     "cover": "npm run -s test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
     "test": "cross-env NODE_OPTIONS=\"--import ../../node-hooks/ignore-styles/register.cjs\" mocha --enable-source-maps --config ./.mocharc.json",
+    "audit": "pnpm audit --audit-level=high",
     "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=./build/docs/extract",
     "link:deps": "node ./scripts/linkWorkspaceDeps.cjs"
   },

--- a/apps/test-viewer/package.json
+++ b/apps/test-viewer/package.json
@@ -113,6 +113,7 @@
     "clean": "rimraf dist",
     "dist": "vite build",
     "lint": "eslint ./src/**/*.{ts,tsx}",
+    "audit": "pnpm audit --audit-level=high",
     "link:deps": "node ./scripts/linkWorkspaceDeps.js",
     "link:deps:watch": "node ./scripts/linkWorkspaceDeps.js --watch"
   },

--- a/lage.config.js
+++ b/lage.config.js
@@ -30,6 +30,11 @@ module.exports = {
       outputs: [],
       inputs: ["src/**"],
     },
+    "audit": {
+      cache: false,
+      dependsOn: [],
+      outputs: [],
+    },
     "extract-api": {
       dependsOn: ["build"],
       outputs: ["./api/**"],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "lage test --grouped --continue",
     "test:e2e": "lage test:e2e --continue --verbose",
     "lint": "lage lint --grouped --continue",
+    "audit": "lage audit --continue --grouped --verbose",
     "clean": "lage clean --grouped --continue",
     "extract-api": "lage extract-api --grouped --continue",
     "check": "beachball check",

--- a/packages/itwin/breakdown-trees/package.json
+++ b/packages/itwin/breakdown-trees/package.json
@@ -35,7 +35,8 @@
     "//test": "mocha \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit"
   },
   "dependencies": {
     "@itwin/itwinui-icons-react": "^2.1.0",

--- a/packages/itwin/ec3-widget/package.json
+++ b/packages/itwin/ec3-widget/package.json
@@ -36,6 +36,7 @@
     "extract-api": "betools extract-api --entry=ec3-widget-react --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "rebuild": "npm run clean && npm run build",
     "test": "jest",
     "test:watch": "jest --watch "

--- a/packages/itwin/geo-tools/package.json
+++ b/packages/itwin/geo-tools/package.json
@@ -35,6 +35,7 @@
     "//cover": "nyc npm -s test",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "pseudolocalize": "betools pseudolocalize --englishDir=./src/public/locales/en --out=./src/public/locales/en-PSEUDO",
     "test": "mocha \"./lib/cjs/test/**/*.test.js\""
   },

--- a/packages/itwin/grouping-mapping-widget/package.json
+++ b/packages/itwin/grouping-mapping-widget/package.json
@@ -34,6 +34,7 @@
     "dual-build": "npm run -s build:cjs && npm run -s build:esm",
     "extract-api": "betools extract-api --entry=grouping-mapping-widget --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
+    "audit": "pnpm audit --audit-level=high",
     "lint:fix": "npm run lint -- --fix",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO",
     "rebuild": "npm run clean && npm run build",

--- a/packages/itwin/imodel-react-hooks/package.json
+++ b/packages/itwin/imodel-react-hooks/package.json
@@ -33,6 +33,7 @@
     "cover": "npm test -- --coverage",
     "lint": "",
     "lint:fix": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2 --fix",
+    "audit": "pnpm audit --audit-level=high",
     "start": "",
     "test": "jest"
   },

--- a/packages/itwin/map-layers/package.json
+++ b/packages/itwin/map-layers/package.json
@@ -18,6 +18,7 @@
     "docs": "",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lintfix": "eslint --fix -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
+    "audit": "pnpm audit --audit-level=high",
     "pseudolocalize": "betools pseudolocalize --englishDir=./src/public/locales/en --out=./src/public/locales/en-PSEUDO",
     "test": "vitest --run",
     "rebuild": "npm run -s clean && npm run -s build"

--- a/packages/itwin/measure-tools/package.json
+++ b/packages/itwin/measure-tools/package.json
@@ -25,6 +25,7 @@
     "rebuild": "npm run clean && npm run build",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "lint:table": "eslint ./**/*.{ts,tsx} 1>&2 -f ./node_modules/@itwin/eslint-plugin/dist/formatters/no-internal-summary-with-table.js",
     "test": "vitest run",
     "cover": "vitest run --coverage",

--- a/packages/itwin/one-click-lca-widget/package.json
+++ b/packages/itwin/one-click-lca-widget/package.json
@@ -33,6 +33,7 @@
     "dual-build": "npm run -s build:cjs && npm run -s build:esm",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "rebuild": "npm run clean && npm run build",
     "test": "jest",
     "cover": "nyc npm test"

--- a/packages/itwin/property-grid/package.json
+++ b/packages/itwin/property-grid/package.json
@@ -45,6 +45,7 @@
     "lint:eslint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:stylelint": "stylelint \"./src/**/*.scss\"",
     "lint:fix": "npm run lint:eslint -- --fix && npm run lint:stylelint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test:dev": "cross-env NODE_OPTIONS=\"--import ../../../node-hooks/ignore-styles/register.cjs\" mocha --enable-source-maps --config ./.mocharc.json",
     "test": "npm run test:dev -- --parallel --jobs=4",

--- a/packages/itwin/reports-config-widget/package.json
+++ b/packages/itwin/reports-config-widget/package.json
@@ -36,6 +36,7 @@
     "extract-api": "betools extract-api --entry=reports-config-widget-react --apiReportFolder=./api --apiReportTempFolder=./api/temp --apiSummaryFolder=./api",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run lint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO",
     "rebuild": "npm run clean && npm run build",
     "test": "jest",

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -44,6 +44,7 @@
     "lint:eslint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:stylelint": "stylelint \"./src/**/*.scss\"",
     "lint:fix": "npm run lint:eslint -- --fix && npm run lint:stylelint -- --fix",
+    "audit": "pnpm audit --audit-level=high",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test:dev": "node --experimental-test-module-mocks --enable-source-maps --import ../../../node-hooks/ignore-styles/register.cjs ./node_modules/mocha/bin/mocha.js --config ./.mocharc.json",
     "test": "npm run test:dev -- --parallel --jobs=4",


### PR DESCRIPTION
This [config](https://github.com/iTwin/viewer-components-react/blame/master/.npmrc#L7) means the pnpm audit task in the repo only runs against the root lockfile, not invidivual lockfiles across the monorepo.

(At time of writing) We have 63 high vulnerabilities and 1 critical to fix.