### PR TITLE
Fix flaky tests

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -29,7 +29,7 @@ import {
   insertSubCategory,
   insertSubModel,
 } from "../../../IModelUtils.js";
-import { TestUtils, waitFor } from "../../../TestUtils.js";
+import { TestUtils } from "../../../TestUtils.js";
 import { createIModelAccess } from "../../Common.js";
 import {
   createCategoryHierarchyNode,
@@ -200,14 +200,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-visible",
+        });
       });
 
       it("showing definition container makes it and all of its contained elements visible and doesn't affect non contained definition containers", async function () {
@@ -253,22 +251,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot2.id]: "hidden",
-              [keys.definitionContainerRoot.id]: "visible",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.category2.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.indirectSubCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot2.id]: "hidden",
+            [keys.definitionContainerRoot.id]: "visible",
+            [keys.definitionContainerChild.id]: "visible",
+            [keys.category2.id]: "hidden",
+            [keys.indirectCategory.id]: "visible",
+            [keys.subCategory2.id]: "hidden",
+            [keys.indirectSubCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more direct child categories", async function () {
@@ -297,19 +293,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.directCategory.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "visible",
+            [keys.directCategory.id]: "hidden",
+            [keys.indirectCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more definition containers", async function () {
@@ -340,20 +334,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.definitionContainerChild2.id]: "hidden",
-              [keys.indirectCategory2.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "visible",
+            [keys.definitionContainerChild2.id]: "hidden",
+            [keys.indirectCategory2.id]: "hidden",
+            [keys.indirectCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing child definition container makes it, all of its contained elements and its parent definition container visible", async function () {
@@ -385,14 +377,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-visible",
+        });
       });
     });
 
@@ -421,14 +411,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-visible",
+        });
       });
 
       it("showing category makes it, all of its contained subCategories visible and doesn't affect other categories", async function () {
@@ -462,19 +450,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category2.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category2.id]: "hidden",
+            [keys.category.id]: "visible",
+            [keys.subCategory2.id]: "hidden",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing category makes it, all of its contained subCategories visible and doesn't affect non related definition container", async function () {
@@ -512,20 +498,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainer.id]: "hidden",
-              [keys.category2.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainer.id]: "hidden",
+            [keys.category2.id]: "hidden",
+            [keys.category.id]: "visible",
+            [keys.subCategory2.id]: "hidden",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing category makes it and all of its subcategories visible, and parent container partially visible if it has more direct child categories", async function () {
@@ -563,20 +547,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.category2.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.category2.id]: "hidden",
+            [keys.category.id]: "visible",
+            [keys.subCategory2.id]: "hidden",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing category makes it and all of its subCategories visible, and parent container partially visible if it has more definition containers", async function () {
@@ -611,20 +593,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "hidden",
-              [keys.indirectCategory.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "hidden",
+            [keys.indirectCategory.id]: "hidden",
+            [keys.category.id]: "visible",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
     });
 
@@ -659,18 +639,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "visible",
+            [keys.subCategory2.id]: "hidden",
+          },
+        });
       });
 
       it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect other categories", async function () {
@@ -699,18 +677,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category2.id]: "hidden",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category2.id]: "hidden",
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing subCategory makes it visible and parents partially visible", async function () {
@@ -740,18 +716,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
 
       it("showing subCategory makes it visible and doesn't affect non related definition containers", async function () {
@@ -788,20 +762,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "hidden",
-              [keys.categoryOfDefinitionContainer.id]: "hidden",
-              [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "hidden",
+            [keys.categoryOfDefinitionContainer.id]: "hidden",
+            [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "visible",
+          },
+        });
       });
     });
 
@@ -834,14 +806,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-hidden",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-hidden",
+        });
       });
     });
 
@@ -880,14 +850,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: "all-visible",
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
         });
 
         it("showing definition container makes it and all of its contained elements visible and doesn't affect non contained definition containers", async function () {
@@ -937,24 +905,22 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot2.id]: "hidden",
-                [keys.definitionContainerRoot.id]: "visible",
-                [keys.definitionContainerChild.id]: "visible",
-                [keys.category2.id]: "hidden",
-                [keys.element2.id]: "hidden",
-                [keys.indirectCategory.id]: "visible",
-                [keys.indirectElement.id]: "visible",
-                [keys.subCategory2.id]: "hidden",
-                [keys.indirectSubCategory.id]: "visible",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot2.id]: "hidden",
+              [keys.definitionContainerRoot.id]: "visible",
+              [keys.definitionContainerChild.id]: "visible",
+              [keys.category2.id]: "hidden",
+              [keys.element2.id]: "hidden",
+              [keys.indirectCategory.id]: "visible",
+              [keys.indirectElement.id]: "visible",
+              [keys.subCategory2.id]: "hidden",
+              [keys.indirectSubCategory.id]: "visible",
+            },
+          });
         });
 
         it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more direct child categories", async function () {
@@ -984,21 +950,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.definitionContainerChild.id]: "visible",
-                [keys.directCategory.id]: "hidden",
-                [keys.indirectCategory.id]: "visible",
-                [keys.indirectElement.id]: "visible",
-                [keys.directElement.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.definitionContainerChild.id]: "visible",
+              [keys.directCategory.id]: "hidden",
+              [keys.indirectCategory.id]: "visible",
+              [keys.indirectElement.id]: "visible",
+              [keys.directElement.id]: "hidden",
+            },
+          });
         });
 
         it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more definition containers", async function () {
@@ -1039,22 +1003,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.definitionContainerChild.id]: "visible",
-                [keys.definitionContainerChild2.id]: "hidden",
-                [keys.indirectCategory2.id]: "hidden",
-                [keys.indirectCategory.id]: "visible",
-                [keys.indirectElement.id]: "visible",
-                [keys.indirectElement2.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.definitionContainerChild.id]: "visible",
+              [keys.definitionContainerChild2.id]: "hidden",
+              [keys.indirectCategory2.id]: "hidden",
+              [keys.indirectCategory.id]: "visible",
+              [keys.indirectElement.id]: "visible",
+              [keys.indirectElement2.id]: "hidden",
+            },
+          });
         });
 
         it("showing child definition container makes it, all of its contained elements and its parent definition container visible", async function () {
@@ -1087,14 +1049,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: "all-visible",
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
         });
       });
 
@@ -1124,14 +1084,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: "all-visible",
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
         });
 
         it("showing category makes it, all of its contained subCategories and elements visible and doesn't affect other categories", async function () {
@@ -1166,21 +1124,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.category2.id]: "hidden",
-                [keys.category.id]: "visible",
-                [keys.element.id]: "visible",
-                [keys.element2.id]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-                [keys.subCategory.id]: "visible",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.category2.id]: "hidden",
+              [keys.category.id]: "visible",
+              [keys.element.id]: "visible",
+              [keys.element2.id]: "hidden",
+              [keys.subCategory2.id]: "hidden",
+              [keys.subCategory.id]: "visible",
+            },
+          });
         });
 
         it("showing category makes it, all of its contained subCategories and elements visible and doesn't affect non related definition container", async function () {
@@ -1219,22 +1175,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainer.id]: "hidden",
-                [keys.category2.id]: "hidden",
-                [keys.category.id]: "visible",
-                [keys.subCategory2.id]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "visible",
-                [keys.element2.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainer.id]: "hidden",
+              [keys.category2.id]: "hidden",
+              [keys.category.id]: "visible",
+              [keys.subCategory2.id]: "hidden",
+              [keys.subCategory.id]: "visible",
+              [keys.element.id]: "visible",
+              [keys.element2.id]: "hidden",
+            },
+          });
         });
 
         it("showing category makes it, all of its subcategories and elements visible, and parent container partially visible if it has more direct child categories", async function () {
@@ -1273,22 +1227,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.category2.id]: "hidden",
-                [keys.category.id]: "visible",
-                [keys.subCategory2.id]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.element2.id]: "hidden",
-                [keys.element.id]: "visible",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.category2.id]: "hidden",
+              [keys.category.id]: "visible",
+              [keys.subCategory2.id]: "hidden",
+              [keys.subCategory.id]: "visible",
+              [keys.element2.id]: "hidden",
+              [keys.element.id]: "visible",
+            },
+          });
         });
 
         it("showing category makes it, all of its subCategories and elements visible, and parent container partially visible if it has more definition containers", async function () {
@@ -1324,22 +1276,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.definitionContainerChild.id]: "hidden",
-                [keys.indirectCategory.id]: "hidden",
-                [keys.category.id]: "visible",
-                [keys.subCategory.id]: "visible",
-                [keys.indirectElement.id]: "hidden",
-                [keys.element.id]: "visible",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.definitionContainerChild.id]: "hidden",
+              [keys.indirectCategory.id]: "hidden",
+              [keys.category.id]: "visible",
+              [keys.subCategory.id]: "visible",
+              [keys.indirectElement.id]: "hidden",
+              [keys.element.id]: "visible",
+            },
+          });
         });
       });
 
@@ -1374,19 +1324,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [keys.subCategory2.id]: "hidden",
-                [keys.element.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "visible",
+              [keys.subCategory2.id]: "hidden",
+              [keys.element.id]: "hidden",
+            },
+          });
         });
 
         it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect elements of other categories", async function () {
@@ -1416,20 +1364,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.category2.id]: "hidden",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-                [keys.element2.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.category2.id]: "hidden",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "visible",
+              [keys.element.id]: "hidden",
+              [keys.element2.id]: "hidden",
+            },
+          });
         });
 
         it("showing subCategory makes it visible and parents partially visible", async function () {
@@ -1460,19 +1406,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "visible",
+              [keys.element.id]: "hidden",
+            },
+          });
         });
 
         it("showing subCategory makes it visible and doesn't affect non related definition containers", async function () {
@@ -1519,22 +1463,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "hidden",
-                [keys.categoryOfDefinitionContainer.id]: "hidden",
-                [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-                [keys.elementOfDefinitionContainer.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "hidden",
+              [keys.categoryOfDefinitionContainer.id]: "hidden",
+              [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "visible",
+              [keys.element.id]: "hidden",
+              [keys.elementOfDefinitionContainer.id]: "hidden",
+            },
+          });
         });
       });
 
@@ -1573,20 +1515,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
             true,
           );
 
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-                [keys.element.id]: "visible",
-                [keys.element2.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "hidden",
+              [keys.subCategory2.id]: "hidden",
+              [keys.element.id]: "visible",
+              [keys.element2.id]: "hidden",
+            },
+          });
         });
 
         it("showing element makes it visible and its parent category partially visible, and doesn't affect other categories or subCategories", async function () {
@@ -1619,20 +1559,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
             createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
             true,
           );
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.category2.id]: "hidden",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "hidden",
-                [keys.element.id]: "visible",
-                [keys.element2.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.category2.id]: "hidden",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "hidden",
+              [keys.element.id]: "visible",
+              [keys.element2.id]: "hidden",
+            },
+          });
         });
 
         it("showing element makes it visible and parents partially visible", async function () {
@@ -1666,19 +1604,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
             createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
             true,
           );
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "partial",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "hidden",
-                [keys.element.id]: "visible",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "partial",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "hidden",
+              [keys.element.id]: "visible",
+            },
+          });
         });
 
         it("showing subCategory makes it visible and doesn't affect non related definition containers", async function () {
@@ -1725,22 +1661,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await waitFor(async () =>
-            validateHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              expectations: {
-                [keys.definitionContainerRoot.id]: "hidden",
-                [keys.categoryOfDefinitionContainer.id]: "hidden",
-                [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-                [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-                [keys.elementOfDefinitionContainer.id]: "hidden",
-              },
-            }),
-          );
+          await validateHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.definitionContainerRoot.id]: "hidden",
+              [keys.categoryOfDefinitionContainer.id]: "hidden",
+              [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+              [keys.category.id]: "partial",
+              [keys.subCategory.id]: "visible",
+              [keys.element.id]: "hidden",
+              [keys.elementOfDefinitionContainer.id]: "hidden",
+            },
+          });
         });
       });
 
@@ -2007,23 +1941,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 expectations: "all-hidden",
               });
               await handler.changeVisibility(nodeToChangeVisibility, true);
-              await waitFor(async () =>
-                validateHierarchyVisibility({
-                  provider,
-                  handler,
-                  viewport,
-                  expectations: expectations(createdIds),
-                }),
-              );
+              await validateHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                expectations: expectations(createdIds),
+              });
               await handler.changeVisibility(nodeToChangeVisibility, false);
-              await waitFor(async () =>
-                validateHierarchyVisibility({
-                  provider,
-                  handler,
-                  viewport,
-                  expectations: "all-hidden",
-                }),
-              );
+              await validateHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                expectations: "all-hidden",
+              });
             });
           });
         });
@@ -2083,14 +2013,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-hidden",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-hidden",
+        });
       });
 
       it("hiding definition container makes it and all of its contained elements hidden and doesn't affect non contained definition containers", async function () {
@@ -2131,22 +2059,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot2.id]: "visible",
-              [keys.definitionContainerRoot.id]: "hidden",
-              [keys.definitionContainerChild.id]: "hidden",
-              [keys.indirectCategory.id]: "hidden",
-              [keys.category2.id]: "visible",
-              [keys.indirectSubCategory.id]: "hidden",
-              [keys.subCategory2.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot2.id]: "visible",
+            [keys.definitionContainerRoot.id]: "hidden",
+            [keys.definitionContainerChild.id]: "hidden",
+            [keys.indirectCategory.id]: "hidden",
+            [keys.category2.id]: "visible",
+            [keys.indirectSubCategory.id]: "hidden",
+            [keys.subCategory2.id]: "visible",
+          },
+        });
       });
 
       it("hiding definition container makes it and all of its contained elements hidden, and parent container partially visible if it has more direct child categories", async function () {
@@ -2170,19 +2096,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "hidden",
-              [keys.indirectCategory.id]: "hidden",
-              [keys.directCategory.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "hidden",
+            [keys.indirectCategory.id]: "hidden",
+            [keys.directCategory.id]: "visible",
+          },
+        });
       });
 
       it("hiding definition container makes it and all of its contained elements hidden, and parent container partially visible if it has more definition containers", async function () {
@@ -2208,20 +2132,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "hidden",
-              [keys.definitionContainerChild2.id]: "visible",
-              [keys.indirectCategory.id]: "hidden",
-              [keys.indirectCategory2.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "hidden",
+            [keys.definitionContainerChild2.id]: "visible",
+            [keys.indirectCategory.id]: "hidden",
+            [keys.indirectCategory2.id]: "visible",
+          },
+        });
       });
 
       it("hiding child definition container makes it, all of its contained elements and its parent definition container hidden", async function () {
@@ -2248,14 +2170,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-hidden",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-hidden",
+        });
       });
     });
 
@@ -2279,14 +2199,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-hidden",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-hidden",
+        });
       });
 
       it("hiding category makes it, all of its contained subCategories hidden and doesn't affect other categories", async function () {
@@ -2315,19 +2233,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category.id]: "hidden",
-              [keys.category2.id]: "visible",
-              [keys.subCategory2.id]: "visible",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category.id]: "hidden",
+            [keys.category2.id]: "visible",
+            [keys.subCategory2.id]: "visible",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
 
       it("hiding category makes it, all of its contained subCategories hidden and doesn't affect non related definition container", async function () {
@@ -2360,20 +2276,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainer.id]: "visible",
-              [keys.category2.id]: "visible",
-              [keys.category.id]: "hidden",
-              [keys.subCategory2.id]: "visible",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainer.id]: "visible",
+            [keys.category2.id]: "visible",
+            [keys.category.id]: "hidden",
+            [keys.subCategory2.id]: "visible",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
 
       it("hiding category makes it and all of its subcategories hidden, and parent container partially visible if it has more direct child categories", async function () {
@@ -2406,20 +2320,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "hidden",
-              [keys.category2.id]: "visible",
-              [keys.subCategory.id]: "hidden",
-              [keys.subCategory2.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.category.id]: "hidden",
+            [keys.category2.id]: "visible",
+            [keys.subCategory.id]: "hidden",
+            [keys.subCategory2.id]: "visible",
+          },
+        });
       });
 
       it("hiding category makes it and all of its subCategories hidden, and parent container partially visible if it has more definition containers", async function () {
@@ -2449,20 +2361,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.category.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.definitionContainerChild.id]: "visible",
+            [keys.category.id]: "hidden",
+            [keys.indirectCategory.id]: "visible",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
     });
 
@@ -2491,18 +2401,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [keys.subCategory2.id]: "visible",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "hidden",
+            [keys.subCategory2.id]: "visible",
+          },
+        });
       });
 
       it("hiding subCategory makes it hidden and its parent category partially visible, and doesn't affect other categories", async function () {
@@ -2526,18 +2434,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.category.id]: "partial",
-              [keys.category2.id]: "visible",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.category.id]: "partial",
+            [keys.category2.id]: "visible",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
 
       it("hiding subCategory makes it hidden and parents partially visible", async function () {
@@ -2562,18 +2468,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "partial",
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
 
       it("hiding subCategory makes it hidden and doesn't affect non related definition containers", async function () {
@@ -2605,20 +2509,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: {
-              [keys.definitionContainerRoot.id]: "visible",
-              [keys.categoryOfDefinitionContainer.id]: "visible",
-              [keys.subCategoryOfDefinitionContainer.id]: "visible",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-            },
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: {
+            [keys.definitionContainerRoot.id]: "visible",
+            [keys.categoryOfDefinitionContainer.id]: "visible",
+            [keys.subCategoryOfDefinitionContainer.id]: "visible",
+            [keys.category.id]: "partial",
+            [keys.subCategory.id]: "hidden",
+          },
+        });
       });
     });
 
@@ -2645,14 +2547,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await waitFor(async () =>
-          validateHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          }),
-        );
+        await validateHierarchyVisibility({
+          provider,
+          handler,
+          viewport,
+          expectations: "all-visible",
+        });
       });
     });
   });

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/VisibilityValidation.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/VisibilityValidation.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 import { EMPTY, expand, from, mergeMap } from "rxjs";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
+import { waitFor } from "@testing-library/react";
 import { CategoriesTreeNode } from "../../../../tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNode.js";
 import { toVoidPromise } from "../../../../tree-widget-react/components/trees/common/Rxjs.js";
 
@@ -94,7 +95,7 @@ export async function validateHierarchyVisibility({
   await toVoidPromise(
     from(provider.getNodes({ parentNode: undefined })).pipe(
       expand((node) => (node.children ? provider.getNodes({ parentNode: node }) : EMPTY)),
-      mergeMap(async (node) => validateNodeVisibility({ ...props, node })),
+      mergeMap(async (node) => waitFor(async () => validateNodeVisibility({ ...props, node }))),
     ),
   );
 }

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/VisibilityValidation.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/VisibilityValidation.ts
@@ -7,6 +7,7 @@ import { assert, expect } from "chai";
 import { expand, from, mergeMap } from "rxjs";
 import { PerModelCategoryVisibility } from "@itwin/core-frontend";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
+import { waitFor } from "@testing-library/react";
 import { toVoidPromise } from "../../../../tree-widget-react/components/trees/common/Rxjs.js";
 import { ModelsTreeNode } from "../../../../tree-widget-react/components/trees/models-tree/internal/ModelsTreeNode.js";
 
@@ -123,7 +124,7 @@ export async function validateHierarchyVisibility({
   await toVoidPromise(
     from(provider.getNodes({ parentNode: undefined })).pipe(
       expand((node) => provider.getNodes({ parentNode: node })),
-      mergeMap(async (node) => validateNodeVisibility({ ...props, node })),
+      mergeMap(async (node) => waitFor(async () => validateNodeVisibility({ ...props, node }))),
     ),
   );
 }


### PR DESCRIPTION
closes #1230 
Following https://github.com/iTwin/viewer-components-react/pull/1265#issuecomment-2768171226
Tried a few things to reproduce the issue:
1. Tried running only those two specific tests 400 times, all of them passed.
2. Tried running all the tests in that specific file (5 times in the pipeline) that those two tests are in, all of them passed.
3. Tried running all the tree-widget tests (20 times) in the pipeline. It seems that only on Windows it started to fail (once after 4 tries, other time after 5 times). On Mac and Linux it passed every time.
4. Tried to reproduce this locally, but couldn't.

Currently, `waitFor` is used after node's visibility is changed and is used to wrap a function (`validateHierarchyVisibility`) that validates visibility of all nodes in the hierarchy. Moved `waitFor` to wrap a function (`validateNodeVisibility`) that validates visibility for a single node.