### PR TITLE
[map-layers] Fix settings popup height

### DIFF
--- a/change/@itwin-map-layers-cc9e50cf-06fb-4c63-960f-b547c7aca5c1.json
+++ b/change/@itwin-map-layers-cc9e50cf-06fb-4c63-960f-b547c7aca5c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Increase height of maplayers settings popup to eliminate scroll bar.",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
@@ -367,7 +367,7 @@ $default-font-size: --iui-font-size-1;
 
 .map-sources-popup-panel {
   padding: 4px;
-  width: 400px;
+  width: 480px;
 
   * {
     box-sizing: border-box;


### PR DESCRIPTION
Current QA version does not show all settings without needing to scroll:
<img width="380" height="495" alt="image" src="https://github.com/user-attachments/assets/afc26459-cb8d-407a-9766-a8a4fb321a9a" />

Prod version shows all settings with no scrollbar:
<img width="389" height="582" alt="image" src="https://github.com/user-attachments/assets/21bfebfe-582a-4dc8-ada4-6f194d0d15e7" />

With this change it looks like this:
<img width="504" height="583" alt="image" src="https://github.com/user-attachments/assets/cdfaeb8e-47d3-4d21-b0d7-40d9e0c8d530" />

