### PR TITLE
Tree widget: Allow returning `undefined` paths from `getFilteredPaths` prop function

### DIFF
--- a/change/@itwin-tree-widget-react-d96e3dbf-a31f-4135-b74a-305c4c38ac62.json
+++ b/change/@itwin-tree-widget-react-d96e3dbf-a31f-4135-b74a-305c4c38ac62.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow Model tree's `getFilteredPaths` prop function to return `undefined` paths. In that case, it's considered that filtering should not be applied, and the full unfiltered tree should be loaded.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -328,6 +328,9 @@ export interface ModelsTreeVisibilityHandlerOverrides {
     }) => Promise<VisibilityStatus>>;
 }
 
+// @public (undocumented)
+type NormalizedHierarchyFilteringPath = ReturnType<(typeof HierarchyFilteringPath)["normalize"]>;
+
 // @public
 export function SelectableTree(props: SelectableTreeProps): JSX.Element | null;
 
@@ -529,13 +532,13 @@ interface UseModelsTreeProps {
             targetItems: Array<InstanceKey | ElementsGroupInfo>;
         } | {
             label: string;
-        }) => Promise<HierarchyFilteringPath[]>;
+        }) => Promise<NormalizedHierarchyFilteringPath[]>;
         filter?: string;
-    }) => Promise<HierarchyFilteringPath[]>;
+    }) => Promise<HierarchyFilteringPath[] | undefined>;
     getSubTreePaths?: (props: {
         createInstanceKeyPaths: (props: {
             targetItems: Array<InstanceKey | ElementsGroupInfo>;
-        }) => Promise<HierarchyFilteringPath[]>;
+        }) => Promise<NormalizedHierarchyFilteringPath[]>;
     }) => Promise<HierarchyFilteringPath[]>;
     // (undocumented)
     hierarchyConfig?: Partial<ModelsTreeHierarchyConfiguration>;

--- a/packages/itwin/tree-widget/src/test/trees/common/UseNodeHighlighting.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/common/UseNodeHighlighting.test.tsx
@@ -9,8 +9,24 @@ import { useNodeHighlighting } from "../../../tree-widget-react/components/trees
 import { render, renderHook } from "../../TestUtils.js";
 import { createPresentationHierarchyNode } from "../TreeUtils.js";
 
+import type { PresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
+
 describe("useNodeHighlighting", () => {
   it("does not highlight text when no matches found", () => {
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "node" })];
+    const onHighlightChangedStub = sinon.stub();
+
+    const { result } = renderHook(useNodeHighlighting, {
+      initialProps: { rootNodes, highlight: { text: "test", activeMatchIndex: undefined, onHighlightChanged: onHighlightChangedStub } },
+    });
+
+    expect(onHighlightChangedStub).to.be.calledWith(0, 0);
+    const { container } = render(result.current.getLabel(rootNodes[0]));
+
+    expect(container.querySelector("mark")).to.be.null;
+  });
+
+  it("does not highlight text when node is not filter target", () => {
     const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "node" })];
     const onHighlightChangedStub = sinon.stub();
 
@@ -25,7 +41,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("highlights text when match found", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "node" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "node" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result } = renderHook(useNodeHighlighting, {
@@ -39,7 +55,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("highlights text in the middle", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "1 test 2" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "1 test 2" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result } = renderHook(useNodeHighlighting, {
@@ -60,7 +76,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("highlights edges of text", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "test node test" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "test node test" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result } = renderHook(useNodeHighlighting, {
@@ -81,7 +97,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("merges adjacent non-active chunks", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "OOOO" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "OOOO" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result } = renderHook(useNodeHighlighting, {
@@ -98,7 +114,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("does not merge active chunk", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "OOOOO" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "OOOOO" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result } = renderHook(useNodeHighlighting, {
@@ -118,7 +134,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("adds and updates active match class", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "test test test" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "test test test" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender: rerenderHook } = renderHook(useNodeHighlighting, {
@@ -157,7 +173,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("updates index when active node predecessor nodes change", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "OOOO" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "OOOO" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender } = renderHook(useNodeHighlighting, {
@@ -176,8 +192,8 @@ describe("useNodeHighlighting", () => {
     expect(marks[2].textContent).to.be.eq("O");
 
     const newRootNodes = [
-      createPresentationHierarchyNode({ id: "predecessor-node", label: "O" }),
-      createPresentationHierarchyNode({ id: "node", label: "OOOO" }),
+      createdFilterTargetHierarchyNode({ id: "predecessor-node", label: "O" }),
+      createdFilterTargetHierarchyNode({ id: "node", label: "OOOO" }),
     ];
 
     onHighlightChangedStub.resetHistory();
@@ -187,7 +203,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("does not update index when active node successor nodes change", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "OOOO" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "OOOO" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender } = renderHook(useNodeHighlighting, {
@@ -206,8 +222,8 @@ describe("useNodeHighlighting", () => {
     expect(marks[2].textContent).to.be.eq("O");
 
     const newRootNodes = [
-      createPresentationHierarchyNode({ id: "node", label: "OOOO" }),
-      createPresentationHierarchyNode({ id: "successor-node", label: "O" }),
+      createdFilterTargetHierarchyNode({ id: "node", label: "OOOO" }),
+      createdFilterTargetHierarchyNode({ id: "successor-node", label: "O" }),
     ];
 
     onHighlightChangedStub.resetHistory();
@@ -217,7 +233,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("returns currently active node", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node-1", label: "node" }), createPresentationHierarchyNode({ id: "node-2", label: "node" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node-1", label: "node" }), createdFilterTargetHierarchyNode({ id: "node-2", label: "node" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender } = renderHook(useNodeHighlighting, {
@@ -235,7 +251,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("clears active node when `searchText` is empty", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "node" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "node" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender } = renderHook(useNodeHighlighting, {
@@ -253,7 +269,7 @@ describe("useNodeHighlighting", () => {
   });
 
   it("clears active node when `rootNodes` is empty", () => {
-    const rootNodes = [createPresentationHierarchyNode({ id: "node", label: "node" })];
+    const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "node" })];
     const onHighlightChangedStub = sinon.stub();
 
     const { result, rerender } = renderHook(useNodeHighlighting, {
@@ -270,3 +286,16 @@ describe("useNodeHighlighting", () => {
     expect(result.current.activeNodeId).to.be.undefined;
   });
 });
+
+function createdFilterTargetHierarchyNode(partial?: Partial<PresentationHierarchyNode>): PresentationHierarchyNode {
+  const node = createPresentationHierarchyNode(partial);
+  return {
+    ...node,
+    nodeData: {
+      ...node.nodeData,
+      filtering: {
+        isFilterTarget: true,
+      },
+    },
+  };
+}

--- a/packages/itwin/tree-widget/src/test/trees/common/UseNodeHighlighting.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/common/UseNodeHighlighting.test.tsx
@@ -54,6 +54,34 @@ describe("useNodeHighlighting", () => {
     expect(container.querySelector("mark")?.textContent).to.be.eq("node");
   });
 
+  it("highlights text when match found on a node nested under grouping node", () => {
+    const groupingNode = createPresentationHierarchyNode({ id: "grouping-node", label: "grouping node" });
+    const rootNodes = [
+      {
+        ...groupingNode,
+        nodeData: {
+          ...groupingNode.nodeData,
+          key: { type: "label-grouping", label: "grouped node" },
+          groupedInstanceKeys: [],
+        },
+        children: [createdFilterTargetHierarchyNode({ id: "grouped-node", label: "grouped node" })],
+      },
+    ] satisfies PresentationHierarchyNode[];
+    const onHighlightChangedStub = sinon.stub();
+
+    const { result } = renderHook(useNodeHighlighting, {
+      initialProps: { rootNodes, highlight: { text: "grouped node", activeMatchIndex: undefined, onHighlightChanged: onHighlightChangedStub } },
+    });
+
+    expect(onHighlightChangedStub).to.be.calledWith(0, 1);
+
+    const groupingNodeRender = render(result.current.getLabel(rootNodes[0]));
+    expect(groupingNodeRender.container.querySelector("mark")?.textContent).to.be.undefined;
+
+    const groupedNodeRender = render(result.current.getLabel(rootNodes[0].children[0]));
+    expect(groupedNodeRender.container.querySelector("mark")?.textContent).to.eq("grouped node");
+  });
+
   it("highlights text in the middle", () => {
     const rootNodes = [createdFilterTargetHierarchyNode({ id: "node", label: "1 test 2" })];
     const onHighlightChangedStub = sinon.stub();

--- a/packages/itwin/tree-widget/src/test/trees/common/Utils.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/Utils.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
 import { joinHierarchyFilteringPaths } from "../../../tree-widget-react/components/trees/common/Utils.js";
 
+import type { NormalizedHierarchyFilteringPath } from "../../../tree-widget-react/components/trees/common/Utils.js";
 import type { HierarchyNodeIdentifiersPath } from "@itwin/presentation-hierarchies";
 
 describe("Utils", () => {
@@ -22,15 +23,15 @@ describe("Utils", () => {
 
     it("returns empty when filter and subTree paths dont overlap", () => {
       const subTreePaths: HierarchyNodeIdentifiersPath[] = [[subject, model]];
-      const filterPaths: HierarchyFilteringPath[] = [
-        [subject, { ...model, imodelKey: "random" }],
-        [subject, { ...model, className: "random" }],
-        [subject, { ...model, id: "random" }],
-        [subject, category1],
-        [category1, model],
-        [model],
-        [category1],
-        [],
+      const filterPaths: NormalizedHierarchyFilteringPath[] = [
+        { path: [subject, { ...model, imodelKey: "random" }] },
+        { path: [subject, { ...model, className: "random" }] },
+        { path: [subject, { ...model, id: "random" }] },
+        { path: [subject, category1] },
+        { path: [category1, model] },
+        { path: [model] },
+        { path: [category1] },
+        { path: [] },
       ];
       const joinedPaths = joinHierarchyFilteringPaths(subTreePaths, filterPaths);
       expect(joinedPaths).to.deep.eq([]);
@@ -44,7 +45,7 @@ describe("Utils", () => {
       const filterPath5 = { path: [element2, element3], options: { autoExpand: { depth: 2, key: { className: element2.className, type: "class-grouping" } } } };
       const filterPath6 = { path: [element3, element4], options: { autoExpand: { depthInHierarchy: 1 } } };
       const filterPath7 = { path: [element4, category1], options: { autoExpand: { depthInPath: 1 } } };
-      const filterPaths: HierarchyFilteringPath[] = [filterPath1, filterPath2, filterPath3, filterPath4, filterPath5, filterPath6, filterPath7];
+      const filterPaths: NormalizedHierarchyFilteringPath[] = [filterPath1, filterPath2, filterPath3, filterPath4, filterPath5, filterPath6, filterPath7];
 
       const subTreePath1 = [...filterPath1.path, model];
       const subTreePath2 = [...filterPath2.path, element4];
@@ -95,8 +96,8 @@ describe("Utils", () => {
         [model, category1, element1, element2],
         [model, category1, element1, element3],
       ];
-      const filterPaths: HierarchyFilteringPath[] = [
-        [subject, model, category1],
+      const filterPaths: NormalizedHierarchyFilteringPath[] = [
+        { path: [subject, model, category1] },
         { path: [model, category1, element1, element2, element3], options: { autoExpand: true } },
         { path: [model, category1, element1, element3, element1], options: { autoExpand: { depth: 2 } } },
       ];

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
@@ -1679,7 +1679,7 @@ describe("Models tree", () => {
               hierarchyConfig,
             })
           ).sort(instanceKeyPathSorter);
-          expect(actualInstanceKeyPaths).to.deep.eq(instanceKeyPaths);
+          expect(actualInstanceKeyPaths).to.deep.eq(instanceKeyPaths.map(HierarchyFilteringPath.normalize));
         });
 
         it("finds instance key paths by target instance label", async function () {
@@ -1695,7 +1695,7 @@ describe("Models tree", () => {
               hierarchyConfig,
             })
           ).sort(instanceKeyPathSorter);
-          expect(actualInstanceKeyPaths).to.deep.eq(instanceKeyPaths);
+          expect(actualInstanceKeyPaths).to.deep.eq(instanceKeyPaths.map(HierarchyFilteringPath.normalize));
         });
       });
     });
@@ -1726,7 +1726,7 @@ describe("Models tree", () => {
           hierarchyConfig,
         })
       ).sort(instanceKeyPathSorter);
-      expect(actualInstanceKeyPaths).to.deep.eq(expectedPaths);
+      expect(actualInstanceKeyPaths).to.deep.eq(expectedPaths.map(HierarchyFilteringPath.normalize));
     });
 
     it("filtering by label aborts when abort signal fires", async function () {
@@ -1762,10 +1762,12 @@ describe("Models tree", () => {
         abortSignal: abortController2.signal,
       });
       expect(await pathsPromise).to.deep.eq([
-        [
-          { className: "BisCore.GeometricModel3d", id: ids.model.id },
-          { className: "BisCore.SpatialCategory", id: ids.category.id },
-        ],
+        {
+          path: [
+            { className: "BisCore.GeometricModel3d", id: ids.model.id },
+            { className: "BisCore.SpatialCategory", id: ids.category.id },
+          ],
+        },
       ]);
     });
 
@@ -1802,10 +1804,12 @@ describe("Models tree", () => {
         abortSignal: abortController2.signal,
       });
       expect(await pathsPromise).to.deep.eq([
-        [
-          { className: "BisCore.GeometricModel3d", id: ids.model.id },
-          { className: "BisCore.SpatialCategory", id: ids.category.id },
-        ],
+        {
+          path: [
+            { className: "BisCore.GeometricModel3d", id: ids.model.id },
+            { className: "BisCore.SpatialCategory", id: ids.category.id },
+          ],
+        },
       ]);
     });
 
@@ -1843,7 +1847,7 @@ describe("Models tree", () => {
             hierarchyConfig,
           })
         ).sort(instanceKeyPathSorter),
-      ).to.deep.eq([[adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element1)]]);
+      ).to.deep.eq([{ path: [adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element1)] }]);
 
       expect(
         (
@@ -1854,7 +1858,7 @@ describe("Models tree", () => {
             hierarchyConfig,
           })
         ).sort(instanceKeyPathSorter),
-      ).to.deep.eq([[adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element2)]]);
+      ).to.deep.eq([{ path: [adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element2)] }]);
 
       expect(
         (
@@ -1865,7 +1869,7 @@ describe("Models tree", () => {
             hierarchyConfig,
           })
         ).sort(instanceKeyPathSorter),
-      ).to.deep.eq([[adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element3)]]);
+      ).to.deep.eq([{ path: [adjustedModelKey(keys.model), keys.category, adjustedElementKey(keys.element3)] }]);
     });
   }
 });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseNodeHighlighting.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseNodeHighlighting.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { isPresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
+import { HierarchyNode, isPresentationHierarchyNode } from "@itwin/presentation-hierarchies-react";
 import { useLatest } from "./Utils.js";
 
 import type { PresentationHierarchyNode, PresentationTreeNode } from "@itwin/presentation-hierarchies-react";
@@ -119,7 +119,10 @@ function computeHighlightState(rootNodes: PresentationTreeNode[], searchText: st
         newState.totalMatches += matches.length;
       }
 
-      if (typeof node.children !== "boolean" && node.nodeData.filtering?.filteredChildrenIdentifierPaths?.length) {
+      if (
+        typeof node.children !== "boolean" &&
+        (HierarchyNode.isGroupingNode(node.nodeData) || node.nodeData.filtering?.filteredChildrenIdentifierPaths?.length)
+      ) {
         computeHighlightStateRecursively(node.children);
       }
     });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseNodeHighlighting.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseNodeHighlighting.tsx
@@ -113,11 +113,13 @@ function computeHighlightState(rootNodes: PresentationTreeNode[], searchText: st
         return;
       }
 
-      const matches = findChunks(node.label, searchText);
-      newState.nodeInfoMap.set(node.id, { startIndex: newState.totalMatches, matches });
-      newState.totalMatches += matches.length;
+      if (node.nodeData.filtering?.isFilterTarget) {
+        const matches = findChunks(node.label, searchText);
+        newState.nodeInfoMap.set(node.id, { startIndex: newState.totalMatches, matches });
+        newState.totalMatches += matches.length;
+      }
 
-      if (typeof node.children !== "boolean") {
+      if (typeof node.children !== "boolean" && node.nodeData.filtering?.filteredChildrenIdentifierPaths?.length) {
         computeHighlightStateRecursively(node.children);
       }
     });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/Utils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/Utils.ts
@@ -54,38 +54,39 @@ export function useLatest<T>(value: T) {
   return ref;
 }
 
-/** @internal */
-export function joinHierarchyFilteringPaths(subTreePaths: HierarchyNodeIdentifiersPath[], filteringPaths: HierarchyFilteringPath[]): HierarchyFilteringPath[] {
-  const normalizedFilteringPaths = filteringPaths.map((filteringPath) => HierarchyFilteringPath.normalize(filteringPath));
+/** @public */
+export type NormalizedHierarchyFilteringPath = ReturnType<(typeof HierarchyFilteringPath)["normalize"]>;
 
-  const result = new Array<HierarchyFilteringPath>();
+/** @internal */
+export function joinHierarchyFilteringPaths(subTreePaths: HierarchyNodeIdentifiersPath[], filteringPaths: NormalizedHierarchyFilteringPath[]): NormalizedHierarchyFilteringPath[] {
+  const result = new Array<NormalizedHierarchyFilteringPath>();
   const filteringPathsToIncludeIndexes = new Set<number>();
 
   subTreePaths.forEach((subTreePath) => {
     let options: HierarchyFilteringPathOptions | undefined;
     let addSubTreePathToResult = false;
 
-    for (let i = 0; i < normalizedFilteringPaths.length; ++i) {
-      const normalizedFilteringPath = normalizedFilteringPaths[i];
-      if (normalizedFilteringPath.path.length === 0) {
+    for (let i = 0; i < filteringPaths.length; ++i) {
+      const filteringPath = filteringPaths[i];
+      if (filteringPath.path.length === 0) {
         continue;
       }
 
       for (let j = 0; j < subTreePath.length; ++j) {
         const identifier = subTreePath[j];
-        if (normalizedFilteringPath.path.length <= j || !HierarchyNodeIdentifier.equal(normalizedFilteringPath.path[j], identifier)) {
+        if (filteringPath.path.length <= j || !HierarchyNodeIdentifier.equal(filteringPath.path[j], identifier)) {
           break;
         }
 
         // filtering paths that are shorter or equal than subTree paths length don't need to be added to the result
-        if (normalizedFilteringPath.path.length === j + 1) {
+        if (filteringPath.path.length === j + 1) {
           addSubTreePathToResult = true;
           // If filtering path has autoExpand set to true, it means that we should expand only to the targeted filtered node
           // This is done by setting depthInPath
           options =
-            normalizedFilteringPath.options?.autoExpand !== true
-              ? HierarchyFilteringPath.mergeOptions(options, normalizedFilteringPath.options)
-              : { autoExpand: { depthInPath: normalizedFilteringPath.path.length } };
+            filteringPath.options?.autoExpand !== true
+              ? HierarchyFilteringPath.mergeOptions(options, filteringPath.options)
+              : { autoExpand: { depthInPath: filteringPath.path.length } };
           break;
         }
 
@@ -105,7 +106,7 @@ export function joinHierarchyFilteringPaths(subTreePaths: HierarchyNodeIdentifie
     }
   });
   for (const index of filteringPathsToIncludeIndexes) {
-    result.push(normalizedFilteringPaths[index]);
+    result.push(filteringPaths[index]);
   }
   return result;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/Utils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/Utils.ts
@@ -58,7 +58,10 @@ export function useLatest<T>(value: T) {
 export type NormalizedHierarchyFilteringPath = ReturnType<(typeof HierarchyFilteringPath)["normalize"]>;
 
 /** @internal */
-export function joinHierarchyFilteringPaths(subTreePaths: HierarchyNodeIdentifiersPath[], filteringPaths: NormalizedHierarchyFilteringPath[]): NormalizedHierarchyFilteringPath[] {
+export function joinHierarchyFilteringPaths(
+  subTreePaths: HierarchyNodeIdentifiersPath[],
+  filteringPaths: NormalizedHierarchyFilteringPath[],
+): NormalizedHierarchyFilteringPath[] {
   const result = new Array<NormalizedHierarchyFilteringPath>();
   const filteringPathsToIncludeIndexes = new Set<number>();
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeComponent.tsx
@@ -170,7 +170,7 @@ function ModelsTreeComponentImpl({
         filteringProps={{
           onFilterStart: applyFilter,
           onFilterClear: clearFilter,
-          isDisabled: instanceFocusEnabled || !!treeProps.getFilteredPaths,
+          isDisabled: instanceFocusEnabled,
         }}
         buttons={buttons}
         density={density}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -25,6 +25,7 @@ import { IModel } from "@itwin/core-common";
 import {
   createNodesQueryClauseFactory,
   createPredicateBasedHierarchyDefinition,
+  HierarchyFilteringPath,
   NodeSelectClauseColumnNames,
   ProcessedHierarchyNode,
 } from "@itwin/presentation-hierarchies";
@@ -34,6 +35,7 @@ import { FilterLimitExceededError } from "../common/TreeErrors.js";
 import { createIdsSelector, parseIdsSelectorResult } from "../common/Utils.js";
 import { releaseMainThreadOnItemsCount } from "./Utils.js";
 
+import type { NormalizedHierarchyFilteringPath} from "../common/Utils.js";
 import type { Id64String } from "@itwin/core-bentley";
 import type { Observable } from "rxjs";
 import type {
@@ -47,7 +49,6 @@ import type {
 } from "@itwin/presentation-shared";
 import type {
   ClassGroupingNodeKey,
-  createIModelHierarchyProvider,
   DefineHierarchyLevelProps,
   DefineInstanceNodeChildHierarchyLevelProps,
   GroupingHierarchyNode,
@@ -128,9 +129,6 @@ type ModelsTreeInstanceKeyPathsFromInstanceLabelProps = {
 } & ModelsTreeInstanceKeyPathsBaseProps;
 
 export type ModelsTreeInstanceKeyPathsProps = ModelsTreeInstanceKeyPathsFromTargetItemsProps | ModelsTreeInstanceKeyPathsFromInstanceLabelProps;
-type HierarchyProviderProps = Parameters<typeof createIModelHierarchyProvider>[0];
-type HierarchyFilteringPaths = NonNullable<NonNullable<HierarchyProviderProps["filtering"]>["paths"]>;
-type HierarchyFilteringPath = HierarchyFilteringPaths[number];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace ModelsTreeInstanceKeyPathsProps {
@@ -544,7 +542,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     ];
   }
 
-  public static async createInstanceKeyPaths(props: ModelsTreeInstanceKeyPathsProps): Promise<HierarchyFilteringPath[]> {
+  public static async createInstanceKeyPaths(props: ModelsTreeInstanceKeyPathsProps): Promise<NormalizedHierarchyFilteringPath[]> {
     return lastValueFrom(
       defer(() => {
         if (ModelsTreeInstanceKeyPathsProps.isLabelProps(props)) {
@@ -593,7 +591,7 @@ function createGeometricElementInstanceKeyPaths(
   idsCache: ModelsTreeIdsCache,
   hierarchyConfig: ModelsTreeHierarchyConfiguration,
   targetItems: Array<Id64String | ElementsGroupInfo>,
-): Observable<HierarchyFilteringPath> {
+): Observable<NormalizedHierarchyFilteringPath> {
   const elementIds = targetItems.filter((info): info is Id64String => typeof info === "string");
   const groupInfos = targetItems.filter((info): info is ElementsGroupInfo => typeof info !== "string");
   const separator = ";";
@@ -673,7 +671,7 @@ function createGeometricElementInstanceKeyPaths(
           newModelPath.pop(); // model is already included in the element hierarchy path
           const path = [...newModelPath, ...elementHierarchyPath];
           if (!groupingNode) {
-            return path;
+            return { path };
           }
           return {
             path,
@@ -719,7 +717,7 @@ function createInstanceKeyPathsFromTargetItemsObs({
   hierarchyConfig,
   idsCache,
   limit,
-}: Omit<ModelsTreeInstanceKeyPathsFromTargetItemsProps, "abortSignal">): Observable<HierarchyFilteringPath[]> {
+}: Omit<ModelsTreeInstanceKeyPathsFromTargetItemsProps, "abortSignal">): Observable<NormalizedHierarchyFilteringPath[]> {
   if (limit !== "unbounded" && targetItems.length > (limit ?? MAX_FILTERING_INSTANCE_KEY_COUNT)) {
     throw new FilterLimitExceededError(limit ?? MAX_FILTERING_INSTANCE_KEY_COUNT);
   }
@@ -773,9 +771,11 @@ function createInstanceKeyPathsFromTargetItemsObs({
       const elementsLength = ids.elements.length;
       return collect(
         merge(
-          from(ids.subjects).pipe(mergeMap((id) => from(idsCache.createSubjectInstanceKeysPath(id)))),
-          from(ids.models).pipe(mergeMap((id) => from(idsCache.createModelInstanceKeyPaths(id)).pipe(mergeAll()))),
-          from(ids.categories).pipe(mergeMap((id) => from(idsCache.createCategoryInstanceKeyPaths(id)).pipe(mergeAll()))),
+          from(ids.subjects).pipe(mergeMap((id) => from(idsCache.createSubjectInstanceKeysPath(id)).pipe(map(HierarchyFilteringPath.normalize)))),
+          from(ids.models).pipe(mergeMap((id) => from(idsCache.createModelInstanceKeyPaths(id)).pipe(mergeAll(), map(HierarchyFilteringPath.normalize)))),
+          from(ids.categories).pipe(
+            mergeMap((id) => from(idsCache.createCategoryInstanceKeyPaths(id)).pipe(mergeAll(), map(HierarchyFilteringPath.normalize))),
+          ),
           from(ids.elements).pipe(
             bufferCount(Math.ceil(elementsLength / Math.ceil(elementsLength / 5000))),
             releaseMainThreadOnItemsCount(1),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -35,7 +35,7 @@ import { FilterLimitExceededError } from "../common/TreeErrors.js";
 import { createIdsSelector, parseIdsSelectorResult } from "../common/Utils.js";
 import { releaseMainThreadOnItemsCount } from "./Utils.js";
 
-import type { NormalizedHierarchyFilteringPath} from "../common/Utils.js";
+import type { NormalizedHierarchyFilteringPath } from "../common/Utils.js";
 import type { Id64String } from "@itwin/core-bentley";
 import type { Observable } from "rxjs";
 import type {


### PR DESCRIPTION
Made it possible in Models tree to apply given filter string only to a subset of the hierarchy (e.g. up to Model nodes, as shown in the updated README example).

Changes made:

1. Ability to use active filter string in the `getFilteredPaths` prop function was non-functional, because we couldn't return `undefined` when the `filter = undefined`. Now we can, and that means that filtering should not be applied.
2. Don't disable the filtering entry point when `getFilteredPaths` prop is provided.
3. Only highlight filter matches on nodes that are filter targets, only recurse into node's children if we know there are filter targets in there. This makes sure we don't highlight substring on nodes that are not filter targets, even if they have a matching substring (e.g. if we only search for Models, we don't want to highlight Categories). As a side effect, we're doing less work.