### PR TITLE
[property-grid]: Open property grid when selection already contains something

### DIFF
--- a/change/@itwin-property-grid-react-bb732407-464d-4b9a-81cd-72a0f9356e81.json
+++ b/change/@itwin-property-grid-react-bb732407-464d-4b9a-81cd-72a0f9356e81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Open property grid if selection contains something before property grid is added to frontstage",
+  "packageName": "@itwin/property-grid-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes https://github.com/iTwin/viewer-components-react/issues/1425