### PR TITLE
[map-layers] Feature info widget fix

### DIFF
--- a/change/@itwin-map-layers-10db00dd-46fc-4291-b75b-193169bdb795.json
+++ b/change/@itwin-map-layers-10db00dd-46fc-4291-b75b-193169bdb795.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix hidden map layers feature info widget to use getWidgets instead of deprecated provideWidgets.",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
+++ b/packages/itwin/map-layers/src/ui/FeatureInfoUiItemsProvider.tsx
@@ -4,7 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ConditionalBooleanValue } from "@itwin/appui-abstract";
-import { StagePanelLocation, StagePanelSection, StageUsage, ToolbarItemUtilities, ToolbarOrientation, ToolbarUsage, WidgetState } from "@itwin/appui-react";
+import {
+  StagePanelLocation,
+  StagePanelSection,
+  ToolbarItemUtilities,
+  ToolbarOrientation,
+  ToolbarUsage,
+  WidgetState
+} from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
 import { SvgMapInfo } from "@itwin/itwinui-icons-react";
 import { MapFeatureInfoTool } from "@itwin/map-layers-formats";
@@ -12,7 +19,7 @@ import { MapLayersUI } from "../mapLayers";
 import { MapLayersSyncUiEventId } from "../MapLayersActionIds";
 import { MapFeatureInfoWidget } from "./widget/FeatureInfoWidget";
 
-import type { ToolbarActionItem, ToolbarItem, UiItemsProvider } from "@itwin/appui-react";
+import type { ToolbarActionItem, ToolbarItem, UiItemsProvider, Widget } from "@itwin/appui-react";
 import type { ScreenViewport } from "@itwin/core-frontend";
 import type { MapLayerProps } from "@itwin/core-common";
 import type { MapFeatureInfoOptions } from "./Interfaces";
@@ -80,20 +87,21 @@ export class FeatureInfoUiItemsProvider implements UiItemsProvider {
     return [];
   }
 
-  public provideWidgets(_stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection) {
-    const widgets = [];
-
-    const tmpSection = section ?? StagePanelSection.End;
-    if (tmpSection === StagePanelSection.End && (stageUsage === StageUsage.General || stageUsage === StageUsage.Edit) && location === StagePanelLocation.Right) {
-      widgets.push({
-        id: FeatureInfoUiItemsProvider.widgetId,
-        label: MapLayersUI.localization.getLocalizedString("mapLayers:FeatureInfoWidget.Label"),
-        icon: <SvgMapInfo />,
-        content: <MapFeatureInfoWidget featureInfoOpts={this._featureInfoOpts} />,
-        defaultState: WidgetState.Hidden,
-      });
-    }
-
+  public getWidgets(): Widget[] {
+    const widgets: Widget[] = [];
+    widgets.push({
+      id: FeatureInfoUiItemsProvider.widgetId,
+      label: MapLayersUI.localization.getLocalizedString("mapLayers:FeatureInfoWidget.Label"),
+      icon: <SvgMapInfo />,
+      content: <MapFeatureInfoWidget featureInfoOpts={this._featureInfoOpts} />,
+      defaultState: WidgetState.Hidden,
+      layouts: {
+        standard: {
+          location: StagePanelLocation.Right,
+          section: StagePanelSection.End,
+        },
+      },
+    });
     return widgets;
   }
 }

--- a/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
@@ -86,19 +86,19 @@ export function MapFeatureInfoWidget({ featureInfoOpts }: MapFeatureInfoWidgetPr
   );
 
   if (hasData && dataProvider.current) {
-    return (
-      <div ref={elementRef}>
-        <VirtualizedPropertyGridWithDataProvider
-          width={width}
-          height={height}
-          dataProvider={dataProvider.current}
-          orientation={Orientation.Vertical}
-          isPropertySelectionEnabled={featureInfoOpts?.propertyGridOptions?.isPropertySelectionEnabled}
-          isPropertyHoverEnabled // This need to be turned on to have the action button appears only when property hovered
-          actionButtonRenderers={[copyButton]}
-        />
-      </div>
-    );
+      return (
+        <div ref={elementRef} style={{ width: "100%", height: "100%" }}>
+          <VirtualizedPropertyGridWithDataProvider
+            width={width}
+            height={height}
+            dataProvider={dataProvider.current}
+            orientation={Orientation.Vertical}
+            isPropertySelectionEnabled={featureInfoOpts?.propertyGridOptions?.isPropertySelectionEnabled}
+            isPropertyHoverEnabled // This need to be turned on to have the action button appears only when property hovered
+            actionButtonRenderers={[copyButton]}
+          />
+        </div>
+      );
   } else {
     return (
       <Flex justifyContent="center" style={{ width: "100%", height: "100%" }}>


### PR DESCRIPTION
When using Map Layers Info tool to click on features in viewport, the Feature Info Widget did not appear.
- this was due to use of deprecated providerWidgets() which is now updated to getWidgets()
- the size of the widget contents was then shown very small and was corrected by setting div width/height to 100%

<img width="954" height="578" alt="image" src="https://github.com/user-attachments/assets/23068e76-910c-4fee-bc55-af70b29ab6e7" />
