### PR TITLE
[measure-tools] Fix performance problem, missing text marker for Area polygon

### DIFF
--- a/change/@itwin-measure-tools-react-f6485d69-9645-4b8b-b09e-cd1608c32857.json
+++ b/change/@itwin-measure-tools-react-f6485d69-9645-4b8b-b09e-cd1608c32857.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix performance, area polygon's text marker when no KoQ schema found",
+  "packageName": "@itwin/measure-tools-react",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/measure-tools/src/api/Polygon.ts
+++ b/packages/itwin/measure-tools/src/api/Polygon.ts
@@ -4,14 +4,15 @@
 *--------------------------------------------------------------------------------------------*/
 
 import type { Ray3d } from "@itwin/core-geometry";
+import { IModelApp, QuantityType } from "@itwin/core-frontend";
 import { Point3d, PolygonOps } from "@itwin/core-geometry";
-import type { DecorateContext, GraphicBuilder} from "@itwin/core-frontend";
-import { IModelApp } from "@itwin/core-frontend";
+import { FormatterUtils } from "./FormatterUtils.js";
 import { StyleSet, WellKnownGraphicStyleType, WellKnownTextStyleType } from "./GraphicStyle.js";
-import type { TextEntry} from "./TextMarker.js";
 import { TextMarker } from "./TextMarker.js";
-import type { MeasurementFormattingProps } from "./MeasurementProps.js";
 
+import type { DecorateContext, GraphicBuilder} from "@itwin/core-frontend";
+import type { TextEntry} from "./TextMarker.js";
+import type { MeasurementFormattingProps } from "./MeasurementProps.js";
 export class Polygon {
   public isSelected: boolean;
   public drawMarker: boolean;
@@ -145,7 +146,7 @@ export class Polygon {
       this._textMarker.textLines = this._overrideText;
     } else {
       const lines: string[] = [];
-      const areaFormatter = IModelApp.quantityFormatter.getSpecsByName(this._areaKoQ)?.formatterSpec;
+      const areaFormatter = FormatterUtils.getFormatterSpecWithFallback(this._areaKoQ, QuantityType.Area);
       if (undefined !== areaFormatter)
         lines.push(IModelApp.quantityFormatter.formatQuantity(this.worldScale * this.worldScale * this.area, areaFormatter));
 

--- a/packages/itwin/measure-tools/src/measurements/AngleMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/AngleMeasurement.ts
@@ -83,8 +83,7 @@ export class AngleMeasurement extends Measurement {
     this._anglePersistenceUnitName = "Units.RAD";
     if (props) this.readFromJSON(props);
 
-    this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())
-    .catch();
+    this.createTextMarker().catch();
   }
 
   public get startPointRef(): Point3d | undefined {

--- a/packages/itwin/measure-tools/src/measurements/AreaMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/AreaMeasurement.ts
@@ -172,7 +172,6 @@ export class AreaMeasurement extends Measurement {
 
     if (props) this.readFromJSON(props);
 
-    this.populateFormattingSpecsRegistry().catch();
   }
 
   private handleTextMarkerButtonEvent(ev: BeButtonEvent): boolean {

--- a/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/DistanceMeasurement.ts
@@ -200,8 +200,7 @@ export class DistanceMeasurement extends Measurement {
 
     if (props) this.readFromJSON(props);
 
-    this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())
-    .catch();
+    this.createTextMarker().catch();
   }
 
   public setStartPoint(point: XYAndZ) {
@@ -501,7 +500,7 @@ export class DistanceMeasurement extends Measurement {
   }
 
   private async createTextMarker(): Promise<void> {
-    const lengthSpec = IModelApp.quantityFormatter.getSpecsByName(this._lengthKoQ)?.formatterSpec;
+    const lengthSpec = FormatterUtils.getFormatterSpecWithFallback(this._lengthKoQ, QuantityType.LengthEngineering);
 
     const distance = this._startPoint.distance(this._endPoint);
     const fDistance = await FormatterUtils.formatLength(

--- a/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/LocationMeasurement.ts
@@ -224,8 +224,7 @@ export class LocationMeasurement extends Measurement {
       this.readFromJSON(props);
     }
 
-    this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())
-    .catch();
+    this.createTextMarker().catch();
   }
 
   /** Changes the location. Only possible if the measurement is dynamic. */

--- a/packages/itwin/measure-tools/src/measurements/RadiusMeasurement.ts
+++ b/packages/itwin/measure-tools/src/measurements/RadiusMeasurement.ts
@@ -105,8 +105,7 @@ export class RadiusMeasurement extends Measurement {
     this._lengthPersistenceUnitName = "Units.M";
     if (props) this.readFromJSON(props);
 
-    this.populateFormattingSpecsRegistry().then(() => this.createTextMarker().catch())
-    .catch();
+    this.createTextMarker().catch();
   }
 
   public get startPointRef(): Point3d | undefined {

--- a/packages/itwin/measure-tools/src/test/measure-tools/AngleMeasurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/AngleMeasurement.test.ts
@@ -4,6 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { assert } from "chai";
+import { vi } from "vitest";
+import { IModelApp, QuantityType } from "@itwin/core-frontend";
 import { Point3d } from "@itwin/core-geometry";
 import { Measurement, MeasurementPickContext } from "../../api/Measurement.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
@@ -64,6 +66,54 @@ describe("AngleMeasurement tests", () => {
     assert.isDefined(measure3.getDecorationGeometry(pickContext));
     assert.isDefined(await measure3.getDataForMeasurementWidget());
     assert.isString(await measure3.getDecorationToolTip(pickContext));
+  });
+
+  it("Test fallback from getFormatterSpec on construction", async () => {
+    // Mock getSpecsByName to return undefined (simulating KoQ lookup failure)
+    const originalGetSpecsByName = IModelApp.quantityFormatter.getSpecsByName;
+    const originalFindFormatterSpecByQuantityType = IModelApp.quantityFormatter.findFormatterSpecByQuantityType;
+
+    // Create a mock that returns undefined for KoQ lookup
+    const getSpecsByNameSpy = vi.fn().mockReturnValue(undefined);
+    const findFormatterSpecSpy = vi.fn().mockReturnValue({
+      format: { formatTraits: 0 },
+      persistenceUnit: { name: "Units.RAD" },
+      applyFormatting: vi.fn().mockReturnValue("mockedFormattedValue")
+    });
+
+    // Replace the methods with our spies
+    IModelApp.quantityFormatter.getSpecsByName = getSpecsByNameSpy;
+    IModelApp.quantityFormatter.findFormatterSpecByQuantityType = findFormatterSpecSpy;
+
+    try {
+      // Create an AngleMeasurement with complete angle data to trigger createTextMarker
+      const measurement = AngleMeasurement.create(
+        Point3d.create(0, 1, 0),
+        Point3d.create(0, 0, 0),
+        Point3d.create(1, 0, 0),
+        WellKnownViewType.XSection
+      );
+
+      // Wait for the async createTextMarker to complete
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify that the KoQ lookup was attempted
+      assert.isTrue(getSpecsByNameSpy.mock.calls.length > 0, "getSpecsByName should have been called during construction");
+      assert.strictEqual(getSpecsByNameSpy.mock.calls[0][0], "AecUnits.ANGLE", "Should lookup the default KoQ string");
+
+      // Verify that the fallback method was called
+      assert.isTrue(findFormatterSpecSpy.mock.calls.length > 0, "findFormatterSpecByQuantityType should have been called as fallback");
+      assert.strictEqual(findFormatterSpecSpy.mock.calls[0][0], QuantityType.Angle, "Should fallback to QuantityType.Angle");
+
+      // Verify the measurement was created successfully
+      assert.isDefined(measurement);
+      assert.isDefined(measurement.angle);
+      assert.strictEqual(measurement.angleKoQ, "AecUnits.ANGLE");
+    } finally {
+      // Restore original methods
+      IModelApp.quantityFormatter.getSpecsByName = originalGetSpecsByName;
+      IModelApp.quantityFormatter.findFormatterSpecByQuantityType = originalFindFormatterSpecByQuantityType;
+    }
   });
 
   it("Test angle measurement", () => {

--- a/packages/itwin/measure-tools/src/test/measure-tools/DistanceMeasurement.test.ts
+++ b/packages/itwin/measure-tools/src/test/measure-tools/DistanceMeasurement.test.ts
@@ -4,6 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { assert } from "chai";
+import { vi } from "vitest";
+import { IModelApp, QuantityType } from "@itwin/core-frontend";
 import { Point3d } from "@itwin/core-geometry";
 import { Measurement, MeasurementPickContext } from "../../api/Measurement.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
@@ -58,6 +60,54 @@ describe("DistanceMeasurement tests", () => {
     assert.isDefined(measure3.getDecorationGeometry(pickContext));
     assert.isDefined(await measure3.getDataForMeasurementWidget());
     assert.isString(await measure3.getDecorationToolTip(pickContext));
+  });
+
+  it("Test fallback from getFormatterSpec on construction", async () => {
+    // Mock getSpecsByName to return undefined (simulating KoQ lookup failure)
+    const originalGetSpecsByName = IModelApp.quantityFormatter.getSpecsByName;
+    const originalFindFormatterSpecByQuantityType = IModelApp.quantityFormatter.findFormatterSpecByQuantityType;
+
+    // Create a mock that returns undefined for KoQ lookup
+    const getSpecsByNameSpy = vi.fn().mockReturnValue(undefined);
+    const findFormatterSpecSpy = vi.fn().mockReturnValue({
+      format: { formatTraits: 0 },
+      persistenceUnit: { name: "Units.M" },
+      applyFormatting: vi.fn().mockReturnValue("mockedFormattedValue")
+    });
+
+    // Replace the methods with our spies
+    IModelApp.quantityFormatter.getSpecsByName = getSpecsByNameSpy;
+    IModelApp.quantityFormatter.findFormatterSpecByQuantityType = findFormatterSpecSpy;
+
+    try {
+      // Create a DistanceMeasurement with complete distance data to trigger createTextMarker
+      const measurement = DistanceMeasurement.create(
+        Point3d.create(0, 0, 0),
+        Point3d.create(0, 10, 0),
+        WellKnownViewType.XSection
+      );
+
+      // Wait for the async createTextMarker to complete
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify that the KoQ lookup was attempted
+      assert.isTrue(getSpecsByNameSpy.mock.calls.length > 0, "getSpecsByName should have been called during construction");
+      assert.strictEqual(getSpecsByNameSpy.mock.calls[0][0], "AecUnits.LENGTH", "Should lookup the default KoQ string");
+
+      // Verify that the fallback method was called
+      assert.isTrue(findFormatterSpecSpy.mock.calls.length > 0, "findFormatterSpecByQuantityType should have been called as fallback");
+      assert.strictEqual(findFormatterSpecSpy.mock.calls[0][0], QuantityType.LengthEngineering, "Should fallback to QuantityType.LengthEngineering");
+
+      // Verify the measurement was created successfully
+      assert.isDefined(measurement);
+      assert.isDefined(measurement.startPointRef);
+      assert.isDefined(measurement.endPointRef);
+      assert.strictEqual(measurement.lengthKoQ, "AecUnits.LENGTH");
+    } finally {
+      // Restore original methods
+      IModelApp.quantityFormatter.getSpecsByName = originalGetSpecsByName;
+      IModelApp.quantityFormatter.findFormatterSpecByQuantityType = originalFindFormatterSpecByQuantityType;
+    }
   });
 
   it("Test setters", () => {


### PR DESCRIPTION
Fix performance problem for measurements. Problem was onMouseMove, a new measurement object is initialized, and inside the ctor of each measurement they try to repopulate the formatterSpec cache if it couldn't retrieve a formatSpec for the KoQ the measurement uses. For iModels that never has the relevant KoQ, that happens every single time. Removed the repopulating code from the ctor.

Example of the problem in question, with an iModel that doesn't have the KoQ:
https://github.com/user-attachments/assets/a8ba5e63-3f25-4ed3-8e8d-e2921f3ff853

Example of an iModel that does have the KoQ
https://github.com/user-attachments/assets/19a6ad7b-4eb9-4928-b57f-af2baf8cf158

Also fixed area polygon's text marker when no KoQ schema found. The code to generate the polygon's inner text marker wasn't using the fallback -_-

https://github.com/user-attachments/assets/0e164218-f03b-42df-a4b5-29b94ef67332


