### PR TITLE
[measure-tools] Make bearing calculation opt in again for Distance measurements

### DIFF
--- a/apps/test-viewer/src/UiProvidersConfig.tsx
+++ b/apps/test-viewer/src/UiProvidersConfig.tsx
@@ -256,7 +256,7 @@ const configuredUiItems = new Map<string, UiItem>([
           measurementFormattingProps: {
             distance: {
               bearing: {
-                koqName: "RoadRailUnits.Bearing",
+                koqName: "RoadRailUnits.BEARING",
                 persistenceUnitName: "Units.RAD",
               },
             },

--- a/change/@itwin-measure-tools-react-efa5cf9f-4e6a-4c7f-8a0f-4f2bfc3b3d03.json
+++ b/change/@itwin-measure-tools-react-efa5cf9f-4e6a-4c7f-8a0f-4f2bfc3b3d03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make bearing calculation opt in again for Distance measurements",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -24,7 +24,6 @@ import type {
   MeasurementWidgetData,
 } from "../api/Measurement.js";
 import type { MeasurementFormattingProps, MeasurementProps } from "../api/MeasurementProps.js";
-import type { FormatterSpec } from "@itwin/core-quantity";
 
 /**
  * Props for serializing a [[DistanceMeasurement]].
@@ -198,8 +197,7 @@ export class DistanceMeasurement extends Measurement {
     this._lengthPersistenceUnitName = "Units.M";
     this._coordinateKoQ = "AecUnits.LENGTH_COORDINATE";
     this._coordinatePersistenceUnitName = "Units.M";
-    this._bearingKoQ = "RoadRailUnits.BEARING";
-    this._bearingPersistenceUnitName = "Units.RAD";
+
     if (props) this.readFromJSON(props);
 
     this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())


### PR DESCRIPTION
To format and display bearing in Distance measurements, we need a revolution unit to lookup - `Units.REVOLUTION` from the units schema is one example. Problem is there are iModels out there that don't have the units schema. In that case, an error would be thrown, and the widget wouldn't show up. 

Making the display of bearing calculation be opt-in again - applications will have to supply a KoQ and persistenceUnit to the measure tools ui provider for bearing, which would then allow unit lookup and formatting.

Image of the measurement widget, without 'Bearing' property shown, when I comment out passing in a koq and persistenceUnit in the test viewer (also fixed a typo in the KoQ for Units.BEARING)
<img width="1444" height="786" alt="image" src="https://github.com/user-attachments/assets/9f15ba33-dea1-4e07-a4cf-e3febb5a8558" />
