### PR TITLE
Tree widget: Make model category elements query chunks smaller

### DIFF
--- a/change/@itwin-tree-widget-react-b7a83ae4-1cc2-4eb5-b8ce-73f7243e26e3.json
+++ b/change/@itwin-tree-widget-react-b7a83ae4-1cc2-4eb5-b8ce-73f7243e26e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Split large queries into smaller chunks to make them execute quicker.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -402,10 +402,9 @@ export class ModelsTreeIdsCache {
         }, new Map<Id64String, Id64Set>()),
         mergeMap((modelCategoryMap) => modelCategoryMap.entries()),
         map(([modelId, categoryIds]) => `Model.Id = ${modelId} AND Category.Id IN (${[...categoryIds].join(", ")})`),
-        // Maximum Depth Of An Expression Tree is set to 3000:
-        // https://github.com/iTwin/imodel-native/blob/f0f36d97fe10fd441b8bf760c331d299615a42b9/iModelCore/BeSQLite/SQLite/bentley-sqlite.c#L22
-        // 2900 makes sure that this limit is not reached
-        bufferCount(2900),
+        // we may have thousands of where clauses here, and sending a single query with all of them could take a
+        // long time - instead, split it into smaller chunks
+        bufferCount(100),
         mergeMap(async (whereClauses) => {
           const reader = this._queryExecutor.createQueryReader(
             {


### PR DESCRIPTION
For the test case at hand, there were ~1900 where clauses, so they were all placed into a single huge query. On a local briefcase the query took ~3 minutes to run, on GPB - more than 5 minutes.

Splitting it into chunks of 100 where clauses allows us to execute them in parallel and in GPB case they take ~11 seconds.
