### PR TITLE
Categories tree reacting to Category visibility changes from Models tree

### DIFF
--- a/change/@itwin-tree-widget-react-7e464ea2-07d4-4e70-9299-c05964263b49.json
+++ b/change/@itwin-tree-widget-react-7e464ea2-07d4-4e70-9299-c05964263b49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Categories tree now reacts to Category visibility changes from Models tree.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-7e464ea2-07d4-4e70-9299-c05964263b49.json
+++ b/change/@itwin-tree-widget-react-7e464ea2-07d4-4e70-9299-c05964263b49.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Categories tree now reacts to Category visibility changes from Models tree.",
+  "comment": "Fixed Categories tree not reacting to Category display changes from Models tree, when they're made on per-model category overrides.",
   "packageName": "@itwin/tree-widget-react",
   "email": "100586436+JonasDov@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-f89c1633-df8e-4e89-8846-18bc29404924.json
+++ b/change/@itwin-tree-widget-react-f89c1633-df8e-4e89-8846-18bc29404924.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Categories tree now shows correct visibilities based on perModelCategoryVisibility.Override",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-f89c1633-df8e-4e89-8846-18bc29404924.json
+++ b/change/@itwin-tree-widget-react-f89c1633-df8e-4e89-8846-18bc29404924.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Categories tree now shows correct visibilities based on perModelCategoryVisibility.Override",
-  "packageName": "@itwin/tree-widget-react",
-  "email": "100586436+JonasDov@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
@@ -55,11 +55,11 @@ describe("CategoriesVisibilityHandler", () => {
     TestUtils.terminate();
   });
 
-  async function createCommonProps({ imodel, categoryIds }: { imodel: IModelConnection; categoryIds: Id64Array }) {
+  async function createCommonProps({ imodel, categoryIds, modelIds }: { imodel: IModelConnection; categoryIds: Id64Array; modelIds: Id64Array }) {
     const imodelAccess = createIModelAccess(imodel);
     const idsCache = new CategoriesTreeIdsCache(imodelAccess, "3d");
     const viewport = OffScreenViewport.create({
-      view: await createViewState(imodel, categoryIds),
+      view: await createViewState(imodel, categoryIds, modelIds),
       viewRect: new ViewRect(),
     });
     return {
@@ -81,8 +81,8 @@ describe("CategoriesVisibilityHandler", () => {
     });
   }
 
-  async function createVisibilityTestData({ imodel, categoryIds }: { imodel: IModelConnection; categoryIds: Id64Array }) {
-    const commonProps = await createCommonProps({ imodel, categoryIds });
+  async function createVisibilityTestData({ imodel, categoryIds, modelIds }: { imodel: IModelConnection; categoryIds: Id64Array; modelIds: Id64Array }) {
+    const commonProps = await createCommonProps({ imodel, categoryIds, modelIds });
     const handler = new CategoriesVisibilityHandler({ idsCache: commonProps.idsCache, viewport: commonProps.viewport });
     const provider = createProvider({ ...commonProps });
     return {
@@ -114,10 +114,10 @@ describe("CategoriesVisibilityHandler", () => {
 
       using visibilityTestData = await createVisibilityTestData({
         imodel,
-        categoryIds: getCategoryIds(keys),
+        ...getModelAndCategoryIds(keys),
       });
       const { handler, provider, viewport } = visibilityTestData;
-      setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+      setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
       await validateHierarchyVisibility({
         provider,
@@ -153,10 +153,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
         await validateHierarchyVisibility({
@@ -204,10 +204,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
         await validateHierarchyVisibility({
@@ -245,10 +245,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
@@ -285,10 +285,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
@@ -327,10 +327,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
@@ -360,10 +360,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -398,10 +398,10 @@ describe("CategoriesVisibilityHandler", () => {
         const { imodel, ...keys } = buildIModelResult;
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -446,10 +446,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -495,10 +495,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -541,10 +541,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -586,10 +586,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
@@ -625,10 +625,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -664,10 +664,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -710,10 +710,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         using visibilityTestData = await createVisibilityTestData({
           imodel,
-          categoryIds: getCategoryIds(keys),
+          ...getModelAndCategoryIds(keys),
         });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -743,9 +743,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), models: [] });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Show);
 
@@ -770,9 +770,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), models: [] });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Show);
 
@@ -799,7 +799,7 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
         setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), categories: [{ id: keys.category.id, visible: true }] });
 
@@ -826,7 +826,7 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
         setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), categories: [{ id: keys.category.id, visible: true }] });
 
@@ -859,9 +859,9 @@ describe("CategoriesVisibilityHandler", () => {
 
       const { imodel, ...keys } = buildIModelResult;
 
-      using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+      using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
       const { handler, provider, viewport } = visibilityTestData;
-      setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+      setupInitialDisplayState({ viewport });
 
       await validateHierarchyVisibility({
         provider,
@@ -895,9 +895,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
         await validateHierarchyVisibility({
@@ -944,9 +944,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
         await validateHierarchyVisibility({
@@ -983,9 +983,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1021,9 +1021,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1061,9 +1061,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1092,9 +1092,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1128,9 +1128,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1173,9 +1173,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1219,9 +1219,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1262,9 +1262,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1304,9 +1304,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1339,9 +1339,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1375,9 +1375,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1418,9 +1418,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         await validateHierarchyVisibility({
           provider,
@@ -1456,9 +1456,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Hide);
 
@@ -1483,9 +1483,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Hide);
 
@@ -1512,9 +1512,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         viewport.changeModelDisplay(keys.physicalModel.id, false);
 
@@ -1539,9 +1539,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
+        using visibilityTestData = await createVisibilityTestData({ imodel, ...getModelAndCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+        setupInitialDisplayState({ viewport });
 
         viewport.changeModelDisplay(keys.physicalModel.id, false);
 
@@ -1558,7 +1558,7 @@ describe("CategoriesVisibilityHandler", () => {
   });
 });
 
-async function createViewState(iModel: IModelConnection, categoryIds: Id64Array) {
+async function createViewState(iModel: IModelConnection, categoryIds: Id64Array, modelIds: Id64Array) {
   const model = IModel.dictionaryId;
   const viewState = SpatialViewState.createFromProps(
     {
@@ -1572,7 +1572,7 @@ async function createViewState(iModel: IModelConnection, categoryIds: Id64Array)
         displayStyleId: "",
       },
       modelSelectorProps: {
-        models: [],
+        models: modelIds,
         code: Code.createEmpty(),
         model,
         classFullName: "BisCore:ModelSelector",
@@ -1668,24 +1668,15 @@ function createHiddenTestData(keys: { [key: string]: InstanceKey }) {
   return { categories, subCategories, elements, models };
 }
 
-function createVisibleModels(keys: { [key: string]: InstanceKey }) {
-  const models = new Array<VisibilityInfo>();
-  for (const key of Object.values(keys)) {
-    if (key.className.toLowerCase().includes("model")) {
-      models.push({ id: key.id, visible: true });
-    }
-  }
-  return { models };
-}
-
 function getDefaultSubCategoryId(categoryId: Id64String) {
   const categoryIdNumber = Number.parseInt(categoryId, 16);
   const subCategoryId = `0x${(categoryIdNumber + 1).toString(16)}`;
   return subCategoryId;
 }
 
-function getCategoryIds(keys: { [key: string]: InstanceKey }) {
+function getModelAndCategoryIds(keys: { [key: string]: InstanceKey }) {
   const categoryIds = new Array<Id64String>();
+  const modelIds = new Array<Id64String>();
   for (const key of Object.values(keys)) {
     if (key.className.toLowerCase().includes("subcategory")) {
       continue;
@@ -1694,6 +1685,9 @@ function getCategoryIds(keys: { [key: string]: InstanceKey }) {
       categoryIds.push(key.id);
       continue;
     }
+    if (key.className.toLowerCase().includes("model")) {
+      modelIds.push(key.id);
+    }
   }
-  return categoryIds;
+  return { categoryIds, modelIds };
 }

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
@@ -81,19 +81,10 @@ describe("CategoriesVisibilityHandler", () => {
     });
   }
 
-  async function createVisibilityTestData({
-    imodel,
-    categoryIds,
-    testDataVisibilityInitializer,
-  }: {
-    imodel: IModelConnection;
-    testDataVisibilityInitializer?: TestDataVisibilityInitializer;
-    categoryIds: Id64Array;
-  }) {
+  async function createVisibilityTestData({ imodel, categoryIds }: { imodel: IModelConnection; categoryIds: Id64Array }) {
     const commonProps = await createCommonProps({ imodel, categoryIds });
     const handler = new CategoriesVisibilityHandler({ idsCache: commonProps.idsCache, viewport: commonProps.viewport });
     const provider = createProvider({ ...commonProps });
-    testDataVisibilityInitializer?.initialize(commonProps.viewport);
     return {
       handler,
       provider,
@@ -120,13 +111,13 @@ describe("CategoriesVisibilityHandler", () => {
       });
 
       const { imodel, ...keys } = buildIModelResult;
-      const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createHiddenTestData(keys));
+
       using visibilityTestData = await createVisibilityTestData({
         imodel,
         categoryIds: getCategoryIds(keys),
-        testDataVisibilityInitializer,
       });
       const { handler, provider, viewport } = visibilityTestData;
+      setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
       await validateHierarchyVisibility({
         provider,
@@ -160,13 +151,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
         await validateHierarchyVisibility({
@@ -212,13 +202,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
         await validateHierarchyVisibility({
@@ -254,13 +243,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
@@ -295,13 +283,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
@@ -338,13 +325,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
         await validateHierarchyVisibility({
           provider,
@@ -371,13 +358,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -410,13 +396,12 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -458,13 +443,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -507,13 +492,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -553,13 +538,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
         await validateHierarchyVisibility({
@@ -598,13 +583,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
@@ -637,13 +622,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -676,13 +661,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -722,13 +707,13 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         using visibilityTestData = await createVisibilityTestData({
           imodel,
           categoryIds: getCategoryIds(keys),
-          testDataVisibilityInitializer,
         });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
         await validateHierarchyVisibility({
@@ -758,9 +743,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
+
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Show);
 
         await validateHierarchyVisibility({
@@ -784,9 +770,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({ ...createHiddenTestData(keys), ...createVisibleModels(keys) });
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), ...createVisibleModels(keys) });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Show);
 
@@ -813,12 +799,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({
-          ...createHiddenTestData(keys),
-          categories: [{ id: keys.category.id, visible: true }],
-        });
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), categories: [{ id: keys.category.id, visible: true }] });
 
         await viewport.addViewedModels(keys.physicalModel.id);
 
@@ -843,12 +826,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer({
-          ...createHiddenTestData(keys),
-          categories: [{ id: keys.category.id, visible: true }],
-        });
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createHiddenTestData(keys), categories: [{ id: keys.category.id, visible: true }] });
+
         await viewport.addViewedModels(keys.physicalModel.id);
 
         await validateHierarchyVisibility({
@@ -878,9 +859,9 @@ describe("CategoriesVisibilityHandler", () => {
 
       const { imodel, ...keys } = buildIModelResult;
 
-      const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-      using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+      using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
       const { handler, provider, viewport } = visibilityTestData;
+      setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
       await validateHierarchyVisibility({
         provider,
@@ -913,9 +894,11 @@ describe("CategoriesVisibilityHandler", () => {
         });
 
         const { imodel, ...keys } = buildIModelResult;
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
         await validateHierarchyVisibility({
           provider,
@@ -961,9 +944,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
         await validateHierarchyVisibility({
@@ -1000,9 +983,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1038,9 +1021,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1078,9 +1061,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
         await validateHierarchyVisibility({
@@ -1109,9 +1092,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1145,9 +1128,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1190,9 +1173,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1236,9 +1219,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1279,9 +1262,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1321,9 +1304,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1356,9 +1339,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1392,9 +1375,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
         await validateHierarchyVisibility({
@@ -1435,9 +1418,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+
         await validateHierarchyVisibility({
           provider,
           handler,
@@ -1472,9 +1456,10 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
+
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Hide);
 
         await validateHierarchyVisibility({
@@ -1498,9 +1483,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         viewport.perModelCategoryVisibility.setOverride(keys.physicalModel.id, keys.category.id, PerModelCategoryVisibility.Override.Hide);
 
@@ -1527,9 +1512,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         viewport.changeModelDisplay(keys.physicalModel.id, false);
 
@@ -1554,9 +1539,9 @@ describe("CategoriesVisibilityHandler", () => {
 
         const { imodel, ...keys } = buildIModelResult;
 
-        const testDataVisibilityInitializer = new TestDataVisibilityInitializer(createVisibleModels(keys));
-        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys), testDataVisibilityInitializer });
+        using visibilityTestData = await createVisibilityTestData({ imodel, categoryIds: getCategoryIds(keys) });
         const { handler, provider, viewport } = visibilityTestData;
+        setupInitialDisplayState({ viewport, ...createVisibleModels(keys) });
 
         viewport.changeModelDisplay(keys.physicalModel.id, false);
 
@@ -1620,47 +1605,40 @@ interface VisibilityInfo {
   visible: boolean;
 }
 
-class TestDataVisibilityInitializer {
-  private _categories: Array<VisibilityInfo>;
-  private _subCategories: Array<VisibilityInfo>;
-  private _models: Array<VisibilityInfo>;
-  private _elements: Array<VisibilityInfo>;
-  constructor(props?: {
-    categories?: Array<VisibilityInfo>;
-    subCategories?: Array<VisibilityInfo>;
-    models?: Array<VisibilityInfo>;
-    elements?: Array<VisibilityInfo>;
-  }) {
-    this._categories = props?.categories ?? [];
-    this._subCategories = props?.subCategories ?? [];
-    this._models = props?.models ?? [];
-    this._elements = props?.elements ?? [];
+function setupInitialDisplayState(props: {
+  viewport: Viewport;
+  categories?: Array<VisibilityInfo>;
+  subCategories?: Array<VisibilityInfo>;
+  models?: Array<VisibilityInfo>;
+  elements?: Array<VisibilityInfo>;
+}) {
+  const { viewport } = props;
+  const categories = props.categories ?? [];
+  const elements = props.elements ?? [];
+  const subCategories = props.subCategories ?? [];
+  const models = props.models ?? [];
+  for (const subCategoryInfo of subCategories) {
+    viewport.changeSubCategoryDisplay(subCategoryInfo.id, subCategoryInfo.visible);
+  }
+  for (const categoryInfo of categories) {
+    viewport.changeCategoryDisplay(categoryInfo.id, categoryInfo.visible, false);
   }
 
-  public initialize(viewport: Viewport): void {
-    for (const subCategoryInfo of this._subCategories) {
-      viewport.changeSubCategoryDisplay(subCategoryInfo.id, subCategoryInfo.visible);
+  for (const elementInfo of elements) {
+    if (elementInfo.visible) {
+      viewport.alwaysDrawn?.add(elementInfo.id);
+      continue;
     }
-    for (const categoryInfo of this._categories) {
-      viewport.changeCategoryDisplay(categoryInfo.id, categoryInfo.visible, false);
-    }
-
-    for (const elementInfo of this._elements) {
-      if (elementInfo.visible) {
-        viewport.alwaysDrawn?.add(elementInfo.id);
-        continue;
-      }
-      viewport.neverDrawn?.add(elementInfo.id);
-    }
-    if (!viewport.alwaysDrawn) {
-      viewport.setAlwaysDrawn(new Set(this._elements.filter(({ visible }) => visible).map(({ id }) => id)));
-    }
-    if (!viewport.neverDrawn) {
-      viewport.setNeverDrawn(new Set(this._elements.filter(({ visible }) => !visible).map(({ id }) => id)));
-    }
-    for (const modelInfo of this._models) {
-      viewport.changeModelDisplay(modelInfo.id, modelInfo.visible);
-    }
+    viewport.neverDrawn?.add(elementInfo.id);
+  }
+  if (!viewport.alwaysDrawn) {
+    viewport.setAlwaysDrawn(new Set(elements.filter(({ visible }) => visible).map(({ id }) => id)));
+  }
+  if (!viewport.neverDrawn) {
+    viewport.setNeverDrawn(new Set(elements.filter(({ visible }) => !visible).map(({ id }) => id)));
+  }
+  for (const modelInfo of models) {
+    viewport.changeModelDisplay(modelInfo.id, modelInfo.visible);
   }
 }
 

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesVisibilityHandler.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../IModelUtils.js";
 import { TestUtils } from "../../../TestUtils.js";
 import { createIModelAccess } from "../../Common.js";
+// eslint-disable-next-line sort-imports
 import { createCategoryHierarchyNode as createModelsTreeCategoryHierarchyNode, createModelHierarchyNode } from "../../models-tree/Utils.js";
 import { createCategoryHierarchyNode, createDefinitionContainerHierarchyNode, createSubCategoryHierarchyNode } from "./Utils.js";
 import { validateHierarchyVisibility } from "./VisibilityValidation.js";

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -3,15 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from "chai";
-import sinon from "sinon";
-import { BeEvent } from "@itwin/core-bentley";
-import { PerModelCategoryVisibility } from "@itwin/core-frontend";
 
-import type { Id64Array, Id64String } from "@itwin/core-bentley";
-import type { Viewport } from "@itwin/core-frontend";
+import type { Id64String } from "@itwin/core-bentley";
 import type { NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
-import type { CategoriesTreeIdsCache } from "../../../../tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 
 /** @internal */
 export function createCategoryHierarchyNode(categoryId: Id64String, hasChildren = false): NonGroupingHierarchyNode {
@@ -60,115 +54,4 @@ export function createDefinitionContainerHierarchyNode(definitionContainerId: Id
       isDefinitionContainer: true,
     },
   };
-}
-
-
-interface ViewportStubValidation {
-  /**
-   * Checks if `changeCategoryDisplay` and `changeSubCategoryDisplay` get called with appropriate params
-   *
-   * @param categories categories parameters that `changeCategoryDisplay` should be called with
-   * @param subCategories subcategories parameters that `changeSubCategoryDisplay` should be called with
-   */
-  validateChangesCalls: (
-    categories: { categoriesToChange: Id64Array; isVisible: boolean; enableAllSubCategories: boolean }[],
-    subCategories: { subCategoryId: Id64String; isVisible: boolean }[],
-  ) => void;
-}
-
-/**
- * Creates a stubbed `Viewport` with that has only necessary properties defined for determening CategoriesTree visibility.
- *
- * This stub allows changing and saving the display of categories and subcategories
- * @returns stubbed `Viewport`
- */
-export async function createViewportStub(props: {
-  idsCache: CategoriesTreeIdsCache;
-  isVisibleOnInitialize: boolean;
-}): Promise<Viewport & ViewportStubValidation> {
-  const subCategoriesMap = new Map<Id64String, boolean>();
-
-  const categoriesMap = new Map<
-    Id64String,
-    {
-      subCategories: Id64Array;
-      isVisible: boolean;
-    }
-  >();
-
-  const { categories: categoriesFromCache } = await props.idsCache.getAllDefinitionContainersAndCategories();
-  for (const category of categoriesFromCache) {
-    const subCategoriesFromCache = await props.idsCache.getSubCategories(category);
-    subCategoriesFromCache.forEach((subCategoryId) => {
-      subCategoriesMap.set(subCategoryId, props.isVisibleOnInitialize);
-    });
-    categoriesMap.set(category, { isVisible: props.isVisibleOnInitialize, subCategories: subCategoriesFromCache });
-  }
-  const changeCategoryDisplayStub = sinon.stub().callsFake((categoriesToChange: Id64Array, isVisible: boolean, enableAllSubCategories: boolean) => {
-    for (const category of categoriesToChange) {
-      const value = categoriesMap.get(category);
-      if (value) {
-        value.isVisible = isVisible;
-        if (enableAllSubCategories) {
-          for (const subCategory of value.subCategories) {
-            subCategoriesMap.set(subCategory, true);
-          }
-        }
-      }
-    }
-  });
-
-  const changeSubCategoryDisplayStub = sinon.stub().callsFake((subCategoryId: Id64String, isVisible: boolean) => {
-    subCategoriesMap.set(subCategoryId, isVisible);
-  });
-
-  return {
-    isSubCategoryVisible: sinon.stub().callsFake((subCategoryId: Id64String) => !!subCategoriesMap.get(subCategoryId)),
-    iModel: {
-      categories: {
-        getCategoryInfo: sinon.stub().callsFake(async (ids: Id64Array) => {
-          const subCategories = [];
-          for (const id of ids) {
-            const subCategoriesToUse = categoriesMap.get(id);
-            if (subCategoriesToUse !== undefined) {
-              subCategories.push(...subCategoriesToUse.subCategories);
-            }
-          }
-          return [
-            {
-              subCategories: subCategories.map((subCategory) => {
-                return {
-                  id: subCategory,
-                };
-              }),
-            },
-          ];
-        }),
-      },
-    },
-    view: {
-      viewsCategory: sinon.stub().callsFake((categoryId: Id64String) => !!categoriesMap.get(categoryId)?.isVisible),
-    },
-    changeSubCategoryDisplay: changeSubCategoryDisplayStub,
-    changeCategoryDisplay: changeCategoryDisplayStub,
-    perModelCategoryVisibility: {
-      getOverride: sinon.fake.returns(PerModelCategoryVisibility.Override.None),
-      setOverride: sinon.fake(),
-      clearOverrides: sinon.fake(),
-      *[Symbol.iterator]() {},
-    },
-    onDisplayStyleChanged: new BeEvent<() => void>(),
-    onViewedCategoriesChanged: new BeEvent<() => void>(),
-    validateChangesCalls(
-      categoriesToValidate: { categoriesToChange: Id64Array; isVisible: boolean; enableAllSubCategories: boolean }[],
-      subCategories: { subCategoryId: Id64String; isVisible: boolean }[],
-    ) {
-      for (const category of categoriesToValidate) {
-        expect(changeCategoryDisplayStub).to.be.calledWith(category.categoriesToChange, category.isVisible, category.enableAllSubCategories);
-      }
-      for (const subCategory of subCategories) {
-        expect(changeSubCategoryDisplayStub).to.be.calledWith(subCategory.subCategoryId, subCategory.isVisible);
-      }
-    },
-  } as unknown as Viewport & ViewportStubValidation;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
@@ -183,7 +183,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     let hideOverrides = 0;
     let noOverrides = 0;
     const modelIds = categoryModelsMap.get(categoryId);
-    for (const modelId of modelIds) {
+    for (const modelId of modelIds ?? []) {
       if (this._viewport.view.viewsModel(modelId)) {
         const override = this._viewport.perModelCategoryVisibility.getOverride(modelId, categoryId);
         if (override === PerModelCategoryVisibility.Override.None) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
@@ -83,7 +83,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     }
 
     if (CategoriesTreeNode.isCategoryNode(node)) {
-      return this.changeCategoryVisibility(node, on);
+      return this.changeCategoryVisibility(CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node), on);
     }
 
     if (CategoriesTreeNode.isSubCategoryNode(node)) {
@@ -208,8 +208,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
       this.changeSubCategoryState(id, on);
     });
   }
-  private async changeCategoryVisibility(node: HierarchyNode, on: boolean) {
-    const categoryIds = CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node);
+  private async changeCategoryVisibility(categoryIds: Id64Array, on: boolean) {
     // make sure models are enabled
     if (on) {
       await this.enableCategoriesElementModelsVisibility(categoryIds);
@@ -220,7 +219,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
   private async changeDefinitionContainerVisibility(node: HierarchyNode, on: boolean) {
     const definitionContainerId = CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node);
     const childCategories = await this._idsCache.getAllContainedCategories(definitionContainerId);
-    return this.changeCategoryState(childCategories, on, on);
+    return this.changeCategoryVisibility(childCategories, on);
   }
 
   private onDisplayStyleChanged = () => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BeEvent } from "@itwin/core-bentley";
+import { PerModelCategoryVisibility } from "@itwin/core-frontend";
 import { HierarchyNode } from "@itwin/presentation-hierarchies";
 import { enableCategoryDisplay, enableSubCategoryDisplay } from "../../common/CategoriesVisibilityUtils.js";
 import { createVisibilityStatus } from "../../common/Tooltip.js";
 import { CategoriesTreeNode } from "./CategoriesTreeNode.js";
 
-import type { Id64Array } from "@itwin/core-bentley";
 import type { Viewport } from "@itwin/core-frontend";
+import type { Visibility } from "../../common/Tooltip.js";
+import type { Id64Array, Id64String } from "@itwin/core-bentley";
 import type { HierarchyVisibilityHandler, VisibilityStatus } from "../../common/UseHierarchyVisibility.js";
 import type { CategoriesTreeIdsCache } from "./CategoriesTreeIdsCache.js";
 
@@ -32,6 +34,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     this._viewport.onDisplayStyleChanged.addListener(this.onDisplayStyleChanged);
     this._viewport.onViewedCategoriesChanged.addListener(this.onViewedCategoriesChanged);
     this._viewport.onViewedCategoriesPerModelChanged.addListener(this.onViewedCategoriesPerModelChanged);
+    this._viewport.onViewedModelsChanged.addListener(this.onViewedModelsChanged);
   }
 
   public dispose() {
@@ -42,6 +45,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     this._viewport.onDisplayStyleChanged.removeListener(this.onDisplayStyleChanged);
     this._viewport.onViewedCategoriesChanged.removeListener(this.onViewedCategoriesChanged);
     this._viewport.onViewedCategoriesPerModelChanged.removeListener(this.onViewedCategoriesPerModelChanged);
+    this._viewport.onViewedModelsChanged.removeListener(this.onViewedModelsChanged);
     clearTimeout(this._pendingVisibilityChange);
   }
 
@@ -54,7 +58,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     }
 
     if (CategoriesTreeNode.isSubCategoryNode(node)) {
-      return createVisibilityStatus(this.getSubCategoryVisibility(node));
+      return createVisibilityStatus(await this.getSubCategoryVisibility(node));
     }
 
     if (CategoriesTreeNode.isCategoryNode(node)) {
@@ -86,90 +90,129 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     }
   }
 
-  private getSubCategoryVisibility(node: HierarchyNode): VisibilityStatus["state"] {
+  private async getSubCategoryVisibility(node: HierarchyNode): Promise<Visibility> {
     const parentCategoryId = node.extendedData?.categoryId;
     if (!parentCategoryId) {
       return "hidden";
     }
 
-    const categoryOverrideResult = this.getCategoryVisibilityFromOverrides(parentCategoryId);
-    if (categoryOverrideResult === "hidden" || categoryOverrideResult === "visible") {
-      return categoryOverrideResult;
-    }
-
-    if (!this._viewport.view.viewsCategory(parentCategoryId)) {
-      return "hidden";
+    const categoryOverrideResult = await this.getCategoryVisibilityWithoutSubCategories(parentCategoryId);
+    if (
+      categoryOverrideResult.reason === "all-overrides" ||
+      categoryOverrideResult.visibility === "hidden" ||
+      categoryOverrideResult.visibility === "partial"
+    ) {
+      return categoryOverrideResult.visibility;
     }
     const subCategoryIds = CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node);
+    const subCategoryVisibility = this.getSubCategoriesVisibility(subCategoryIds);
+    return subCategoryVisibility === "hidden" && categoryOverrideResult.reason === "some-overrides" ? "partial" : subCategoryVisibility;
+  }
+
+  private async getDefinitionContainerVisibility(node: HierarchyNode): Promise<Visibility> {
+    const categoryIds = await this._idsCache.getAllContainedCategories(CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node));
+    return this.getCategoriesVisibility(categoryIds);
+  }
+
+  private async getCategoriesVisibility(categoryIds: Id64Array): Promise<Visibility> {
+    const categoriesVisibilty = await Promise.all(
+      categoryIds.map(async (categoryId) => {
+        const { visibility, reason } = await this.getCategoryVisibilityWithoutSubCategories(categoryId);
+        return { categoryId, visibility, reason };
+      }),
+    );
+
     let visibleCount = 0;
     let hiddenCount = 0;
-    for (const subCategoryId of subCategoryIds) {
-      const isVisible = this._viewport.isSubCategoryVisible(subCategoryId);
-      if (isVisible) {
-        ++visibleCount;
-      } else {
-        ++hiddenCount;
-      }
+    for (const { categoryId, visibility, reason } of categoriesVisibilty) {
       if (visibleCount > 0 && hiddenCount > 0) {
         return "partial";
       }
+      if (visibility === "partial") {
+        return "partial";
+      }
+      if (visibility === "hidden") {
+        ++hiddenCount;
+        continue;
+      }
+      if (reason === "all-overrides") {
+        ++visibleCount;
+        continue;
+      }
+      const subCategories = await this._idsCache.getSubCategories(categoryId);
+      const subCategoriesVisibility = this.getSubCategoriesVisibility(subCategories);
+      if (subCategoriesVisibility === "partial") {
+        return "partial";
+      }
+
+      if (subCategoriesVisibility === "hidden" && reason === "some-overrides") {
+        return "partial";
+      }
+      if (subCategoriesVisibility === "hidden") {
+        ++hiddenCount;
+      } else {
+        ++visibleCount;
+      }
+    }
+    if (visibleCount > 0 && hiddenCount > 0) {
+      return "partial";
     }
     return visibleCount > 0 ? "visible" : "hidden";
   }
 
-  private async getDefinitionContainerVisibility(node: HierarchyNode): Promise<VisibilityStatus["state"]> {
-    const childrenResult = await this._idsCache.getAllContainedCategories(CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node));
-    let hiddenCount = 0;
-    let visibleCount = 0;
-    for (const categoryId of childrenResult) {
-      const categoryVisibility = await this.getCategoriesVisibility([categoryId]);
-      if (categoryVisibility === "partial") {
-        return "partial";
-      }
-
-      if (categoryVisibility === "hidden") {
-        ++hiddenCount;
+  private async getCategoryVisibilityWithoutSubCategories(
+    categoryId: Id64String,
+  ): Promise<{ visibility: VisibilityStatus["state"]; reason: "all-overrides" | "some-overrides" | "no-Overrides" }> {
+    const categoryModelsMap = await this._idsCache.getCategoriesElementModels([categoryId]);
+    let showOverrides = 0;
+    let hideOverrides = 0;
+    let noOverrides = 0;
+    const modelIds = categoryModelsMap.get(categoryId);
+    if (!modelIds) {
+      return { visibility: this._viewport.view.viewsCategory(categoryId) ? "visible" : "hidden", reason: "no-Overrides" };
+    }
+    for (const modelId of modelIds) {
+      if (this._viewport.view.viewsModel(modelId)) {
+        const override = this._viewport.perModelCategoryVisibility.getOverride(modelId, categoryId);
+        if (override === PerModelCategoryVisibility.Override.None) {
+          ++noOverrides;
+          continue;
+        }
+        if (override === PerModelCategoryVisibility.Override.Hide) {
+          ++hideOverrides;
+        } else {
+          ++showOverrides;
+        }
       } else {
-        ++visibleCount;
+        ++hideOverrides;
       }
 
-      if (hiddenCount > 0 && visibleCount > 0) {
-        return "partial";
+      if (showOverrides > 0 && hideOverrides > 0) {
+        return { visibility: "partial", reason: "all-overrides" };
       }
     }
 
-    return hiddenCount > 0 ? "hidden" : "visible";
+    if (showOverrides === 0 && hideOverrides === 0) {
+      return { visibility: this._viewport.view.viewsCategory(categoryId) ? "visible" : "hidden", reason: "no-Overrides" };
+    }
+    if (noOverrides > 0) {
+      if (this._viewport.view.viewsCategory(categoryId)) {
+        return { visibility: showOverrides > 0 ? "visible" : "partial", reason: "some-overrides" };
+      }
+      return { visibility: showOverrides > 0 ? "partial" : "hidden", reason: "some-overrides" };
+    }
+
+    return { visibility: showOverrides > 0 ? "visible" : "hidden", reason: "all-overrides" };
   }
 
-  private async getCategoriesVisibility(categoryIds: Id64Array): Promise<VisibilityStatus["state"]> {
-    const overrideResult = this.getCategoryVisibilityFromOverrides(categoryIds);
-    if (overrideResult !== "none") {
-      return overrideResult;
+  private getSubCategoriesVisibility(subCategoryIds: Id64Array): Visibility {
+    if (subCategoryIds.length === 0) {
+      return "visible";
     }
-    let visibleCount = 0;
-    let hiddenCount = 0;
-    for (const categoryId of categoryIds) {
-      const isVisible = this._viewport.view.viewsCategory(categoryId);
-      if (isVisible) {
-        ++visibleCount;
-      } else {
-        ++hiddenCount;
-      }
-      if (visibleCount > 0 && hiddenCount > 0) {
-        return "partial";
-      }
-    }
-
-    if (hiddenCount > 0) {
-      return "hidden";
-    }
-
-    const subCategories = (await Promise.all(categoryIds.map(async (id) => this._idsCache.getSubCategories(id)))).reduce((acc, val) => acc.concat(val), []);
     let visibleSubCategoryCount = 0;
     let hiddenSubCategoryCount = 0;
-
-    for (const subCategory of subCategories) {
-      const isVisible = this._viewport.isSubCategoryVisible(subCategory);
+    for (const subCategoryId of subCategoryIds) {
+      const isVisible = this._viewport.isSubCategoryVisible(subCategoryId);
       if (isVisible) {
         ++visibleSubCategoryCount;
       } else {
@@ -179,41 +222,27 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
         return "partial";
       }
     }
-
     return hiddenSubCategoryCount > 0 ? "hidden" : "visible";
-  }
-
-  private getCategoryVisibilityFromOverrides(categoryIds: Id64Array): VisibilityStatus["state"] | "none" {
-    let showOverrides = 0;
-    let hideOverrides = 0;
-
-    for (const currentOverride of this._viewport.perModelCategoryVisibility) {
-      if (categoryIds.includes(currentOverride.categoryId)) {
-        if (currentOverride.visible) {
-          ++showOverrides;
-        } else {
-          ++hideOverrides;
-        }
-
-        if (showOverrides > 0 && hideOverrides > 0) {
-          return "partial";
-        }
-      }
-    }
-
-    if (showOverrides === 0 && hideOverrides === 0) {
-      return "none";
-    }
-
-    return showOverrides > 0 ? "visible" : "hidden";
   }
 
   private async changeSubCategoryVisibility(node: HierarchyNode, on: boolean) {
     const parentCategoryId = node.extendedData?.categoryId;
 
-    // make sure parent category is enabled
+    // make sure parent category and models are enabled
     if (on && parentCategoryId) {
-      await this.changeCategoryState([parentCategoryId], true, false);
+      await Promise.all([
+        (async () => {
+          const categoriesModelsMap = await this._idsCache.getCategoriesElementModels([parentCategoryId]);
+          const modelIds = [...categoriesModelsMap.values()].reduce((acc, categoryModels) => {
+            return acc.concat(categoryModels);
+          }, new Array<Id64String>());
+          const hiddenModels = modelIds.filter((modelId) => !this._viewport.view.viewsModel(modelId));
+          if (hiddenModels.length > 0) {
+            this._viewport.changeModelDisplay(hiddenModels, on);
+          }
+        })(),
+        await this.changeCategoryState([parentCategoryId], true, false),
+      ]);
     }
 
     const subCategoryIds = CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node);
@@ -221,9 +250,19 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
       this.changeSubCategoryState(id, on);
     });
   }
-
   private async changeCategoryVisibility(node: HierarchyNode, on: boolean) {
     const categoryIds = CategoriesVisibilityHandler.getInstanceIdsFromHierarchyNode(node);
+    // make sure models are enabled
+    if (on) {
+      const categoriesModelsMap = await this._idsCache.getCategoriesElementModels(categoryIds);
+      const modelIds = [...categoriesModelsMap.values()].reduce((acc, categoryModels) => {
+        return acc.concat(categoryModels);
+      }, new Array<Id64String>());
+      const hiddenModels = modelIds.filter((modelId) => !this._viewport.view.viewsModel(modelId));
+      if (hiddenModels.length > 0) {
+        this._viewport.changeModelDisplay(hiddenModels, on);
+      }
+    }
     return this.changeCategoryState(categoryIds, on, on);
   }
 
@@ -242,6 +281,10 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
   };
 
   private onViewedCategoriesPerModelChanged = () => {
+    this.onVisibilityChangeInternal();
+  };
+
+  private onViewedModelsChanged = () => {
     this.onVisibilityChangeInternal();
   };
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
@@ -31,6 +31,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     this._viewport = props.viewport;
     this._viewport.onDisplayStyleChanged.addListener(this.onDisplayStyleChanged);
     this._viewport.onViewedCategoriesChanged.addListener(this.onViewedCategoriesChanged);
+    this._viewport.onViewedCategoriesPerModelChanged.addListener(this.onViewedCategoriesPerModelChanged);
   }
 
   public dispose() {
@@ -40,6 +41,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
   public [Symbol.dispose]() {
     this._viewport.onDisplayStyleChanged.removeListener(this.onDisplayStyleChanged);
     this._viewport.onViewedCategoriesChanged.removeListener(this.onViewedCategoriesChanged);
+    this._viewport.onViewedCategoriesPerModelChanged.removeListener(this.onViewedCategoriesPerModelChanged);
     clearTimeout(this._pendingVisibilityChange);
   }
 
@@ -231,13 +233,15 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     return this.changeCategoryState(childCategories, on, on);
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   private onDisplayStyleChanged = () => {
     this.onVisibilityChangeInternal();
   };
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   private onViewedCategoriesChanged = () => {
+    this.onVisibilityChangeInternal();
+  };
+
+  private onViewedCategoriesPerModelChanged = () => {
     this.onVisibilityChangeInternal();
   };
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesVisibilityHandler.ts
@@ -255,9 +255,7 @@ export class CategoriesVisibilityHandler implements HierarchyVisibilityHandler {
     // make sure models are enabled
     if (on) {
       const categoriesModelsMap = await this._idsCache.getCategoriesElementModels(categoryIds);
-      const modelIds = [...categoriesModelsMap.values()].reduce((acc, categoryModels) => {
-        return acc.concat(categoryModels);
-      }, new Array<Id64String>());
+      const modelIds = [...categoriesModelsMap.values()].flat();
       const hiddenModels = modelIds.filter((modelId) => !this._viewport.view.viewsModel(modelId));
       if (hiddenModels.length > 0) {
         this._viewport.changeModelDisplay(hiddenModels, on);


### PR DESCRIPTION
closes #912
- Fixed Categories tree not reacting to visibility changes from Models tree. This was happening due to `onViewedCategoriesPerModelChanged` not having a listener registered in Categories tree.
- Fixed how Visibilities are determined in Categories tree. Previously if Category was under two different Models in Models tree, and Category had `PerModelCategoryVisibility.Override` set to "Hide", we would show it as "hidden" in Categories tree (while it is still visible for other model). Also, Category was not taking into a count GeometricElement's models: if "hide all" button was pressed when Models tree was opened, then viewport would not display anything, but we would show all categories as "visible" (in Categories tree).
- Added tests for those two fixes.