### PR TITLE
[map-layers] Restore header label and add optional flag to hide it

### DIFF
--- a/change/@itwin-map-layers-ac4194f0-f2e3-4bdd-86a8-dd75972e07e6.json
+++ b/change/@itwin-map-layers-ac4194f0-f2e3-4bdd-86a8-dd75972e07e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore maplayers header label and add optional flag to hide it",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/public/locales/en/mapLayers.json
+++ b/packages/itwin/map-layers/src/public/locales/en/mapLayers.json
@@ -5,6 +5,7 @@
   },
   "Basemap": {
     "BaseLayer": "Base",
+    "BaseMapPanelTitle": "Map Layers",
     "ColorFill": "Solid Fill Color",
     "SelectBaseMap": "Select base layer"
   },

--- a/packages/itwin/map-layers/src/ui/Interfaces.ts
+++ b/packages/itwin/map-layers/src/ui/Interfaces.ts
@@ -47,6 +47,9 @@ export interface MapLayerOptions {
 
   /** Optionally show the user preferences storage options(i.e. iTwin vs iModel).  Defaults to false */
   showUserPreferencesStorageOptions?: boolean;
+
+  /** Optionally hide the header label */
+  hideHeaderLabel?: boolean;
 }
 
 export interface MapFeatureInfoPropertyGridOptions {

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
@@ -31,6 +31,14 @@ $default-font-size: --iui-font-size-1;
   border-bottom-style: solid;
   border-bottom-width: 1px;
 
+  .map-manager-header-label {
+    font-size: $default-font-size;
+    width: auto;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    padding-left: 10px;
+  }
+
   .map-manager-header-buttons-group {
     margin-left: auto;
     border: none;

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.tsx
@@ -658,6 +658,8 @@ export function MapLayerManager(props: MapLayerManagerProps) {
     ],
   );
 
+  const [baseMapPanelLabel] = React.useState(MapLayersUI.localization.getLocalizedString("mapLayers:Basemap.BaseMapPanelTitle"));
+
   return (
     <SourceMapContext.Provider
       value={{
@@ -673,6 +675,8 @@ export function MapLayerManager(props: MapLayerManagerProps) {
     >
       {/* Header*/}
       <div className="map-manager-top-header">
+        {!props.mapLayerOptions?.hideHeaderLabel &&
+        <span className="map-manager-header-label">{baseMapPanelLabel}</span>}
         <div className="map-manager-header-buttons-group">
           <ToggleSwitch className="map-manager-toggle" checked={backgroundMapVisible} onChange={handleMapLayersToggle} />
           <MapLayerSettingsPopupButton disabled={!backgroundMapVisible} />


### PR DESCRIPTION
The maplayers header label was previously removed but after discussion, this is being restored but with an optional flag to hide it.

Previous PR to remove:  https://github.com/iTwin/viewer-components-react/pull/1261/files

<img width="308" height="372" alt="image" src="https://github.com/user-attachments/assets/f75fa246-1b21-48c8-a9da-780d455aafbe" />
