### PR TITLE
[Tree widget]: Add missing peers

### DIFF
--- a/change/@itwin-tree-widget-react-28af0add-8cae-4243-83fc-abd20b9a8cd5.json
+++ b/change/@itwin-tree-widget-react-28af0add-8cae-4243-83fc-abd20b9a8cd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added missing peer dependencies.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -62,11 +62,15 @@
   "peerDependencies": {
     "@itwin/appui-abstract": "^4.0.0 || ^5.0.0",
     "@itwin/appui-react": "^4.10.0 || ^5.0.0",
+    "@itwin/core-common": "^4.0.0 || ^5.0.0",
     "@itwin/components-react": "^4.10.0 || ^5.0.0",
+    "@itwin/core-bentley": "^4.0.0 || ^5.0.0",
     "@itwin/core-frontend": "^4.0.0 || ^5.0.0",
     "@itwin/ecschema-metadata": "^4.0.0 || ^5.0.0",
     "@itwin/itwinui-react": "^3.11.0",
+    "@itwin/presentation-common": "^4.0.0 || ^5.0.0",
     "@itwin/presentation-components": "^5.0.0",
+    "@itwin/presentation-frontend": "^4.0.0 || ^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
Added missing peer dependecies:
- `@itwin/core-bentley` https://github.com/iTwin/viewer-components-react/blob/532f6f6a5d896c981d04a851f72b5960b3eb08f3/packages/itwin/tree-widget/src/tree-widget-react/TreeWidget.ts#L6
- `@itwin/core-common` https://github.com/iTwin/viewer-components-react/blob/532f6f6a5d896c981d04a851f72b5960b3eb08f3/packages/itwin/tree-widget/src/tree-widget-react/components/trees/imodel-content-tree/IModelContentTreeDefinition.ts#L6
- `@itwin/presentation-common` https://github.com/iTwin/viewer-components-react/blob/532f6f6a5d896c981d04a851f72b5960b3eb08f3/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyFiltering.tsx#L10
- `@itwin/presentation-frontend` https://github.com/iTwin/viewer-components-react/blob/532f6f6a5d896c981d04a851f72b5960b3eb08f3/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyFiltering.tsx#L12