### PR TITLE
Remove Inline Styles from map-layers

### DIFF
--- a/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.scss
+++ b/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.scss
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.map-manager-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 100;
+}
+
+.map-manager-popover-overflow {
+  overflow: auto;
+}

--- a/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.tsx
@@ -442,13 +442,7 @@ function AttachLayerPanel({ isOverlay, onLayerAttached, onHandleOutsideClick, se
   return (
     <div className="map-manager-header">
       {(loading || loadingSources) && (
-        <div style={{
-          position: "absolute",
-          inset: 0,
-          display: "grid",
-          placeItems: "center",
-          zIndex: 100,
-        }}>
+        <div className="map-manager-loading-overlay">
           <ProgressRadial as="div"/>
         </div>
       )}
@@ -628,7 +622,7 @@ export function AttachLayerPopupButton(props: AttachLayerPopupButtonProps) {
         onVisibleChange={setPopupOpen}
         closeOnOutsideClick={handleOutsideClick}
         placement={"bottom-end"}
-        style={{ overflow: "auto" }}
+        className="map-manager-popover-overflow"
       >
         {renderButton()}
       </Popover>

--- a/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/AttachLayerPopupButton.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import "./AttachLayerPopupButton.scss";
 import * as React from "react";
 import { UiFramework } from "@itwin/appui-react";
 import { IModelApp, MapLayerSource, MapLayerSourceStatus, NotifyMessageDetails, OutputMessagePriority } from "@itwin/core-frontend";

--- a/packages/itwin/map-layers/src/ui/widget/BasemapPanel.scss
+++ b/packages/itwin/map-layers/src/ui/widget/BasemapPanel.scss
@@ -80,6 +80,10 @@ $hovered-icon-color: var(--iui-color-icon-accent);
       margin-inline: var(--iui-size-2xs);
       padding: 0;
       border: 0;
+
+      .iui-color-swatch {
+        pointer-events: none;
+      }
     }
   }
 }

--- a/packages/itwin/map-layers/src/ui/widget/BasemapPanel.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/BasemapPanel.tsx
@@ -362,7 +362,7 @@ export function BasemapPanel(props: BasemapPanelProps) {
             }
           >
             <IconButton label='Show color picker' styleType='borderless' className='map-manager-base-item-color components-color-swatch'>
-              <ColorSwatch style={{ pointerEvents: 'none' }} color={ColorValue.fromTbgr(bgColor)} />
+              <ColorSwatch color={ColorValue.fromTbgr(bgColor)} />
             </IconButton>
           </Popover>
         )}

--- a/packages/itwin/map-layers/src/ui/widget/CustomParamEditDialog.scss
+++ b/packages/itwin/map-layers/src/ui/widget/CustomParamEditDialog.scss
@@ -23,3 +23,8 @@
 .custom-param-edit-dialog-input {
   margin-bottom: 5px;
 }
+
+.custom-param-edit-dialog-modal {
+  min-height: 120px;
+  min-width: 120px;
+}

--- a/packages/itwin/map-layers/src/ui/widget/CustomParamEditDialog.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/CustomParamEditDialog.tsx
@@ -67,7 +67,7 @@ export function CustomParamEditDialog(props: CustomParamEditDialogProps) {
       title={MapLayersUI.translate(props.item ? "CustomParamEditDialog.DialogTitleEdit" : "CustomParamEditDialog.DialogTitleAdd")}
       isOpen={true}
       onClose={handleCancel}
-      style={{ minHeight: 120, minWidth: 120 }}
+      className="custom-param-edit-dialog-modal"
       portal
     >
       <ModalContent>

--- a/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.scss
+++ b/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.scss
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.feature-info-widget-container {
+  width: 100%;
+  height: 100%;
+}
+
+.feature-info-widget-no-records {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
@@ -1,8 +1,8 @@
-import "./FeatureInfoWidget.scss";
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import "./FeatureInfoWidget.scss";
 import * as React from "react";
 import { useActiveFrontstageDef, WidgetState } from "@itwin/appui-react";
 import { Orientation, VirtualizedPropertyGridWithDataProvider } from "@itwin/components-react";

--- a/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/FeatureInfoWidget.tsx
@@ -1,3 +1,4 @@
+import "./FeatureInfoWidget.scss";
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
@@ -9,8 +10,8 @@ import { SvgCopy } from "@itwin/itwinui-icons-react";
 import { Flex, IconButton } from "@itwin/itwinui-react";
 import { MapLayersUI } from "../../mapLayers";
 import { FeatureInfoUiItemsProvider } from "../FeatureInfoUiItemsProvider";
-import { FeatureInfoDataProvider } from "./FeatureInfoDataProvider";
 import { useResizeObserver } from "../hooks/useResizeObserver";
+import { FeatureInfoDataProvider } from "./FeatureInfoDataProvider";
 
 import type { PrimitiveValue } from "@itwin/appui-abstract";
 import type { ActionButtonRendererProps } from "@itwin/components-react";
@@ -87,7 +88,7 @@ export function MapFeatureInfoWidget({ featureInfoOpts }: MapFeatureInfoWidgetPr
 
   if (hasData && dataProvider.current) {
     return (
-      <div ref={elementRef} style={{ width: "100%", height: "100%" }}>
+      <div ref={elementRef} className="feature-info-widget-container">
         <VirtualizedPropertyGridWithDataProvider
           width={width}
           height={height}
@@ -101,7 +102,7 @@ export function MapFeatureInfoWidget({ featureInfoOpts }: MapFeatureInfoWidgetPr
     );
   } else {
     return (
-      <Flex justifyContent="center" style={{ width: "100%", height: "100%" }}>
+      <Flex justifyContent="center" className="feature-info-widget-no-records">
         <span>
           <i>{noRecordsMessage}</i>
         </span>

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.scss
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.map-manager-hidden {
+  visibility: hidden;
+}
+
+.map-manager-display-none {
+  display: none;
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
@@ -6,7 +6,7 @@
 
 // the following quiet warning caused by react-beautiful-dnd package
 
-import "./MapLayerManager.scss";
+import "./MapLayerDroppable.scss";
 import * as React from "react";
 import { Draggable, Droppable } from "react-beautiful-dnd";
 import { UiFramework } from "@itwin/appui-react";

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
@@ -204,7 +204,7 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
         </span>
 
         {/* SubLayersPopupButton */}
-        <div id="MapLayerSettingsSubLayersMenu" style={{ visibility: "hidden" }} className="map-manager-item-sub-layer-container">
+        <div id="MapLayerSettingsSubLayersMenu" className="map-manager-item-sub-layer-container map-manager-hidden">
           {activeLayer.subLayers && activeLayer.subLayers.length > 1 && (
             <SubLayersPopupButton
               checkboxStyle="eye"
@@ -252,7 +252,7 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
             <SvgStatusWarning />
           </IconButton>
         )}
-        <div id="MapLayerSettingsMenuWrapper" style={{ visibility: "hidden" }}>
+        <div id="MapLayerSettingsMenuWrapper" className="map-manager-hidden">
           <MapLayerSettingsMenu
             activeViewport={props.activeViewport}
             mapLayerSettings={activeLayer}
@@ -304,7 +304,7 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
         {/* We don't want a placeholder when displaying the 'Drop here' message
               Unfortunately, if don't add it, 'react-beautiful-dnd' show an error message in the console.
               So I simply make it hidden. See https://github.com/atlassian/react-beautiful-dnd/issues/518 */}
-        <div style={containsLayer ? undefined : { display: "none" }}>{dropProvided.placeholder}</div>
+        <div className={containsLayer ? undefined : "map-manager-display-none"}>{dropProvided.placeholder}</div>
       </div>
     );
   }

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
@@ -424,3 +424,25 @@ $default-font-size: --iui-font-size-1;
     }
   }
 }
+
+// Loading overlay styles
+.map-manager-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 100;
+}
+
+.map-manager-popover-overflow {
+  overflow: auto;
+}
+
+// Hidden element utilities
+.map-manager-hidden {
+  visibility: hidden;
+}
+
+.map-manager-display-none {
+  display: none;
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerManager.scss
@@ -424,25 +424,3 @@ $default-font-size: --iui-font-size-1;
     }
   }
 }
-
-// Loading overlay styles
-.map-manager-loading-overlay {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  z-index: 100;
-}
-
-.map-manager-popover-overflow {
-  overflow: auto;
-}
-
-// Hidden element utilities
-.map-manager-hidden {
-  visibility: hidden;
-}
-
-.map-manager-display-none {
-  display: none;
-}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.scss
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.map-layers-widget-not-geo-located {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayersWidget.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import "./MapLayersWidget.scss";
 import * as React from "react";
 import { useActiveViewport } from "@itwin/appui-react";
 import { Flex } from "@itwin/itwinui-react";
@@ -44,7 +45,7 @@ export function MapLayersWidget(props: MapLayersWidgetProps) {
   }
 
   return (
-    <Flex justifyContent="center" style={{ width: "100%", height: "100%" }}>
+    <Flex justifyContent="center" className="map-layers-widget-not-geo-located">
       <div className="map-manager-not-geo-located-text">{notGeoLocatedMsg}</div>
     </Flex>
   );

--- a/packages/itwin/map-layers/src/ui/widget/MapSelectFeaturesDialog.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapSelectFeaturesDialog.scss
@@ -5,6 +5,8 @@
 
 .map-layer-select-features-dialog {
   z-index: var(--uicore-z-index-cursor-overlay);
+  max-width: 600px;
+  min-height: 250px;
 }
 
 .map-layer-select-features-dialog.core-dialog .core-dialog-container .core-dialog-area > .core-dialog-content {

--- a/packages/itwin/map-layers/src/ui/widget/MapSelectFeaturesDialog.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapSelectFeaturesDialog.tsx
@@ -19,7 +19,6 @@ export interface MapSelectFeaturesProps {
   handleOk: (subLayers: MapSubLayerProps[]) => void;
   handleCancel: () => void;
 }
-const minHeight = 250;
 const maxSubLayers = 30;
 
 export function MapSelectFeaturesDialog(props: MapSelectFeaturesProps) {
@@ -88,7 +87,6 @@ export function MapSelectFeaturesDialog(props: MapSelectFeaturesProps) {
         title={MapLayersUI.translate("CustomAttach.SelectLayersToCreate")}
         isOpen={true}
         onClose={handleCancel}
-        style={{ minHeight, maxWidth: 600 }}
         portal
       >
         {/* 'onSubLayerStateChange' is used to trigger hook state change only, no need to update subLayer objects */}

--- a/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.scss
@@ -8,6 +8,8 @@ $default-font-size: var(--iui-font-size-1);
 
 .map-layer-url-dialog {
   z-index: var(--uicore-z-index-cursor-overlay);
+  min-height: 120px;
+  max-width: 600px;
 }
 
 .map-layer-url-dialog-content {

--- a/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -15,10 +15,10 @@ import { CustomParamsStorage } from "../../CustomParamsStorage";
 import { CustomParamUtils } from "../../CustomParamUtils";
 import { MapLayerPreferences } from "../../MapLayerPreferences";
 import { MapLayersUI } from "../../mapLayers";
+import { useCrossOriginPopup } from "../hooks/useCrossOriginPopup";
 import { SelectCustomParam } from "./SelectCustomParam";
 import { SelectMapFormat } from "./SelectMapFormat";
 import { UserPreferencesStorageOptions } from "./UserPreferencesStorageOptions";
-import { useCrossOriginPopup } from "../hooks/useCrossOriginPopup";
 
 import type { ImageMapLayerSettings } from "@itwin/core-common";
 import type { MapLayerAccessClient, MapLayerSourceValidation, ScreenViewport } from "@itwin/core-frontend";
@@ -626,7 +626,6 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
         title={dialogTitle}
         isOpen={true}
         onClose={handleCancel}
-        style={{ minHeight: 120, maxWidth: 600 }}
         portal
       >
         <ModalContent>

--- a/packages/itwin/map-layers/src/ui/widget/SelectCustomParam.scss
+++ b/packages/itwin/map-layers/src/ui/widget/SelectCustomParam.scss
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.map-layer-source-select .iui-select-menu {
+  z-index: 100000; /* Ensure the dropdown selection is on top of the Modal that utilizes this component */
+}

--- a/packages/itwin/map-layers/src/ui/widget/SelectCustomParam.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/SelectCustomParam.tsx
@@ -5,6 +5,7 @@
 // cSpell:ignore Modeless WMTS
 
 import "./MapUrlDialog.scss";
+import "./SelectCustomParam.scss";
 import * as React from "react";
 import { Select } from "@itwin/itwinui-react";
 import { CustomParamsStorage } from "../../CustomParamsStorage";
@@ -72,7 +73,6 @@ export function SelectCustomParam(props: SelectCustomParamProps) {
         options={customParams}
         value={paramValues}
         disabled={props.disabled || customParams.length === 0}
-        menuStyle={{ zIndex: 100000 }} // Ensure the dropdown selection is on top of the Modal that utilizes this component
         onChange={handleOnChange}
         size="small"
         onKeyDown={handleKeyDown}

--- a/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.scss
+++ b/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.scss
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.map-layer-source-select .iui-select-menu {
+  z-index: 100000; /* Ensure the dropdown selection is on top of the Modal that utilizes this component */
+}

--- a/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/SelectMapFormat.tsx
@@ -5,6 +5,7 @@
 // cSpell:ignore Modeless WMTS
 
 import "./MapUrlDialog.scss";
+import "./SelectMapFormat.scss";
 import * as React from "react";
 import { IModelApp } from "@itwin/core-frontend";
 import { LabeledSelect } from "@itwin/itwinui-react";
@@ -74,7 +75,6 @@ export function SelectMapFormat(props: SelectMapFormatProps) {
       className="map-layer-source-select"
       options={mapFormats}
       value={mapFormat}
-      menuStyle={{ zIndex: 100000 }} // Ensure the dropdown selection is on top of the Modal that utilizes this component
       disabled={props.disabled}
       onChange={handleOnChange}
       size="small"

--- a/packages/itwin/map-layers/src/ui/widget/SubLayersTree.scss
+++ b/packages/itwin/map-layers/src/ui/widget/SubLayersTree.scss
@@ -46,6 +46,10 @@
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
+
+    .iui-button:nth-child(2) {
+      margin-left: 5px;
+    }
   }
 
   .tree-toolbar-searchbox {

--- a/packages/itwin/map-layers/src/ui/widget/SubLayersTree.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/SubLayersTree.tsx
@@ -1,10 +1,9 @@
-
-import "./SubLayersTree.scss";
-import * as React from "react";
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import "./SubLayersTree.scss";
+import * as React from "react";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
 import {
   CheckBoxState,

--- a/packages/itwin/map-layers/src/ui/widget/SubLayersTree.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/SubLayersTree.tsx
@@ -1,11 +1,11 @@
 
+import "./SubLayersTree.scss";
+import * as React from "react";
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { PropertyValueFormat } from "@itwin/appui-abstract";
-import "./SubLayersTree.scss";
-import * as React from "react";
 import {
   CheckBoxState,
   ControlledTree,
@@ -21,8 +21,8 @@ import {
 import { SvgCheckboxDeselect, SvgCheckboxSelect, SvgVisibilityHide, SvgVisibilityShow } from "@itwin/itwinui-icons-react";
 import { Checkbox, IconButton, Input } from "@itwin/itwinui-react";
 import { MapLayersUI } from "../../mapLayers";
-import { SubLayersDataProvider } from "./SubLayersDataProvider";
 import { useResizeObserver } from "../hooks/useResizeObserver";
+import { SubLayersDataProvider } from "./SubLayersDataProvider";
 
 import type {
   AbstractTreeNodeLoaderWithProvider,
@@ -184,7 +184,6 @@ export function SubLayersTree(props: SubLayersTreeProps) {
                   {props.checkboxStyle === "eye" ? <SvgVisibilityShow /> : <SvgCheckboxSelect />}
                 </IconButton>,
                 <IconButton
-                  style={{ marginLeft: "5px" }}
                   key="hide-all-btn"
                   size="small"
                   label={props.checkboxStyle === "eye" ? MapLayersUI.translate("SubLayers.AllOff") : MapLayersUI.translate("SelectFeaturesDialog.AllOff")}


### PR DESCRIPTION
Resolves https://github.com/iTwin/viewer-components-react/issues/1389.

Currently, the map-layers package uses inline styles for multiple things including hovering over external layers. Inline styles are not allowed by some apps' content security policy, which causes errors as outlined in the issue above. This PR fixes this problem by replacing all instances of inline styles within the map-layers package with appropriate css classes which maintain the current stylings.