### PR TITLE
[property-grid]: Improve properties filtering reporting

### DIFF
--- a/change/@itwin-property-grid-react-66bf838d-c359-4521-ac6f-5d56ce5e7baf.json
+++ b/change/@itwin-property-grid-react-66bf838d-c359-4521-ac6f-5d56ce5e7baf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce `filter-properties` feature reporting duplication.",
+  "packageName": "@itwin/property-grid-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Updated `filter-properties` feature reporting to reduce duplication when typing slowly. Previous implementation had 1s delay between reporting which meant that if typing filter text takes longer than 1s it will be reported again. This should fix https://github.com/iTwin/viewer-components-react/issues/1287