### PR TITLE
[tree-widget]: Bump hierarchies-react to `alpha.17`

### DIFF
--- a/apps/test-viewer/pnpm-lock.yaml
+++ b/apps/test-viewer/pnpm-lock.yaml
@@ -982,8 +982,8 @@ packages:
       '@itwin/itwinui-react':
         optional: true
 
-  '@itwin/presentation-hierarchies-react@2.0.0-alpha.16':
-    resolution: {integrity: sha512-9cB1tKqnCRxtg33fXdHBZ/opd9x0y68TMNTkPiJRYiiQn2A/E+UemNomIrTapYPrJUCN+FSnBjSdVl0bedKBqA==}
+  '@itwin/presentation-hierarchies-react@2.0.0-alpha.17':
+    resolution: {integrity: sha512-32v7h3Agq4zh8pNzr96kytZolYMkU2y44KPw1mgD5Yf8P9LuN+WrISYnJJlRchYKeL0cUsuGf+l5kQwy/bB+kA==}
     peerDependencies:
       '@itwin/itwinui-icons': 5.0.0-alpha.7
       '@itwin/itwinui-react': 5.0.0-alpha.14
@@ -4274,7 +4274,7 @@ snapshots:
     optionalDependencies:
       '@itwin/itwinui-react': 3.17.2(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@itwin/presentation-hierarchies-react@2.0.0-alpha.16(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@itwin/presentation-hierarchies-react@2.0.0-alpha.17(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@itwin/core-bentley': 4.10.10
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4388,7 +4388,7 @@ snapshots:
       '@itwin/presentation-components': 5.11.0(76d3ac514099925487f6de6ab9e3280d)
       '@itwin/presentation-core-interop': 1.3.1(@itwin/core-bentley@4.10.10)(@itwin/core-common@4.10.10(@itwin/core-bentley@4.10.10)(@itwin/core-geometry@4.10.10))(@itwin/core-geometry@4.10.10)(@itwin/core-quantity@4.10.10(@itwin/core-bentley@4.10.10))(@itwin/ecschema-metadata@4.10.10(@itwin/core-bentley@4.10.10)(@itwin/core-quantity@4.10.10(@itwin/core-bentley@4.10.10)))
       '@itwin/presentation-hierarchies': 1.4.1
-      '@itwin/presentation-hierarchies-react': 2.0.0-alpha.16(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@itwin/presentation-hierarchies-react': 2.0.0-alpha.17(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/presentation-shared': 1.2.0
       '@itwin/unified-selection': 1.3.0
       classnames: 2.5.1

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@itwin/presentation-core-interop": "^1.3.0",
     "@itwin/presentation-hierarchies": "^1.4.1",
-    "@itwin/presentation-hierarchies-react": "2.0.0-alpha.16",
+    "@itwin/presentation-hierarchies-react": "2.0.0-alpha.17",
     "@itwin/presentation-shared": "^1.2.0",
     "@itwin/unified-selection": "^1.3.0",
     "classnames": "^2.5.1",

--- a/packages/itwin/tree-widget/pnpm-lock.yaml
+++ b/packages/itwin/tree-widget/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       '@itwin/presentation-hierarchies-react':
-        specifier: 2.0.0-alpha.16
-        version: 2.0.0-alpha.16(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.0.0-alpha.17
+        version: 2.0.0-alpha.17(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@itwin/presentation-shared':
         specifier: ^1.2.0
         version: 1.2.0
@@ -765,8 +765,8 @@ packages:
       '@itwin/ecschema-metadata': ^4.10.2
       '@itwin/presentation-common': ^4.10.2
 
-  '@itwin/presentation-hierarchies-react@2.0.0-alpha.16':
-    resolution: {integrity: sha512-9cB1tKqnCRxtg33fXdHBZ/opd9x0y68TMNTkPiJRYiiQn2A/E+UemNomIrTapYPrJUCN+FSnBjSdVl0bedKBqA==}
+  '@itwin/presentation-hierarchies-react@2.0.0-alpha.17':
+    resolution: {integrity: sha512-32v7h3Agq4zh8pNzr96kytZolYMkU2y44KPw1mgD5Yf8P9LuN+WrISYnJJlRchYKeL0cUsuGf+l5kQwy/bB+kA==}
     peerDependencies:
       '@itwin/itwinui-icons': 5.0.0-alpha.7
       '@itwin/itwinui-react': 5.0.0-alpha.14
@@ -5119,7 +5119,7 @@ snapshots:
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0(rxjs@7.8.1)
 
-  '@itwin/presentation-hierarchies-react@2.0.0-alpha.16(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@itwin/presentation-hierarchies-react@2.0.0-alpha.17(@itwin/itwinui-icons@5.0.0-alpha.7)(@itwin/itwinui-react@5.0.0-alpha.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@itwin/core-bentley': 4.10.11
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Bumped hierarchies-react version to `alpha.17` with a change to use default imports for svgs instead of `URL` constructor.