### PR TITLE
Fix aggregatableValues missing formatting in Measurement widgets

### DIFF
--- a/change/@itwin-measure-tools-react-1a5a6a2c-f7a8-4ec8-88ef-19284186d546.json
+++ b/change/@itwin-measure-tools-react-1a5a6a2c-f7a8-4ec8-88ef-19284186d546.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix aggregatableValues missing formatting in Measurement widgets",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "https://github.com/iTwin/viewer-components-react.git"
   },
-  "packageManager": "pnpm@10.6.5",
+  "packageManager": "pnpm@10.14.0",
   "scripts": {
     "build": "lage build --grouped",
     "cover": "lage cover --grouped --continue",

--- a/packages/itwin/measure-tools/src/api/FormatterUtils.ts
+++ b/packages/itwin/measure-tools/src/api/FormatterUtils.ts
@@ -6,11 +6,28 @@
 import type { Point3d, XAndY } from "@itwin/core-geometry";
 import type { Cartographic } from "@itwin/core-common";
 import { IModelApp, QuantityType } from "@itwin/core-frontend";
-import type { FormatProps } from "@itwin/core-quantity";
-import { FormatTraits, type FormatterSpec } from "@itwin/core-quantity";
+import { FormatTraits } from "@itwin/core-quantity";
 import { MeasureTools } from "../MeasureTools.js";
 
+import type { FormatProps , FormatterSpec} from "@itwin/core-quantity";
 export namespace FormatterUtils {
+
+  /**
+   * Gets a FormatterSpec by KoQ string with fallback to QuantityType.
+   * @param koqString The Kind of Quantity string to look up.
+   * @param fallbackQuantityType The QuantityType to use if KoQ lookup fails.
+   * @returns A FormatterSpec or undefined if both lookups fail.
+   */
+  export function getFormatterSpecWithFallback(koqString: string, fallbackQuantityType: QuantityType): FormatterSpec | undefined {
+    // First try to get the spec by KoQ string
+    const koqEntry = IModelApp.quantityFormatter.getSpecsByName(koqString);
+    if (koqEntry) {
+      return koqEntry.formatterSpec;
+    }
+
+    // Fallback to QuantityType
+    return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(fallbackQuantityType);
+  }
 
   /** Formats a sequence of values with spec without the unit label */
   function formatValuesWithNoUnitLabel(values: number[], spec: FormatterSpec): string {

--- a/packages/itwin/measure-tools/src/measurements/AngleMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/AngleMeasurement.ts
@@ -5,41 +5,23 @@
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { XYZProps } from "@itwin/core-geometry";
-import {
-  Angle,
-  AngleSweep,
-  Arc3d,
-  AxisOrder,
-  IModelJson,
-  Matrix3d,
-  Point3d,
-  PointString3d,
-  Vector3d,
-} from "@itwin/core-geometry";
-import type { GeometryStreamProps } from "@itwin/core-common";
-import type { BeButtonEvent, DecorateContext } from "@itwin/core-frontend";
-import { GraphicType, IModelApp } from "@itwin/core-frontend";
+import { GraphicType, IModelApp, QuantityType } from "@itwin/core-frontend";
+import { Angle, AngleSweep, Arc3d, AxisOrder, IModelJson, Matrix3d, Point3d, PointString3d, Vector3d } from "@itwin/core-geometry";
 import { FormatterUtils } from "../api/FormatterUtils.js";
-import {
-  StyleSet,
-  WellKnownGraphicStyleType,
-  WellKnownTextStyleType,
-} from "../api/GraphicStyle.js";
-import type {
-  MeasurementEqualityOptions,
-  MeasurementWidgetData,
-} from "../api/Measurement.js";
-import {
-  Measurement,
-  MeasurementPickContext,
-  MeasurementSerializer,
-} from "../api/Measurement.js";
+import { StyleSet, WellKnownGraphicStyleType, WellKnownTextStyleType } from "../api/GraphicStyle.js";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement.js";
 import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
-import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
 import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
 import { TextMarker } from "../api/TextMarker.js";
 import { MeasureTools } from "../MeasureTools.js";
 
+import type { GeometryStreamProps } from "@itwin/core-common";
+import type { BeButtonEvent, DecorateContext } from "@itwin/core-frontend";
+import type {
+  MeasurementEqualityOptions,
+  MeasurementWidgetData,
+} from "../api/Measurement.js";
+import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
 export interface AngleMeasurementProps extends MeasurementProps {
   startPoint?: XYZProps;
   center?: XYZProps;
@@ -407,7 +389,7 @@ export class AngleMeasurement extends Measurement {
   }
 
   protected override async getDataForMeasurementWidgetInternal(): Promise<MeasurementWidgetData> {
-    const angleSpec = IModelApp.quantityFormatter.getSpecsByName(this._angleKoQ)?.formatterSpec;
+    const angleSpec = FormatterUtils.getFormatterSpecWithFallback(this._angleKoQ, QuantityType.Angle);
     const angle = this.angle ?? 0;
     const fAngle = await FormatterUtils.formatAngle(angle, angleSpec);
 
@@ -436,7 +418,7 @@ export class AngleMeasurement extends Measurement {
 
   private async createTextMarker(): Promise<void> {
     if (this._center !== undefined && this.angle !== undefined) {
-      const angleSpec = IModelApp.quantityFormatter.getSpecsByName(this._angleKoQ)?.formatterSpec;
+      const angleSpec = FormatterUtils.getFormatterSpecWithFallback(this._angleKoQ, QuantityType.Angle);
       const angle = this.angle;
       const fAngle = await FormatterUtils.formatAngle(
         angle,

--- a/packages/itwin/measure-tools/src/measurements/AreaMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/AreaMeasurement.ts
@@ -5,13 +5,17 @@
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { XYZProps } from "@itwin/core-geometry";
-import {
-  Geometry,
-  IModelJson,
-  Point3d,
-  PointString3d,
-  PolygonOps,
-} from "@itwin/core-geometry";
+import { GraphicType, IModelApp, QuantityType } from "@itwin/core-frontend";
+import { Geometry, IModelJson, Point3d, PointString3d, PolygonOps } from "@itwin/core-geometry";
+import { FormatterUtils } from "../api/FormatterUtils.js";
+import { StyleSet, WellKnownGraphicStyleType } from "../api/GraphicStyle.js";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement.js";
+import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
+import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
+import { Polygon } from "../api/Polygon.js";
+import { MeasureTools } from "../MeasureTools.js";
+import { DistanceMeasurement } from "./DistanceMeasurement.js";
+
 import type { GeometryStreamProps } from "@itwin/core-common";
 import type {
   BeButtonEvent,
@@ -19,25 +23,11 @@ import type {
   GraphicBuilder,
   RenderGraphicOwner,
 } from "@itwin/core-frontend";
-import { GraphicType, IModelApp } from "@itwin/core-frontend";
-import { FormatterUtils } from "../api/FormatterUtils.js";
-import { StyleSet, WellKnownGraphicStyleType } from "../api/GraphicStyle.js";
 import type {
   MeasurementEqualityOptions,
   MeasurementWidgetData,
 } from "../api/Measurement.js";
-import {
-  Measurement,
-  MeasurementPickContext,
-  MeasurementSerializer,
-} from "../api/Measurement.js";
-import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
 import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
-import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
-import { Polygon } from "../api/Polygon.js";
-import { DistanceMeasurement } from "./DistanceMeasurement.js";
-import { MeasureTools } from "../MeasureTools.js";
-
 /**
  * Props for serializing a [[AreaMeasurement]].
  */
@@ -471,8 +461,8 @@ export class AreaMeasurement extends Measurement {
   }
 
   protected override async getDataForMeasurementWidgetInternal(): Promise<MeasurementWidgetData> {
-    const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
-    const areaSpec = IModelApp.quantityFormatter.getSpecsByName(this._areaKoQ)?.formatterSpec;
+    const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
+    const areaSpec = FormatterUtils.getFormatterSpecWithFallback(this._areaKoQ, QuantityType.Area);
 
     const fPerimeter = await FormatterUtils.formatLength(
       this.worldScale * this._polygon.perimeter,

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -5,44 +5,25 @@
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { XYAndZ, XYZProps } from "@itwin/core-geometry";
-import { Geometry, Range1d } from "@itwin/core-geometry";
-import {
-  IModelJson,
-  LineSegment3d,
-  Point3d,
-  PointString3d,
-  Ray3d,
-  Vector3d,
-} from "@itwin/core-geometry";
+import { GraphicType, IModelApp, QuantityType } from "@itwin/core-frontend";
+import { Geometry, IModelJson, LineSegment3d, Point3d, PointString3d, Range1d, Ray3d, Vector3d } from "@itwin/core-geometry";
+import { FormatterUtils } from "../api/FormatterUtils.js";
+import { StyleSet, TextOffsetType, WellKnownGraphicStyleType, WellKnownTextStyleType } from "../api/GraphicStyle.js";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement.js";
+import { MeasurementManager } from "../api/MeasurementManager.js";
+import { MeasurementPreferences, MeasurementPreferencesProperty } from "../api/MeasurementPreferences.js";
+import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
+import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
+import { TextMarker } from "../api/TextMarker.js";
+import { MeasureTools } from "../MeasureTools.js";
+
 import type { GeometryStreamProps } from "@itwin/core-common";
 import type { BeButtonEvent, DecorateContext } from "@itwin/core-frontend";
-import { GraphicType, IModelApp } from "@itwin/core-frontend";
-import { FormatterUtils } from "../api/FormatterUtils.js";
-import {
-  StyleSet,
-  TextOffsetType,
-  WellKnownGraphicStyleType,
-  WellKnownTextStyleType,
-} from "../api/GraphicStyle.js";
 import type {
   MeasurementEqualityOptions,
   MeasurementWidgetData,
 } from "../api/Measurement.js";
-import {
-  Measurement,
-  MeasurementPickContext,
-  MeasurementSerializer,
-} from "../api/Measurement.js";
-import { MeasurementManager } from "../api/MeasurementManager.js";
-import {
-  MeasurementPreferences,
-  MeasurementPreferencesProperty,
-} from "../api/MeasurementPreferences.js";
-import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
 import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
-import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
-import { TextMarker } from "../api/TextMarker.js";
-import { MeasureTools } from "../MeasureTools.js";
 import type { FormatterSpec } from "@itwin/core-quantity";
 
 /**
@@ -569,17 +550,17 @@ export class DistanceMeasurement extends Measurement {
     const bearing = FormatterUtils.calculateBearing(this._endPoint.x - this._startPoint.x, this._endPoint.y - this._startPoint.y);
     const adjustedStart = this.adjustPointForGlobalOrigin(this._startPoint);
     const adjustedEnd = this.adjustPointForGlobalOrigin(this._endPoint);
-    const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
-    const coordinateSpec = IModelApp.quantityFormatter.getSpecsByName(this._coordinateKoQ)?.formatterSpec;
+    const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
+    const coordinateSpec = FormatterUtils.getFormatterSpecWithFallback(this._coordinateKoQ, QuantityType.Coordinate);
 
-    const fDistance = await FormatterUtils.formatLength(distance, lengthSpec);
+    const fDistance = lengthSpec ? IModelApp.quantityFormatter.formatQuantity(distance, lengthSpec) : await FormatterUtils.formatLength(distance);
     const fStartCoords = FormatterUtils.formatCoordinatesImmediate(adjustedStart, coordinateSpec);
     const fEndCoords = FormatterUtils.formatCoordinatesImmediate(adjustedEnd, coordinateSpec);
     const fSlope = FormatterUtils.formatSlope(slope, true);
-    const fRun = await FormatterUtils.formatLength(run, lengthSpec);
-    const fDeltaX = await FormatterUtils.formatLength(dx, lengthSpec);
-    const fDeltaY = await FormatterUtils.formatLength(dy, lengthSpec);
-    const fRise = await FormatterUtils.formatLength(rise, lengthSpec);
+    const fRun = lengthSpec ? IModelApp.quantityFormatter.formatQuantity(run, lengthSpec) : await FormatterUtils.formatLength(run);
+    const fDeltaX = lengthSpec ? IModelApp.quantityFormatter.formatQuantity(dx, lengthSpec) : await FormatterUtils.formatLength(dx);
+    const fDeltaY = lengthSpec ? IModelApp.quantityFormatter.formatQuantity(dy, lengthSpec) : await FormatterUtils.formatLength(dy);
+    const fRise = lengthSpec ? IModelApp.quantityFormatter.formatQuantity(rise, lengthSpec) : await FormatterUtils.formatLength(rise);
 
     let title = MeasureTools.localization.getLocalizedString(
       "MeasureTools:Measurements.distanceMeasurement"

--- a/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
@@ -5,42 +5,29 @@
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { XYZProps } from "@itwin/core-geometry";
-import {
-  Geometry,
-  IModelJson,
-  Point3d,
-  PointString3d,
-} from "@itwin/core-geometry";
-import type {
-  CartographicProps,
-  GeometryStreamProps,
-} from "@itwin/core-common";
 import { Cartographic } from "@itwin/core-common";
-import type { BeButtonEvent, DecorateContext } from "@itwin/core-frontend";
-import { GraphicType, IModelApp } from "@itwin/core-frontend";
+import { GraphicType, IModelApp, QuantityType } from "@itwin/core-frontend";
+import { Geometry, IModelJson, Point3d, PointString3d } from "@itwin/core-geometry";
 import { FormatterUtils } from "../api/FormatterUtils.js";
-import {
-  StyleSet,
-  WellKnownGraphicStyleType,
-  WellKnownTextStyleType,
-} from "../api/GraphicStyle.js";
-import type {
-  MeasurementEqualityOptions,
-  MeasurementWidgetData,
-} from "../api/Measurement.js";
-import {
-  Measurement,
-  MeasurementPickContext,
-  MeasurementSerializer,
-} from "../api/Measurement.js";
+import { StyleSet, WellKnownGraphicStyleType, WellKnownTextStyleType } from "../api/GraphicStyle.js";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement.js";
 import { WellKnownViewType } from "../api/MeasurementEnums.js";
 import { MeasurementPreferences } from "../api/MeasurementPreferences.js";
 import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
-import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
 import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
 import { TextMarker } from "../api/TextMarker.js";
 import { MeasureTools } from "../MeasureTools.js";
 
+import type {
+  CartographicProps,
+  GeometryStreamProps,
+} from "@itwin/core-common";
+import type { BeButtonEvent, DecorateContext } from "@itwin/core-frontend";
+import type {
+  MeasurementEqualityOptions,
+  MeasurementWidgetData,
+} from "../api/Measurement.js";
+import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
 /**
  * Props for serializing a [[LocationMeasurement]].
  */
@@ -348,7 +335,7 @@ export class LocationMeasurement extends Measurement {
 
   private async createTextMarker(): Promise<void> {
     const adjustedLocation = this.adjustPointWithSheetToWorldTransform(this.adjustPointForGlobalOrigin(this._location));
-    const coordinateSpec = IModelApp.quantityFormatter.getSpecsByName(this._coordinateKoQ)?.formatterSpec;
+    const coordinateSpec = FormatterUtils.getFormatterSpecWithFallback(this._coordinateKoQ, QuantityType.Coordinate);
 
     const entries = [
       {
@@ -404,10 +391,10 @@ export class LocationMeasurement extends Measurement {
   protected override async getDataForMeasurementWidgetInternal(): Promise<
   MeasurementWidgetData | undefined
   > {
-    const coordinateSpec = IModelApp.quantityFormatter.getSpecsByName(this._coordinateKoQ)?.formatterSpec;
-    const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
-    const angleSpec = IModelApp.quantityFormatter.getSpecsByName(this._angleKoQ)?.formatterSpec;
-    const stationSpec = IModelApp.quantityFormatter.getSpecsByName(this._stationKoQ)?.formatterSpec;
+    const coordinateSpec = FormatterUtils.getFormatterSpecWithFallback(this._coordinateKoQ, QuantityType.Coordinate);
+    const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
+    const angleSpec = FormatterUtils.getFormatterSpecWithFallback(this._angleKoQ, QuantityType.Angle);
+    const stationSpec = FormatterUtils.getFormatterSpecWithFallback(this._stationKoQ, QuantityType.Stationing);
 
     const adjustedLocation = this.adjustPointWithSheetToWorldTransform(this.adjustPointForGlobalOrigin(this._location));
     const fCoordinates = FormatterUtils.formatCoordinatesImmediate(adjustedLocation, coordinateSpec);

--- a/packages/itwin/measure-tools/src/measurements/RadiusMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/RadiusMeasurement.ts
@@ -5,42 +5,28 @@
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { XYZProps } from "@itwin/core-geometry";
-import {
-  Arc3d,
-  IModelJson,
-  Point3d,
-  Ray3d,
-  Vector3d,
-} from "@itwin/core-geometry";
+import { GraphicType, IModelApp, QuantityType } from "@itwin/core-frontend";
+import { Arc3d, IModelJson, Point3d, Ray3d, Vector3d } from "@itwin/core-geometry";
+import { FormatterUtils } from "../api/FormatterUtils.js";
+import { StyleSet, WellKnownGraphicStyleType, WellKnownTextStyleType } from "../api/GraphicStyle.js";
+import { Measurement, MeasurementPickContext, MeasurementSerializer } from "../api/Measurement.js";
+import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
+import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
+import { TextMarker } from "../api/TextMarker.js";
+import { ViewHelper } from "../api/ViewHelper.js";
+import { MeasureTools } from "../MeasureTools.js";
+
 import type { GeometryStreamProps } from "@itwin/core-common";
 import type {
   BeButtonEvent,
   DecorateContext,
   Viewport,
 } from "@itwin/core-frontend";
-import { GraphicType, IModelApp } from "@itwin/core-frontend";
-import { FormatterUtils } from "../api/FormatterUtils.js";
-import {
-  StyleSet,
-  WellKnownGraphicStyleType,
-  WellKnownTextStyleType,
-} from "../api/GraphicStyle.js";
 import type {
   MeasurementEqualityOptions,
   MeasurementWidgetData,
 } from "../api/Measurement.js";
-import {
-  Measurement,
-  MeasurementPickContext,
-  MeasurementSerializer,
-} from "../api/Measurement.js";
-import { MeasurementPropertyHelper } from "../api/MeasurementPropertyHelper.js";
 import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
-import { MeasurementSelectionSet } from "../api/MeasurementSelectionSet.js";
-import { TextMarker } from "../api/TextMarker.js";
-import { ViewHelper } from "../api/ViewHelper.js";
-import { MeasureTools } from "../MeasureTools.js";
-
 export interface RadiusMeasurementProps extends MeasurementProps {
   startPoint?: XYZProps;
   midPoint?: XYZProps;
@@ -449,7 +435,7 @@ export class RadiusMeasurement extends Measurement {
   }
 
   protected override async getDataForMeasurementWidgetInternal(): Promise<MeasurementWidgetData> {
-    const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
+    const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
 
     const radius = this._arc?.circularRadius() ?? 0.0;
     const diameter = radius * 2;
@@ -550,7 +536,7 @@ export class RadiusMeasurement extends Measurement {
 
   private async createTextMarker(): Promise<void> {
     if (this._arc !== undefined) {
-      const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
+      const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
       const radius = this._arc.circularRadius()!;
       const fRadius = await FormatterUtils.formatLength(
         radius,

--- a/packages/itwin/measure-tools/src/test/measure-tools/AngleMeasurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/AngleMeasurement.test.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Point3d } from "@itwin/core-geometry";
 import { assert } from "chai";
+import { Point3d } from "@itwin/core-geometry";
 import { Measurement, MeasurementPickContext } from "../../api/Measurement.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
 import { AngleMeasurement, AngleMeasurementSerializer } from "../../measurements/AngleMeasurement.js";
@@ -117,9 +117,10 @@ describe("AngleMeasurement tests", () => {
 
     assert.lengthOf(model.measurements, 0);
     assert.instanceOf(model.dynamicMeasurement, AngleMeasurement);
-    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(model.dynamicMeasurement!.startPointRef!));
-    assert.isUndefined(model.dynamicMeasurement!.centerRef);
-    assert.isUndefined(model.dynamicMeasurement!.endPointRef);
+    const dynamicMeasurement = model.dynamicMeasurement as AngleMeasurement;
+    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(dynamicMeasurement.startPointRef!));
+    assert.isUndefined(dynamicMeasurement.centerRef);
+    assert.isUndefined(dynamicMeasurement.endPointRef);
 
     // Test SetCenter state
     assert.strictEqual(MeasureAngleToolModel.State.SetCenter, model.currentState);

--- a/packages/itwin/measure-tools/src/test/measure-tools/DistanceMeasurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/DistanceMeasurement.test.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Point3d } from "@itwin/core-geometry";
 import { assert } from "chai";
+import { Point3d } from "@itwin/core-geometry";
 import { Measurement, MeasurementPickContext } from "../../api/Measurement.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
 import { DistanceMeasurement, DistanceMeasurementSerializer } from "../../measurements/DistanceMeasurement.js";
@@ -101,8 +101,9 @@ describe("DistanceMeasurement tests", () => {
 
     assert.lengthOf(model.measurements, 0);
     assert.instanceOf(model.dynamicMeasurement, DistanceMeasurement);
-    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(model.dynamicMeasurement!.startPointRef));
-    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(model.dynamicMeasurement!.endPointRef));
+    const dynamicMeasurement = model.dynamicMeasurement as DistanceMeasurement;
+    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(dynamicMeasurement.startPointRef));
+    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(dynamicMeasurement.endPointRef));
 
     // Test state with dynamics
     assert.strictEqual(MeasureDistanceToolModel.State.SetEndPoint, model.currentState);

--- a/packages/itwin/measure-tools/src/test/measure-tools/RadiusMeasurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/RadiusMeasurement.test.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Point3d } from "@itwin/core-geometry";
 import { assert } from "chai";
+import { Point3d } from "@itwin/core-geometry";
 import { Measurement, MeasurementPickContext } from "../../api/Measurement.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
 import { RadiusMeasurement, RadiusMeasurementSerializer } from "../../measurements/RadiusMeasurement.js";
@@ -117,9 +117,10 @@ describe("RadiusMeasurement tests", () => {
 
     assert.lengthOf(model.measurements, 0);
     assert.instanceOf(model.dynamicMeasurement, RadiusMeasurement);
-    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(model.dynamicMeasurement!.startPointRef!));
-    assert.isUndefined(model.dynamicMeasurement!.midPointRef);
-    assert.isUndefined(model.dynamicMeasurement!.endPointRef);
+    const dynamicMeasurement = model.dynamicMeasurement as RadiusMeasurement;
+    assert.isTrue(Point3d.create(1, 2, 3).isAlmostEqual(dynamicMeasurement.startPointRef!));
+    assert.isUndefined(dynamicMeasurement.midPointRef);
+    assert.isUndefined(dynamicMeasurement.endPointRef);
 
     // Test SetMidPoint state
     assert.strictEqual(MeasureRadiusToolModel.State.SetMidPoint, model.currentState);

--- a/packages/itwin/measure-tools/src/test/measure-tools/_Setup.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/_Setup.test.ts
@@ -2,16 +2,15 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { afterAll, beforeAll } from "vitest";
-
-import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
-import { MeasureTools } from "../../MeasureTools.js";
-import { TestUtils } from "../TestUtils.js";
-import { EmptyLocalization } from "@itwin/core-common";
-import { SchemaContext, SchemaUnitProvider } from "@itwin/ecschema-metadata";
-import { SchemaXmlFileLocater } from "@itwin/ecschema-locaters";
 
 import * as path from "path";
+import { afterAll, beforeAll, vi } from "vitest";
+import { EmptyLocalization } from "@itwin/core-common";
+import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
+import { SchemaXmlFileLocater } from "@itwin/ecschema-locaters";
+import { SchemaContext, SchemaUnitProvider } from "@itwin/ecschema-metadata";
+import { MeasureTools } from "../../MeasureTools.js";
+import { TestUtils } from "../TestUtils.js";
 
 // Before all tests, initialize any global services
 beforeAll(async () => {
@@ -25,6 +24,8 @@ beforeAll(async () => {
   locUnits.addSchemaSearchPath(unitSchemaFilePath)
   schemaContext.addLocater(locUnits);
   IModelApp.quantityFormatter.setUnitsProvider(new SchemaUnitProvider(schemaContext));
+  window.HTMLElement.prototype.scrollTo = vi.fn();
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Closes https://github.com/iTwin/viewer-components-react/issues/1415.

Falling back to QuantityType was working for iModels that don't have the specified KoQ, however aggregatableValue fields did not include that fallback because it was still trying to use an undefined formatSpec associated with the missing KoQ, when other fields are using the fallbacks. Fixed it so now aggregatableValue fields will use fallback formatter specs as well.

Also, bumped pnpm package manager version in the root of repo, to address [bug](https://github.com/pnpm/pnpm/issues/9792) with pnpm