### PR TITLE
Update `getFilteredPaths` documentation

### DIFF
--- a/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
+++ b/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
@@ -106,7 +106,6 @@ function CustomModelsTreeComponentWithPostProcessing({
 // __PUBLISH_EXTRACT_END__
 
 // __PUBLISH_EXTRACT_START__ TreeWidget.GetFilteredPathsComponentWithFilterAndTargetItemsExample
-
 function CustomModelsTreeComponentWithFilterAndTargetItems({
   viewport,
   selectionStorage,

--- a/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
+++ b/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
@@ -69,7 +69,6 @@ function CustomModelsTreeComponentWithTargetItems({
 // __PUBLISH_EXTRACT_END__
 
 // __PUBLISH_EXTRACT_START__ TreeWidget.GetFilteredPathsComponentWithPostProcessingExample
-
 function CustomModelsTreeComponentWithPostProcessing({
   viewport,
   selectionStorage,

--- a/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
+++ b/apps/learning-snippets/src/test/tree-widget/FilteredPaths.test.tsx
@@ -115,30 +115,25 @@ function CustomModelsTreeComponentWithFilterAndTargetItems({
   selectionStorage: SelectionStorage;
   imodel: IModelConnection;
 }) {
-  const customFilter = 'test';
   const getFilteredPaths = useCallback<GetFilteredPathsType>(
     async ({ createInstanceKeyPaths, filter }) => {
-      const userLabelFilter = filter ?? customFilter;
       const targetItems = new Array<InstanceKey>();
       for await (const row of imodel.createQueryReader(`
           SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
           FROM BisCore.Element e
-          WHERE UserLabel LIKE '%${userLabelFilter}%'
+          WHERE UserLabel LIKE '%${filter ?? ""}%'
         `,
         undefined,
         { rowFormat: QueryRowFormat.UseJsPropertyNames },
       )) {
         targetItems.push({ id: row.id, className: row.className });
       }
-
-      return createInstanceKeyPaths({
-        targetItems,
-      });
+      return createInstanceKeyPaths({ targetItems });
     },
     [imodel],
   );
 
-  const { modelsTreeProps, rendererProps } = useModelsTree({ activeView: viewport, getFilteredPaths, filter: customFilter });
+  const { modelsTreeProps, rendererProps } = useModelsTree({ activeView: viewport, getFilteredPaths, filter: "test" });
 
   return (
     <VisibilityTree

--- a/change/@itwin-tree-widget-react-4979d818-712d-4f2a-b27e-ac9adef6517b.json
+++ b/change/@itwin-tree-widget-react-4979d818-712d-4f2a-b27e-ac9adef6517b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add optional `filter` prop has been added to `getFilteredPaths`. This prop is provided when `getFilteredPaths` is called and it is the same as the filter that is provided to `useModelsTree`. Added docs explaining getFilteredPaths usage.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-4979d818-712d-4f2a-b27e-ac9adef6517b.json
+++ b/change/@itwin-tree-widget-react-4979d818-712d-4f2a-b27e-ac9adef6517b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add optional `filter` prop has been added to `getFilteredPaths`. This prop is provided when `getFilteredPaths` is called and it is the same as the filter that is provided to `useModelsTree`. Added docs explaining getFilteredPaths usage.",
+  "comment": "`useModelsTree`: The `getFilteredPaths` callback prop now has a `filter` prop, which matches the value of `filter` prop passed to `useModelsTree` hook. This make it more convenient for consumers to filter by instance keys and label at the same time.",
   "packageName": "@itwin/tree-widget-react",
   "email": "100586436+JonasDov@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -328,31 +328,26 @@ Use `getFilteredPaths` when you need more control over which nodes are shown. He
     selectionStorage: SelectionStorage;
     imodel: IModelConnection;
   }) {
-    const customFilter = "test";
     const getFilteredPaths = useCallback<GetFilteredPathsType>(
       async ({ createInstanceKeyPaths, filter }) => {
-        const userLabelFilter = filter ?? customFilter;
         const targetItems = new Array<InstanceKey>();
         for await (const row of imodel.createQueryReader(
           `
             SELECT ec_classname(e.ECClassId, 's.c') className, e.ECInstanceId id
             FROM BisCore.Element e
-            WHERE UserLabel LIKE '%${userLabelFilter}%'
+            WHERE UserLabel LIKE '%${filter ?? ""}%'
           `,
           undefined,
           { rowFormat: QueryRowFormat.UseJsPropertyNames },
         )) {
           targetItems.push({ id: row.id, className: row.className });
         }
-
-        return createInstanceKeyPaths({
-          targetItems,
-        });
+        return createInstanceKeyPaths({ targetItems });
       },
       [imodel],
     );
 
-    const { modelsTreeProps, rendererProps } = useModelsTree({ activeView: viewport, getFilteredPaths, filter: customFilter });
+    const { modelsTreeProps, rendererProps } = useModelsTree({ activeView: viewport, getFilteredPaths, filter: "test" });
 
     return (
       <VisibilityTree

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -225,7 +225,6 @@ Models tree allows displaying a subset of all nodes by providing a `getFilteredP
 
 When these paths are provided, the displayed hierarchy consists only of the targeted nodes, their ancestors, and their children.
 
-If `getFilteredPaths` is **not** provided, the default filtering logic uses the `filter` string and `createInstanceKeyPaths` internally.
 Use `getFilteredPaths` when you need more control over which nodes are shown. Here are some example use cases:
 
 - **Filter by known instance keys**: You already have a list of `InstanceKey` items that should remain in the tree. Pass them as `targetItems` to `createInstanceKeyPaths`.

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -218,7 +218,7 @@ function CustomModelsTreeComponent({ imodel, viewport, getSchemaContext, selecti
 
 #### Displaying a subset of the tree
 
-Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives an internal helper function called `createInstanceKeyPaths`, which can generate paths from either
+Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives an internal helper function called `createInstanceKeyPaths`, which can generate paths from either:
 - a list of instance keys (`targetItems`)
 - a label string
 
@@ -309,7 +309,7 @@ Use `getFilteredPaths` when you need more control over which nodes are shown. He
 
   <!-- END EXTRACTION -->
 
-- **Apply fully custom logic**: Generate pahts based on completely custom implementation, like showing each category that has an override applied in viewport.
+- **Apply fully custom logic**: Generate paths based on completely custom implementation. For exampel: showing each category that has an override applied in viewport.
     <!-- [[include: [TreeWidget.GetFilteredPathsComponentExample3], tsx]] -->
     <!-- BEGIN EXTRACTION -->
   ```tsx

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -218,11 +218,16 @@ function CustomModelsTreeComponent({ imodel, viewport, getSchemaContext, selecti
 
 #### Displaying a subset of the tree
 
-Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function, which receives a `createInstanceKeyPaths` function for creating hierarchy node paths from instance keys or an instance label and returns a list of hierarchy node paths targeting some nodes. When these paths are provided, the displayed hierarchy consists only of the targeted nodes, their ancestors, and their children.
-`getFilteredPaths` function doesn't need to be provided to be able to use search in `ModelsTreeComponent`. `createInstanceKeyPaths` is the internal function which is used when `getFilteredPaths` is undefined.
-`getFilteredPaths` function is useful when you want to apply additional or custom filtering. Example use cases:
+Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives an internal helper function called `createInstanceKeyPaths`, which can generate paths from either
+- a list of instance keys (`targetItems`)
+- a label string
 
-- You have instance keys of items you want to keep, these instance keys can be provided as `targetItems` to `createInstanceKeyPaths`. `createInstanceKeyPaths` will create filter paths based on the `targetItems`.
+When these paths are provided, the displayed hierarchy consists only of the targeted nodes, their ancestors, and their children.
+
+If `getFilteredPaths` is **not** provided, the default filtering logic uses the `filter` string and `createInstanceKeyPaths` internally.
+Use `getFilteredPaths` when you need more control over which nodes are shown. Here are some example use cases:
+
+- **Filter by known instance keys**: You already have a list of `InstanceKey` items that should remain in the tree. Pass them as `targetItems` to `createInstanceKeyPaths`.
   <!-- [[include: [TreeWidget.GetFilteredPathsComponentExample], tsx]] -->
   <!-- BEGIN EXTRACTION -->
 
@@ -263,7 +268,7 @@ Models tree allows displaying a subset of all nodes by providing a `getFilteredP
 
   <!-- END EXTRACTION -->
 
-- You want to modify paths which would be created by default. For example: `createInstanceKeyPaths` creates paths based on filter string, but you want to additionally filter out paths that are too long.
+- **Post-process the paths created `createInstanceKeyPaths`**: Use `filter` string to generate the paths, then apply additional filtering - e.g., remove paths that are too long.
   <!-- [[include: [TreeWidget.GetFilteredPathsComponentExample2], tsx]] -->
   <!-- BEGIN EXTRACTION -->
 
@@ -304,7 +309,7 @@ Models tree allows displaying a subset of all nodes by providing a `getFilteredP
 
   <!-- END EXTRACTION -->
 
-- You want to create filter paths based on custom logic. For example: you want to create a path for each category override in viewport.
+- **Apply fully custom logic**: Generate pahts based on completely custom implementation, like showing each category that has an override applied in viewport.
     <!-- [[include: [TreeWidget.GetFilteredPathsComponentExample3], tsx]] -->
     <!-- BEGIN EXTRACTION -->
   ```tsx

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -219,6 +219,7 @@ function CustomModelsTreeComponent({ imodel, viewport, getSchemaContext, selecti
 #### Displaying a subset of the tree
 
 Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives an internal helper function called `createInstanceKeyPaths`, which can generate paths from either:
+
 - a list of instance keys (`targetItems`)
 - a label string
 

--- a/packages/itwin/tree-widget/README.md
+++ b/packages/itwin/tree-widget/README.md
@@ -218,7 +218,7 @@ function CustomModelsTreeComponent({ imodel, viewport, getSchemaContext, selecti
 
 #### Displaying a subset of the tree
 
-Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives an internal helper function called `createInstanceKeyPaths`, which can generate paths from either:
+Models tree allows displaying a subset of all nodes by providing a `getFilteredPaths` function. This function receives a helper function called `createInstanceKeyPaths`, which can generate paths from either:
 
 - a list of instance keys (`targetItems`)
 - a label string

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -526,15 +526,14 @@ export function useModelsTreeButtonProps({ imodel, viewport }: {
 interface UseModelsTreeProps {
     // (undocumented)
     activeView: Viewport;
-    // (undocumented)
     filter?: string;
-    // (undocumented)
     getFilteredPaths?: (props: {
         createInstanceKeyPaths: (props: {
             targetItems: Array<InstanceKey | ElementsGroupInfo>;
         } | {
             label: string;
         }) => Promise<HierarchyFilteringPath[]>;
+        filter?: string;
     }) => Promise<HierarchyFilteringPath[]>;
     // (undocumented)
     hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -46,10 +46,9 @@ export interface UseModelsTreeProps {
   hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;
   visibilityHandlerOverrides?: ModelsTreeVisibilityHandlerOverrides;
   /**
-   * Optional function for providing custom filter paths.
-   * When defined, this function overrides the default filtering logic that uses the `filter` string.
+   * Optional function for applying custom filtering on the hierarchy. Use it when you want full control over which nodes should be displayed, based on more complex logic or known instance keys.
    *
-   * Use this function when you want full control over which nodes should be displaed, based on more complex logic or known instance keys.
+   * When defined, this function takes precedence over filtering by `filter` string. If both are supplied, the `filter` is provided as an argument to `getFilteredPaths`.
    *
    * @param props Parameters provided when `getFilteredPaths` is called:
    * - `createInstanceKeyPaths`: Helper function to create filter paths.

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -65,7 +65,7 @@ export interface UseModelsTreeProps {
   getFilteredPaths?: (props: {
     /** A function that creates filtering paths based on provided target instance keys or node label. */
     createInstanceKeyPaths: (props: { targetItems: Array<InstanceKey | ElementsGroupInfo> } | { label: string }) => Promise<HierarchyFilteringPath[]>;
-    /** Filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. It is usually the search string.*/
+    /** Filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. */
     filter?: string;
   }) => Promise<HierarchyFilteringPath[]>;
   onModelsFiltered?: (modelIds: Id64String[] | undefined) => void;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -35,7 +35,7 @@ type ModelsTreeFilteringError = "tooManyFilterMatches" | "tooManyInstancesFocuse
 /** @beta */
 export interface UseModelsTreeProps {
   /**
-   * Optional search string used to filter tree nodes.
+   * Optional search string used to filter tree nodes by label, as well as highlight matching substrings in the tree.
    * Nodes that do not contain this string in their label will be filtered out.
    *
    * If `getFilteredPaths` function is provided, it will take precedence and automatic filtering by this string will not be applied.

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -38,8 +38,8 @@ export interface UseModelsTreeProps {
    * Optional search string used to filter tree nodes.
    * Nodes that do not contain this string in their label will be filtered out.
    *
-   * This filtering works without the need of `getFilteredPaths`. If `getFilteredPaths` function is provided, it will take precedence and this
-   * string will be ignored during filtering process.
+   * If `getFilteredPaths` function is provided, it will take precedence and automatic filtering by this string will not be applied.
+   * Instead, the string will be supplied to the given `getFilteredPaths` function for consumers to apply the filtering.
    */
   filter?: string;
   activeView: Viewport;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -54,10 +54,11 @@ export interface UseModelsTreeProps {
    * - `createInstanceKeyPaths`: Helper function to create filter paths.
    * - `filter`: The filter string which would otherwise be used for default filtering.
    *
-   * ### Example use cases:
-   * - You have a list of `InstanceKey` items, which you want to keep. Pass them as `targetItems` to `createInstanceKeyPaths`.
-   * - You want to create filter paths based on a label, but also apply some extra conditions (for example exclude paths with sub-models).
+   * **Example use cases:**
+   * - You have a list of `InstanceKey` items, which you want to use for filtering the hierarchy.
+   * - You want to create filter paths based on node label, but also apply some extra conditions (for example exclude paths with sub-models).
    * - You want to construct custom filtered paths. For example: create a filter path for each geometric element which has a parent element.
+   *
    * @note Paths returned  by `createInstanceKeyPaths` will not have `autoExpand` flag set. If you want nodes to be expanded, iterate over the paths and
    * set `autoExpand: true` manually.
    */

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -34,12 +34,33 @@ type ModelsTreeFilteringError = "tooManyFilterMatches" | "tooManyInstancesFocuse
 
 /** @beta */
 export interface UseModelsTreeProps {
+  /** String used to filter models tree nodes. Nodes which don't contain specified string in their label will be filtered out.*/
   filter?: string;
   activeView: Viewport;
   hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;
   visibilityHandlerOverrides?: ModelsTreeVisibilityHandlerOverrides;
+  /**
+   * Function that can be used to create custom filter paths. This function doesn't need to be provided for filtering by filter string to work.
+   * `createInstanceKeyPaths` is the internal function which is used when `getFilteredPaths` is not provided.
+   *
+   * This function is useful when you want to apply additional or custom filtering. Example use cases:
+   * - You have instance keys of items you want to keep, these instance keys can be provided as `targetItems` to `createInstanceKeyPaths`.
+   * `createInstanceKeyPaths` will create filter paths based on the `targetItems`.
+   * - You want to modify paths which would be created by default. For example: `createInstanceKeyPaths` creates paths based on filter string and
+   * you want to additionally filter out paths that contain sub-models.
+   * - You want to create filter paths based on custom logic. For example: you want to create path for each geometric element that has a parent
+   * geometric element.
+   * @param props provided when `getFilteredPaths` is called.
+   * - `createInstanceKeyPaths` is the internal function that creates filtering paths based on provided target items or node label.
+   * - `filter` is the filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. It is usually the search string.
+   * @note Paths created by `createInstanceKeyPaths` won't have `autoExpand` flag set. If you want nodes to be expanded, iterate through each path and
+   * set `autoExpand` flag to `true`.
+   */
   getFilteredPaths?: (props: {
+    /** Internal function that creates filtering paths based on provided target items or node label.*/
     createInstanceKeyPaths: (props: { targetItems: Array<InstanceKey | ElementsGroupInfo> } | { label: string }) => Promise<HierarchyFilteringPath[]>;
+    /** Filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. It is usually the search string.*/
+    filter?: string;
   }) => Promise<HierarchyFilteringPath[]>;
   onModelsFiltered?: (modelIds: Id64String[] | undefined) => void;
   /**

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -34,27 +34,33 @@ type ModelsTreeFilteringError = "tooManyFilterMatches" | "tooManyInstancesFocuse
 
 /** @beta */
 export interface UseModelsTreeProps {
-  /** String used to filter models tree nodes. Nodes which don't contain specified string in their label will be filtered out.*/
+  /**
+   * Optional search string used to filter tree nodes.
+   * Nodes that do not contain this string in their label will be filtered out.
+   *
+   * This filtering works without the need of `getFilteredPaths`. If `getFilteredPaths` function is provided, it will take precedence and this
+   * string will be ignored during filtering process.
+   */
   filter?: string;
   activeView: Viewport;
   hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;
   visibilityHandlerOverrides?: ModelsTreeVisibilityHandlerOverrides;
   /**
-   * Function that can be used to create custom filter paths. This function doesn't need to be provided for filtering by filter string to work.
-   * `createInstanceKeyPaths` is the internal function which is used when `getFilteredPaths` is not provided.
+   * Optional function for providing custom filter paths.
+   * When defined, this function overrides the default filtering logic that uses the `filter` string.
    *
-   * This function is useful when you want to apply additional or custom filtering. Example use cases:
-   * - You have instance keys of items you want to keep, these instance keys can be provided as `targetItems` to `createInstanceKeyPaths`.
-   * `createInstanceKeyPaths` will create filter paths based on the `targetItems`.
-   * - You want to modify paths which would be created by default. For example: `createInstanceKeyPaths` creates paths based on filter string and
-   * you want to additionally filter out paths that contain sub-models.
-   * - You want to create filter paths based on custom logic. For example: you want to create path for each geometric element that has a parent
-   * geometric element.
-   * @param props provided when `getFilteredPaths` is called.
-   * - `createInstanceKeyPaths` is the internal function that creates filtering paths based on provided target items or node label.
-   * - `filter` is the filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. It is usually the search string.
-   * @note Paths created by `createInstanceKeyPaths` won't have `autoExpand` flag set. If you want nodes to be expanded, iterate through each path and
-   * set `autoExpand` flag to `true`.
+   * Use this function when you want full control over which nodes should be displaed, based on more complex logic or known instance keys.
+   *
+   * @param props Parameters provided when `getFilteredPaths` is called:
+   * - `createInstanceKeyPaths`: Helper function to create filter paths.
+   * - `filter`: The filter string which would otherwise be used for default filtering.
+   *
+   * ### Example use cases:
+   * - You have a list of `InstanceKey` items, which you want to keep. Pass them as `targetItems` to `createInstanceKeyPaths`.
+   * - You want to create filter paths based on a label, but also apply some extra conditions (for example exclude paths with sub-models).
+   * - You want to construct custom filtered paths. For example: create a filter path for each geometric element which has a parent element.
+   * @note Paths returned  by `createInstanceKeyPaths` will not have `autoExpand` flag set. If you want nodes to be expanded, iterate over the paths and
+   * set `autoExpand: true` manually.
    */
   getFilteredPaths?: (props: {
     /** Internal function that creates filtering paths based on provided target items or node label.*/
@@ -182,6 +188,7 @@ export function useModelsTree({
                 hierarchyConfig: hierarchyConfiguration,
                 limit: "unbounded",
               }),
+            filter,
           });
           void handlePaths(paths, imodelAccess);
           return paths;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -63,7 +63,7 @@ export interface UseModelsTreeProps {
    * set `autoExpand: true` manually.
    */
   getFilteredPaths?: (props: {
-    /** Internal function that creates filtering paths based on provided target items or node label.*/
+    /** A function that creates filtering paths based on provided target instance keys or node label. */
     createInstanceKeyPaths: (props: { targetItems: Array<InstanceKey | ElementsGroupInfo> } | { label: string }) => Promise<HierarchyFilteringPath[]>;
     /** Filter which would be used to create filter paths if `getFilteredPaths` wouldn't be provided. It is usually the search string.*/
     filter?: string;


### PR DESCRIPTION
closes #[1319](https://github.com/iTwin/viewer-components-react/issues/1319).

Added documentation explaining `getFilteredPaths` and its usage