### PR TITLE
Update MeasurementWidget to react to format change events

### DIFF
--- a/change/@itwin-measure-tools-react-95ece8b6-df5c-41c3-b011-4963415a12c2.json
+++ b/change/@itwin-measure-tools-react-95ece8b6-df5c-41c3-b011-4963415a12c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MeasurementWidget reacts to formatsProvider changes",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/api/FormatterUtils.ts
+++ b/packages/itwin/measure-tools/src/api/FormatterUtils.ts
@@ -219,6 +219,34 @@ export namespace FormatterUtils {
     return bearing;
   }
 
+  /**
+   * Creates a FormatterSpec for bearing using the provided KoQ string with fallback to default bearing format.
+   * @param bearingKoQ The Kind of Quantity string for bearing.
+   * @param persistenceUnitName The persistence unit name for the bearing.
+   * @returns A FormatterSpec for bearing formatting.
+   */
+  export async function getBearingFormatterSpec(bearingKoQ: string, persistenceUnitName: string): Promise<FormatterSpec | undefined> {
+    let formatProps: FormatProps | undefined;
+
+    try {
+      // First try to get format props from the formats provider using the bearingKoQ
+      formatProps = await IModelApp.formatsProvider.getFormat(bearingKoQ);
+    } catch {
+      // If that fails, formatProps will remain undefined and we'll use the fallback
+    }
+
+    // If we couldn't get format props from the provider, use the default bearing format
+    if (!formatProps) {
+      formatProps = getDefaultBearingFormatProps();
+    }
+
+    // Create and return the formatter spec
+    return IModelApp.quantityFormatter.createFormatterSpec({
+      persistenceUnitName,
+      formatProps
+    });
+  }
+
   export function getDefaultBearingFormatProps(): FormatProps {
     return {
       minWidth: 2,

--- a/packages/itwin/measure-tools/src/api/FormatterUtils.ts
+++ b/packages/itwin/measure-tools/src/api/FormatterUtils.ts
@@ -9,7 +9,7 @@ import { IModelApp, QuantityType } from "@itwin/core-frontend";
 import { FormatTraits } from "@itwin/core-quantity";
 import { MeasureTools } from "../MeasureTools.js";
 
-import type { FormatProps , FormatterSpec} from "@itwin/core-quantity";
+import type { FormatDefinition, FormatProps , FormatterSpec} from "@itwin/core-quantity";
 export namespace FormatterUtils {
 
   /**
@@ -226,17 +226,13 @@ export namespace FormatterUtils {
    * @returns A FormatterSpec for bearing formatting.
    */
   export async function getBearingFormatterSpec(bearingKoQ: string, persistenceUnitName: string): Promise<FormatterSpec | undefined> {
-    let formatProps: FormatProps | undefined;
-
+    let formatProps: FormatDefinition;
     try {
-      // First try to get format props from the formats provider using the bearingKoQ
-      formatProps = await IModelApp.formatsProvider.getFormat(bearingKoQ);
+      // Get format props from the formats provider using the bearingKoQ. If undefined, use default bearing format
+      const result = await IModelApp.formatsProvider.getFormat(bearingKoQ);
+      formatProps = result ?? getDefaultBearingFormatProps();
     } catch {
-      // If that fails, formatProps will remain undefined and we'll use the fallback
-    }
-
-    // If we couldn't get format props from the provider, use the default bearing format
-    if (!formatProps) {
+    // If an error occurs, use the default bearing format
       formatProps = getDefaultBearingFormatProps();
     }
 

--- a/packages/itwin/measure-tools/src/api/MeasurementManager.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementManager.ts
@@ -15,7 +15,7 @@ import { ShimFunctions } from "./ShimFunctions.js";
 import type { GeometryStreamProps } from "@itwin/core-common";
 import type { BeButtonEvent, DecorateContext, Decorator, HitDetail, ScreenViewport, Viewport } from "@itwin/core-frontend";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { Measurement} from "./Measurement.js";
+import type { Measurement } from "./Measurement.js";
 /** Handler for overriding what is returned for the tooltip of a measurement. */
 export type MeasurementToolTipHandler = (measurement: Measurement, pickContext: MeasurementPickContext) => Promise<HTMLElement | string>;
 

--- a/packages/itwin/measure-tools/src/api/MeasurementManager.ts
+++ b/packages/itwin/measure-tools/src/api/MeasurementManager.ts
@@ -4,11 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeUiEvent } from "@itwin/core-bentley";
-import type { GeometryStreamProps } from "@itwin/core-common";
-import type { BeButtonEvent, DecorateContext, Decorator, HitDetail, ScreenViewport, Viewport } from "@itwin/core-frontend";
-import type { IModelConnection } from "@itwin/core-frontend";
 import { EventHandled, IModelApp } from "@itwin/core-frontend";
-import type { Measurement} from "./Measurement.js";
 import { MeasurementPickContext } from "./Measurement.js";
 import { MeasurementCachedGraphicsHandler } from "./MeasurementCachedGraphicsHandler.js";
 import { MeasurementButtonHandledEvent, WellKnownViewType } from "./MeasurementEnums.js";
@@ -16,6 +12,10 @@ import { MeasurementSelectionSet } from "./MeasurementSelectionSet.js";
 import { MeasurementUIEvents } from "./MeasurementUIEvents.js";
 import { ShimFunctions } from "./ShimFunctions.js";
 
+import type { GeometryStreamProps } from "@itwin/core-common";
+import type { BeButtonEvent, DecorateContext, Decorator, HitDetail, ScreenViewport, Viewport } from "@itwin/core-frontend";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { Measurement} from "./Measurement.js";
 /** Handler for overriding what is returned for the tooltip of a measurement. */
 export type MeasurementToolTipHandler = (measurement: Measurement, pickContext: MeasurementPickContext) => Promise<HTMLElement | string>;
 
@@ -498,6 +498,7 @@ export class MeasurementManager implements Decorator {
       measurement.onDisplayUnitsChanged();
       this.invalidateDecorations();
     }
+    MeasurementUIEvents.notifyMeasurementPropertiesChanged(this._measurements)
   }
 }
 

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -198,6 +198,8 @@ export class DistanceMeasurement extends Measurement {
     this._lengthPersistenceUnitName = "Units.M";
     this._coordinateKoQ = "AecUnits.LENGTH_COORDINATE";
     this._coordinatePersistenceUnitName = "Units.M";
+    this._bearingKoQ = "RoadRailUnits.BEARING";
+    this._bearingPersistenceUnitName = "Units.RAD";
     if (props) this.readFromJSON(props);
 
     this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())
@@ -609,14 +611,7 @@ export class DistanceMeasurement extends Measurement {
       },
     );
     if (this._bearingKoQ && this._bearingPersistenceUnitName) {
-      let bearingSpec: FormatterSpec | undefined;
-      const bearingFormatProps = FormatterUtils.getDefaultBearingFormatProps();
-      if (bearingFormatProps) {
-        bearingSpec = await IModelApp.quantityFormatter.createFormatterSpec({
-          persistenceUnitName: this._bearingPersistenceUnitName,
-          formatProps: bearingFormatProps
-        });
-      }
+      const bearingSpec = await FormatterUtils.getBearingFormatterSpec(this._bearingKoQ, this._bearingPersistenceUnitName);
       const fBearing: string = IModelApp.quantityFormatter.formatQuantity(bearing, bearingSpec);
       data.properties.push({
         label: MeasureTools.localization.getLocalizedString(


### PR DESCRIPTION
As stated in PR title, have the widget update to format changes without selecting/unselecting (matching property-grid behavior)

- Also, updating bearing property in distance measurement widget, previously it had used hard coded bearing formatProps, now it'll use bearing format coming from FormatsProvider, falling back to hard coded props if formatsProvider can't find any.