### PR TITLE
[tree-widget]: Use default imports for svg icons

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/TreeWidgetUiItemsProvider.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/TreeWidgetUiItemsProvider.tsx
@@ -7,6 +7,7 @@ import "./TreeWidgetUiItemsProvider.css";
 import { useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { StagePanelLocation, StagePanelSection, useTransientState } from "@itwin/appui-react";
+import hierarchyTreeSvg from "@itwin/itwinui-icons/hierarchy-tree.svg";
 import { Icon } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../TreeWidget.js";
 import { ErrorState } from "./tree-header/ErrorState.js";
@@ -34,7 +35,6 @@ interface TreeWidgetProps {
   onFeatureUsed?: (feature: string) => void;
 }
 
-const hierarchyTreeSvg = new URL("@itwin/itwinui-icons/hierarchy-tree.svg", import.meta.url).href;
 
 /**
  * Creates a tree widget definition that should be returned from `UiItemsProvider.getWidgets()`.

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/ErrorState.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/ErrorState.tsx
@@ -3,12 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import errorSvg from "@itwin/itwinui-icons/status-error.svg";
 import { Button, Icon, Text } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../TreeWidget.js";
 
 import type { FallbackProps } from "react-error-boundary";
-
-const errorSvg = new URL("@itwin/itwinui-icons/status-error.svg", import.meta.url).href;
 
 /** @internal */
 export function ErrorState({ resetErrorBoundary }: FallbackProps) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/SearchBox.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/tree-header/SearchBox.tsx
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useEffect, useRef, useState } from "react";
+import dismissSvg from "@itwin/itwinui-icons/dismiss.svg";
+import searchSvg from "@itwin/itwinui-icons/search.svg";
 import { IconButton, TextBox } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../TreeWidget.js";
 
@@ -14,9 +16,6 @@ interface DebouncedSearchBoxProps {
   delay: number;
   className?: string;
 }
-
-const dismissSvg = new URL("@itwin/itwinui-icons/dismiss.svg", import.meta.url).href;
-const searchSvg = new URL("@itwin/itwinui-icons/search.svg", import.meta.url).href;
 
 /** @internal */
 export function DebouncedSearchBox({ isOpened, onSearch, setIsOpened, delay, className }: DebouncedSearchBoxProps) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -6,6 +6,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAsyncValue } from "@itwin/components-react";
 import { QueryRowFormat } from "@itwin/core-common";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
+import visibilityInvertSvg from "@itwin/itwinui-icons/visibilty-invert.svg";
 import { IconButton } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../../TreeWidget.js";
 import { hideAllCategories, invertAllCategories } from "../common/CategoriesVisibilityUtils.js";
@@ -73,8 +76,6 @@ export function useCategoriesTreeButtonProps({ viewport }: { viewport: Viewport 
 /** @public */
 export type CategoriesTreeHeaderButtonType = (props: CategoriesTreeHeaderButtonProps) => React.ReactElement | null;
 
-const visibilityShowSvg = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
-
 /** @public */
 export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
   return (
@@ -89,8 +90,6 @@ export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
     />
   );
 }
-
-const visibilityHideSvg = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
 
 /** @public */
 export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
@@ -110,8 +109,6 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
     />
   );
 }
-
-const visibilityInvertSvg = new URL("@itwin/itwinui-icons/visibilty-invert.svg", import.meta.url).href;
 
 /** @public */
 export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
@@ -4,6 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import subcategorySvg from "@itwin/itwinui-icons/bis-category-subcategory.svg";
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import definitionContainerSvg from "@itwin/itwinui-icons/bis-definitions-container.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
 import { Icon } from "@itwin/itwinui-react/bricks";
 import { EmptyTreeContent, FilterUnknownError, NoFilterMatches, TooManyFilterMatches } from "../common/components/EmptyTree.js";
 import { CategoriesTreeDefinition, defaultHierarchyConfiguration } from "./CategoriesTreeDefinition.js";
@@ -124,8 +129,6 @@ function useCachedVisibility(activeView: Viewport, hierarchyConfig: CategoriesTr
   };
 }
 
-const categorySvg = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-
 function getEmptyTreeContentComponent(filter?: string, error?: CategoriesTreeFilteringError, emptyTreeContent?: React.ReactNode) {
   if (error) {
     if (error === "tooManyFilterMatches") {
@@ -141,11 +144,6 @@ function getEmptyTreeContentComponent(filter?: string, error?: CategoriesTreeFil
   }
   return <EmptyTreeContent icon={categorySvg} />;
 }
-
-const subcategorySvg = new URL("@itwin/itwinui-icons/bis-category-subcategory.svg", import.meta.url).href;
-const definitionContainerSvg = new URL("@itwin/itwinui-icons/bis-definitions-container.svg", import.meta.url).href;
-const classSvg = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const elementSvg = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
 
 /** @beta */
 export function CategoriesTreeIcon({ node }: { node: PresentationHierarchyNode }) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/components/TreeNodeVisibilityButton.tsx
@@ -5,6 +5,9 @@
 
 import "./TreeNodeVisibilityButton.css";
 import { memo } from "react";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityPartialSvg from "@itwin/itwinui-icons/visibility-partial.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
 import { Tree } from "@itwin/itwinui-react/bricks";
 import { createTooltip } from "../internal/Tooltip.js";
 
@@ -27,10 +30,6 @@ export interface TreeItemVisibilityButtonProps {
   /** Callback that should be used to determine current checkbox state. */
   getVisibilityButtonState: (node: PresentationHierarchyNode) => TreeItemVisibilityButtonState;
 }
-
-const visibilityHideSvg = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
-const visibilityPartialSvg = new URL("@itwin/itwinui-icons/visibility-partial.svg", import.meta.url).href;
-const visibilityShowSvg = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
 
 /** @internal */
 export const VisibilityAction = memo(function VisibilityAction({

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/external-sources-tree/ExternalSourcesTree.tsx
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import documentSvg from "@itwin/itwinui-icons/document.svg";
+import ecSchemaSvg from "@itwin/itwinui-icons/selection-children.svg";
 import { Icon } from "@itwin/itwinui-react/bricks";
 import { EmptyTreeContent } from "../common/components/EmptyTree.js";
 import { Tree } from "../common/components/Tree.js";
@@ -41,11 +45,6 @@ export function ExternalSourcesTree({ getActions, getDecorations, selectionMode,
 const getDefinitionsProvider: TreeProps["getHierarchyDefinition"] = (props) => {
   return new ExternalSourcesTreeDefinition(props);
 };
-
-const classSvg = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const elementSvg = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
-const documentSvg = new URL("@itwin/itwinui-icons/document.svg", import.meta.url).href;
-const ecSchemaSvg = new URL("@itwin/itwinui-icons/selection-children.svg", import.meta.url).href;
 
 /** @beta */
 export function ExternalSourcesTreeIcon({ node }: { node: PresentationHierarchyNode }) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTree.tsx
@@ -4,6 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useCallback } from "react";
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import subjectSvg from "@itwin/itwinui-icons/bis-subject.svg";
+import groupSvg from "@itwin/itwinui-icons/group.svg";
+import modelSvg from "@itwin/itwinui-icons/model-cube.svg";
+import hierarchyTreeSvg from "@itwin/itwinui-icons/selection-children.svg";
 import { Icon } from "@itwin/itwinui-react/bricks";
 import { EmptyTreeContent } from "../common/components/EmptyTree.js";
 import { Tree } from "../common/components/Tree.js";
@@ -54,14 +61,6 @@ export function IModelContentTree({ getActions, getDecorations, selectionMode, h
     />
   );
 }
-
-const categorySvg = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-const classSvg = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const elementSvg = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
-const subjectSvg = new URL("@itwin/itwinui-icons/bis-subject.svg", import.meta.url).href;
-const groupSvg = new URL("@itwin/itwinui-icons/group.svg", import.meta.url).href;
-const modelSvg = new URL("@itwin/itwinui-icons/model-cube.svg", import.meta.url).href;
-const hierarchyTreeSvg = new URL("@itwin/itwinui-icons/selection-children.svg", import.meta.url).href;
 
 /** @beta */
 export function IModelContentTreeIcon({ node }: { node: PresentationHierarchyNode }) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -4,6 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useEffect, useMemo, useState } from "react";
+import toggle2DSvg from "@itwin/itwinui-icons/2d.svg";
+import toggle3DSvg from "@itwin/itwinui-icons/3d.svg";
+import focusModeSvg from "@itwin/itwinui-icons/cursor-click.svg";
+import visibilityHideSvg from "@itwin/itwinui-icons/visibility-hide.svg";
+import visibilityShowSvg from "@itwin/itwinui-icons/visibility-show.svg";
+import visibilityInvertSvg from "@itwin/itwinui-icons/visibilty-invert.svg";
 import { IconButton } from "@itwin/itwinui-react/bricks";
 import { TreeWidget } from "../../../TreeWidget.js";
 import { useFocusedInstancesContext } from "../common/FocusedInstancesContext.js";
@@ -111,8 +117,6 @@ async function queryModelsForHeaderActions(iModel: IModelConnection) {
 /** @public */
 export type ModelsTreeHeaderButtonType = (props: ModelsTreeHeaderButtonProps) => React.ReactElement | null;
 
-const visibilityShowSvg = new URL("@itwin/itwinui-icons/visibility-show.svg", import.meta.url).href;
-
 /** @public */
 export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
   return (
@@ -130,8 +134,6 @@ export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
     />
   );
 }
-
-const visibilityHideSvg = new URL("@itwin/itwinui-icons/visibility-hide.svg", import.meta.url).href;
 
 /** @public */
 export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
@@ -151,8 +153,6 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
   );
 }
 
-const visibilityInvertSvg = new URL("@itwin/itwinui-icons/visibilty-invert.svg", import.meta.url).href;
-
 /** @public */
 export function InvertButton(props: ModelsTreeHeaderButtonProps) {
   return (
@@ -170,8 +170,6 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
     />
   );
 }
-
-const toggle2DSvg = new URL("@itwin/itwinui-icons/2d.svg", import.meta.url).href;
 
 /** @public */
 export function View2DButton(props: ModelsTreeHeaderButtonProps) {
@@ -201,8 +199,6 @@ export function View2DButton(props: ModelsTreeHeaderButtonProps) {
   );
 }
 
-const toggle3DSvg = new URL("@itwin/itwinui-icons/3d.svg", import.meta.url).href;
-
 /** @public */
 export function View3DButton(props: ModelsTreeHeaderButtonProps) {
   const models3d = useMemo(() => {
@@ -230,8 +226,6 @@ export function View3DButton(props: ModelsTreeHeaderButtonProps) {
     />
   );
 }
-
-const focusModeSvg = new URL("@itwin/itwinui-icons/cursor-click.svg", import.meta.url).href;
 
 /** @public */
 export function ToggleInstancesFocusButton({ onFeatureUsed, disabled }: { onFeatureUsed?: (feature: string) => void; disabled?: boolean }) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -4,6 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import categorySvg from "@itwin/itwinui-icons/bis-category-3d.svg";
+import classSvg from "@itwin/itwinui-icons/bis-class.svg";
+import elementSvg from "@itwin/itwinui-icons/bis-element.svg";
+import subjectSvg from "@itwin/itwinui-icons/bis-subject.svg";
+import modelSvg from "@itwin/itwinui-icons/model-cube.svg";
 import { Icon } from "@itwin/itwinui-react/bricks";
 import {
   EmptyTreeContent,
@@ -190,12 +195,6 @@ function InstanceFocusError({ error }: { error: ModelsTreeFilteringError }) {
   }
   return <UnknownInstanceFocusError base={"modelsTree"} />;
 }
-
-const subjectSvg = new URL("@itwin/itwinui-icons/bis-subject.svg", import.meta.url).href;
-const classSvg = new URL("@itwin/itwinui-icons/bis-class.svg", import.meta.url).href;
-const modelSvg = new URL("@itwin/itwinui-icons/model-cube.svg", import.meta.url).href;
-const categorySvg = new URL("@itwin/itwinui-icons/bis-category-3d.svg", import.meta.url).href;
-const elementSvg = new URL("@itwin/itwinui-icons/bis-element.svg", import.meta.url).href;
 
 /** @beta */
 export function ModelsTreeIcon({ node }: { node: PresentationHierarchyNode }) {


### PR DESCRIPTION
Switching back to default import instead of `new URL` for loading svg.