### PR TITLE
Move integration test to performance tests

### DIFF
--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -63,7 +63,7 @@ export async function validateHierarchyVisibility({
 }) {
   await toVoidPromise(
     from(provider.getNodes({ parentNode: undefined })).pipe(
-      expand((node) => (node.children && (!ignoreChildren || !ignoreChildren(node)) ? provider.getNodes({ parentNode: node }) : EMPTY), 1000),
+      expand((node) => (node.children && !ignoreChildren(node) ? provider.getNodes({ parentNode: node }) : EMPTY), 1000),
       mergeMap(async (node) => waitFor(async () => validateNodeVisibility({ ...props, node })), 1000),
     ),
   );

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -56,7 +56,7 @@ async function validateNodeVisibility({ node, handler, expectations }: ValidateN
 
 export async function validateHierarchyVisibility({
   provider,
-  ignoreChildren,
+  ignoreChildren = () => false,
   ...props
 }: ValidateNodeProps & {
   provider: HierarchyProvider;

--- a/apps/performance-tests/src/util/TestReporter.cts
+++ b/apps/performance-tests/src/util/TestReporter.cts
@@ -7,7 +7,9 @@ import asTable from "as-table";
 import fs from "fs";
 import Mocha from "mocha";
 import { LOGGER } from "./Logging.cjs";
-import { MainThreadBlocksDetector, Summary } from "./MainThreadBlocksDetector.cjs";
+import { MainThreadBlocksDetector } from "./MainThreadBlocksDetector.cjs";
+
+import type { Summary } from "./MainThreadBlocksDetector.cjs";
 
 interface TestInfo {
   test: Mocha.Runnable;

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -2196,36 +2196,6 @@ describe("ModelsTreeVisibilityHandler", () => {
       });
     });
 
-    it.skip("validates visibility for large iModel", async function () {
-      await using buildIModelResult = await buildIModel(this, async (builder) => {
-        const modelsToTurnOn = new Array<string>();
-        let elementId = "";
-        for (let i = 0; i < 3; ++i) {
-          const model = insertPhysicalModelWithPartition({ builder, partitionParentId: IModel.rootSubjectId, codeValue: `model${i}` }).id;
-          modelsToTurnOn.push(model);
-          for (let j = 0; j < 1000; ++j) {
-            const categoryId = insertSpatialCategory({ builder, codeValue: `category${i}-${j}` }).id;
-            elementId = insertPhysicalElement({ builder, modelId: model, categoryId }).id;
-          }
-        }
-        return { modelsToTurnOn, elementId };
-      });
-
-      const { imodel, ...ids } = buildIModelResult;
-      using visibilityTestData = createVisibilityTestData({ imodel });
-      const { handler, provider, viewport } = visibilityTestData;
-      await Promise.all(ids.modelsToTurnOn.map(async (modelId) => handler.changeVisibility(createModelHierarchyNode(modelId), true)));
-      viewport.setAlwaysDrawn(new Set([ids.elementId]));
-      viewport.renderFrame();
-      await validateHierarchyVisibility({
-        provider,
-        handler,
-        viewport,
-        visibilityExpectations: VisibilityExpectations.all("visible"),
-        waitForOptions: { timeout: 2000 },
-      });
-    });
-
     it("showing model makes it, all its categories and elements visible and doesn't affect other models", async function () {
       await using buildIModelResult = await buildIModel(this, async (builder) => {
         const categoryId = insertSpatialCategory({ builder, codeValue: "category" }).id;


### PR DESCRIPTION
In https://github.com/iTwin/viewer-components-react/pull/1364 integration test was added which was failing on release pipeline. Created a similar test under performance tests and removed the old one.