### PR TITLE
Create StrictModeDroppable Component to fix Invariant Failing

### DIFF
--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
@@ -21,11 +21,13 @@ import { MapLayerSettingsMenu } from "./MapLayerSettingsMenu";
 import { MapUrlDialog } from "./MapUrlDialog";
 import { SubLayersPopupButton } from "./SubLayersPopupButton";
 
-import type { DraggableChildrenFn, DroppableProvided, DroppableStateSnapshot } from "react-beautiful-dnd";
+import type { DraggableChildrenFn, DroppableProps , DroppableProvided , DroppableStateSnapshot } from "react-beautiful-dnd";
 import type { SubLayerId } from "@itwin/core-common";
 import type { MapLayerIndex, ScreenViewport } from "@itwin/core-frontend";
 import type { MapLayerOptions, StyleMapLayerSettings } from "../Interfaces";
 import type { SourceState } from "./MapUrlDialog";
+
+
 /** @internal */
 interface MapLayerDroppableProps {
   isOverlay: boolean;
@@ -39,6 +41,22 @@ interface MapLayerDroppableProps {
   onItemEdited: () => void;
   disabled?: boolean;
 }
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const StrictModeDroppable = ({ children, ...props }: DroppableProps) =>{
+  const [enabled, setEnabled] = React.useState(false);
+  React.useEffect(() => {
+    const animation = requestAnimationFrame(() => setEnabled(true));
+    return () => {
+      cancelAnimationFrame(animation);
+      setEnabled(false);
+    };
+  }, []);
+  if (!enabled) {
+    return null;
+  }
+  return <Droppable {...props}>{children}</Droppable>;
+};
 
 const changeVisibilityByElementId = (element: Element | null, visible: boolean) => {
   if (element) {
@@ -292,8 +310,8 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
   }
 
   return (
-    <Droppable droppableId={droppableId} renderClone={renderItem} getContainerForClone={props.getContainerForClone as any}>
+    <StrictModeDroppable droppableId={droppableId} renderClone={renderItem} getContainerForClone={props.getContainerForClone as any}>
       {renderDraggable}
-    </Droppable>
+    </StrictModeDroppable>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/iTwin/viewer-components-react/issues/1390.

Currently, we are unable to drag an attached external map layer between overlay and background in the Map Layers widget. When attempting to drag the map layer, `react-beautiful-dnd` throws an `Invariant Failed` error. This is a known issue with the `react-beautiful-dnd` library and the `Droppable` component's interactions with apps run in `React.StrictMode`. To solve this issue without needing to disable `StrictMode`, this PR creates the `StrictModeDroppable` component which is a wrapper around the `Droppable` component allowing it to work within `StrictMode`. Below is a screen recording of the map layer successfully dragging between background and overlay in the Map Layers widget. 


https://github.com/user-attachments/assets/c4f26e43-6e25-4bc8-8b6a-90a20ea99368

