### PR TITLE
[measure-tools-react] Bugfix. ViewTypeClassifier not using registered classifiers

### DIFF
--- a/change/@itwin-measure-tools-react-df6218c8-a91a-46a6-bf67-f0c6d9b2037e.json
+++ b/change/@itwin-measure-tools-react-df6218c8-a91a-46a6-bf67-f0c6d9b2037e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix issue in MeasurementViewTypeClassifier. fallback classifiers had higher priority than registered classifier.",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "3418768+a-gagnon@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This PR fixes a problem with the MeasurementViewTypeClassifier where the more generic fallback types (ie. "spatial", "drawing", "sheet") are being checked before registered classifiers.

-Add some logic to ensure the registered classifiers have a higher priority than the fallback ones.
- Change the logic to allow more than 1 classifier for a given view type. While this case is a bit of a stretch, it makes it easier to gracefully handle cases where we would have multiple instances of the same viewport type (eg. multiple civil sections) and each section managing its own view type classifier.