### PR TITLE
[tree-widget]: Models tree filtering control

### DIFF
--- a/change/@itwin-tree-widget-react-17f9436f-e92e-4045-bf75-b29b44ec6cc4.json
+++ b/change/@itwin-tree-widget-react-17f9436f-e92e-4045-bf75-b29b44ec6cc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added ability to disabled hierarchy level filtering in `ModelsTree`.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -284,6 +284,7 @@ interface ModelsTreeHierarchyConfiguration {
     elementClassGrouping: "enable" | "enableWithCounts" | "disable";
     elementClassSpecification: string;
     hideRootSubject: boolean;
+    hierarchyLevelFiltering: "enable" | "disable";
     showEmptyModels: boolean;
 }
 

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeDefinition.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeDefinition.test.ts
@@ -1261,6 +1261,72 @@ describe("Models tree", () => {
           expect: [],
         });
       });
+
+      it("disables hierarchy level filtering support when `hierarchyLevelFiltering` is set to `disable`", async function () {
+        await using buildIModelResult = await buildIModel(this, async (builder) => {
+          const rootSubject: InstanceKey = { className: "BisCore.Subject", id: IModel.rootSubjectId };
+          const model = insertPhysicalModelWithPartition({ builder, codeValue: `model`, partitionParentId: rootSubject.id });
+          const category = insertSpatialCategory({ builder, codeValue: "category" });
+          const parentElement = insertPhysicalElement({
+            builder,
+            userLabel: `parent element 1`,
+            modelId: model.id,
+            categoryId: category.id,
+          });
+          const childElement = insertPhysicalElement({
+            builder,
+            userLabel: `child element 1`,
+            modelId: model.id,
+            categoryId: category.id,
+            parentId: parentElement.id,
+          });
+          return { rootSubject, model, category, parentElement, childElement };
+        });
+
+        const { imodel, ...keys } = buildIModelResult;
+        using provider = createModelsTreeProvider({
+          imodel,
+          hierarchyConfig: { hierarchyLevelFiltering: "disable" },
+        });
+        await validateHierarchy({
+          provider,
+          expect: [
+            NodeValidators.createForInstanceNode({
+              instanceKeys: [keys.model],
+              supportsFiltering: false,
+              children: [
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.category],
+                  supportsFiltering: false,
+                  children: [
+                    NodeValidators.createForClassGroupingNode({
+                      className: keys.parentElement.className,
+                      children: [
+                        NodeValidators.createForInstanceNode({
+                          instanceKeys: [keys.parentElement],
+                          supportsFiltering: false,
+                          children: [
+                            NodeValidators.createForClassGroupingNode({
+                              className: keys.childElement.className,
+                              children: [
+                                NodeValidators.createForInstanceNode({
+                                  instanceKeys: [keys.childElement],
+                                  supportsFiltering: false,
+                                  children: false,
+                                }),
+                              ],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        });
+      });
     });
   });
 });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -60,6 +60,8 @@ export interface ModelsTreeHierarchyConfiguration {
   showEmptyModels: boolean;
   /** Should the root Subject node be hidden. Defaults to `false`. */
   hideRootSubject: boolean;
+  /** Should hierarchy level be filterable. Defaults to `enable` */
+  hierarchyLevelFiltering: "enable" | "disable";
 }
 
 /** @internal */
@@ -68,6 +70,7 @@ export const defaultHierarchyConfiguration: ModelsTreeHierarchyConfiguration = {
   elementClassSpecification: "BisCore.GeometricElement3d",
   showEmptyModels: false,
   hideRootSubject: false,
+  hierarchyLevelFiltering: "enable",
 };
 
 interface ModelsTreeDefinitionProps {
@@ -239,7 +242,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   isSubject: true,
                 },
                 autoExpand: { selector: `IIF(this.ECInstanceId = ${IModel.rootSubjectId}, true, false)` },
-                supportsFiltering: true,
+                supportsFiltering: this.supportsFiltering(),
               })}
             FROM ${subjectFilterClauses.from} this
             ${subjectFilterClauses.joins}
@@ -297,7 +300,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                     imageId: "icon-model",
                     isModel: true,
                   },
-                  supportsFiltering: true,
+                  supportsFiltering: this.supportsFiltering(),
                 })}
               FROM Bis.GeometricModel3d m
               JOIN bis.InformationPartitionElement [partition] ON [partition].ECInstanceId = m.ModeledElement.Id
@@ -373,7 +376,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   isCategory: true,
                   modelIds: { selector: createIdsSelector(modelIds) },
                 },
-                supportsFiltering: true,
+                supportsFiltering: this.supportsFiltering(),
               })}
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
@@ -452,7 +455,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   categoryId: { selector: "IdToHex(this.Category.Id)" },
                   imageId: "icon-item",
                 },
-                supportsFiltering: true,
+                supportsFiltering: this.supportsFiltering(),
               })}
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
@@ -510,7 +513,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   categoryId: { selector: "IdToHex(this.Category.Id)" },
                   imageId: "icon-item",
                 },
-                supportsFiltering: true,
+                supportsFiltering: this.supportsFiltering(),
               })}
             FROM ${instanceFilterClauses.from} this
             ${instanceFilterClauses.joins}
@@ -530,6 +533,10 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
       return createInstanceKeyPathsFromInstanceLabel({ ...props, labelsFactory });
     }
     return createInstanceKeyPathsFromTargetItems(props);
+  }
+
+  private supportsFiltering() {
+    return this._hierarchyConfig.hierarchyLevelFiltering === "enable";
   }
 
   private async isSupported() {


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1293
Added ability to control hierarchy level filtering in `ModelsTree`. Current implementation only allows to turn on/off filtering for all hierarchy levels.