### PR TITLE
[tree-widget] Add missing peer deps

### DIFF
--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -56,13 +56,16 @@
   "peerDependencies": {
     "@itwin/appui-abstract": "^5.0.0",
     "@itwin/appui-react": "^5.5.0",
+    "@itwin/core-bentley": "^5.0.0",
     "@itwin/components-react": "^5.5.0",
+    "@itwin/core-common": "^5.0.0",
     "@itwin/core-frontend": "^5.0.0",
     "@itwin/ecschema-metadata": "^5.0.0",
     "@stratakit/icons": "^0.1.0",
     "@stratakit/bricks": "^0.3.3",
     "@stratakit/foundations": "^0.2.2",
     "@stratakit/structures": "^0.3.1",
+    "@itwin/presentation-common": "^5.0.0",
     "@itwin/presentation-components": "^5.12.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"


### PR DESCRIPTION
Added missing peer dependencies. There are multiple places where stuff is imported from these packages but we don't have peer or direct dependency on them. Added `@itwin/core-bentley` to the peer deps because we already have quite a few peer deps on itwinjs-core. It's easier to move from peer deps to direct later if necessary.