### PR TITLE
Fixed DistanceMeasurement value when using it in sheets

### DIFF
--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -507,7 +507,7 @@ export class DistanceMeasurement extends Measurement {
 
     const distance = this._startPoint.distance(this._endPoint);
     const fDistance = await FormatterUtils.formatLength(
-      distance,
+      distance * this.worldScale,
       lengthSpec
     );
 


### PR DESCRIPTION
This looks like it was removed by mistake. It was causing the tooltip not to display the world value as it was not converted:
<img width="1287" height="676" alt="image" src="https://github.com/user-attachments/assets/c64336b0-75b5-4521-bd9f-5d79b6b04afb" />
