### PR TITLE
Tree widget: Add "loading" state to `TreeNodeCheckboxState` type

### DIFF
--- a/change/@itwin-tree-widget-react-c2a5489f-ac72-4be2-9bf9-ea1edb1514a1.json
+++ b/change/@itwin-tree-widget-react-c2a5489f-ac72-4be2-9bf9-ea1edb1514a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Introduce an extra state to `TreeNodeCheckboxState` interface - `{ isLoading: true }`. When such state is returned, the \"eye\" checkboxes are not rendered by `<VisibilityTreeRenderer />` and `<TreeNodeRenderer />`. Previously, we were returning \"disabled\" state, resulting in disabled checkboxes being briefly shown until the states were loaded.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -405,14 +405,14 @@ interface TreeHeaderButtonProps {
 }
 
 // @beta
-interface TreeNodeCheckboxState {
-    // (undocumented)
-    isDisabled?: boolean;
-    // (undocumented)
+type TreeNodeCheckboxState = ({
     state: "on" | "off" | "partial";
-    // (undocumented)
+    isDisabled?: boolean;
+} | {
+    isLoading: true;
+}) & {
     tooltip?: string;
-}
+};
 
 // @beta (undocumented)
 type TreeNodeRendererProps = ComponentPropsWithoutRef<typeof TreeNodeRenderer> & {

--- a/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
@@ -46,20 +46,19 @@ describe("useHierarchyVisibility", () => {
     visibilityHandler.getVisibilityStatus.resolves({ state: "visible" });
 
     act(() => {
-      // expect initial state to be `off` and disabled
+      // expect initial state to be "loading"
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("off");
-      expect(state.isDisabled).to.be.true;
+      expect(state).to.deep.eq({ isLoading: true });
     });
 
     await waitFor(() => {
       // wait for visibility status to be calculated
       expect(visibilityHandler.getVisibilityStatus).to.be.called;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("on");
+      expect(state).to.deep.eq({ state: "on" });
     });
 
-    expect(result.current.getCheckboxState(node).state).to.be.eq("on");
+    expect(result.current.getCheckboxState(node)).to.deep.eq({ state: "on" });
     expect(visibilityHandler.getVisibilityStatus).to.be.calledOnce;
   });
 
@@ -71,17 +70,16 @@ describe("useHierarchyVisibility", () => {
     visibilityHandler.getVisibilityStatus.resolves({ state: "visible" });
 
     act(() => {
-      // expect initial state to be `off` and disabled
+      // expect initial state to be "loading"
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("off");
-      expect(state.isDisabled).to.be.true;
+      expect(state).to.deep.eq({ isLoading: true });
     });
 
     await waitFor(() => {
       // wait for visibility status to calculated
       expect(visibilityHandler.getVisibilityStatus).to.be.called;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("on");
+      expect(state).to.deep.eq({ state: "on" });
     });
 
     expect(visibilityHandler.getVisibilityStatus).to.be.calledOnce;
@@ -97,17 +95,17 @@ describe("useHierarchyVisibility", () => {
       // expect visibility state to be same
       expect(visibilityHandler.getVisibilityStatus).to.be.called;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("on");
+      expect(state).to.deep.eq({ state: "on" });
     });
 
     await waitFor(() => {
       // wait for visibility status to calculated
       expect(visibilityHandler.getVisibilityStatus).to.be.calledTwice;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("partial");
+      expect(state).to.deep.eq({ state: "partial" });
     });
 
-    expect(result.current.getCheckboxState(node).state).to.be.eq("partial");
+    expect(result.current.getCheckboxState(node)).to.deep.eq({ state: "partial" });
     expect(visibilityHandler.getVisibilityStatus).to.be.calledTwice;
   });
 
@@ -119,17 +117,16 @@ describe("useHierarchyVisibility", () => {
     visibilityHandler.getVisibilityStatus.resolves({ state: "visible" });
 
     act(() => {
-      // expect initial state to be `off` and disabled
+      // expect initial state to be "loading"
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("off");
-      expect(state.isDisabled).to.be.true;
+      expect(state).to.deep.eq({ isLoading: true });
     });
 
     await waitFor(() => {
       // wait for visibility status to calculated
       expect(visibilityHandler.getVisibilityStatus).to.be.called;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("on");
+      expect(state).to.deep.eq({ state: "on" });
     });
 
     expect(visibilityHandler.getVisibilityStatus).to.be.calledOnce;
@@ -152,14 +149,14 @@ describe("useHierarchyVisibility", () => {
       // expect visibility state to be optimistically updated to 'off'
       expect(visibilityHandler.getVisibilityStatus).to.be.calledOnce;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("off");
+      expect(state).to.deep.eq({ state: "off" });
     });
 
     await waitFor(() => {
       // wait for visibility status to recalculated
       expect(visibilityHandler.getVisibilityStatus).to.be.calledTwice;
       const state = result.current.getCheckboxState(node);
-      expect(state.state).to.be.eq("off");
+      expect(state).to.deep.eq({ state: "off" });
     });
 
     expect(visibilityHandler.getVisibilityStatus).to.be.calledTwice;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
@@ -61,7 +61,7 @@ interface UseHierarchyVisibilityProps {
 export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarchyVisibilityProps): TreeCheckboxProps & { triggerRefresh: () => void } {
   const visibilityStatusMap = useRef(new Map<string, { node: PresentationHierarchyNode; status: VisibilityStatus; needsRefresh: boolean }>());
   const [state, setState] = useState<TreeCheckboxProps & { triggerRefresh: () => void }>({
-    getCheckboxState: () => ({ state: "off", isDisabled: true }),
+    getCheckboxState: () => ({ isLoading: true }),
     onCheckboxClicked: () => {},
     triggerRefresh: () => {},
   });
@@ -126,7 +126,7 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
         return;
       }
       entry.status.state = checked ? "visible" : "hidden";
-      entry.status.tooltip = undefined;
+      delete entry.status.tooltip;
       triggerCheckboxUpdate();
     };
 
@@ -162,17 +162,17 @@ function createStateGetter(
     const entry = map.current.get(node.id);
     if (entry === undefined) {
       calculateVisibility(node);
-      return { state: "off", isDisabled: true };
+      return { isLoading: true };
     }
+
     if (entry.needsRefresh) {
       calculateVisibility(node);
     }
 
     const status = entry.status;
     return {
+      ...status,
       state: status.state === "visible" ? "on" : status.state === "hidden" ? "off" : "partial",
-      tooltip: status.tooltip,
-      isDisabled: status.isDisabled,
     };
   };
 }


### PR DESCRIPTION
closes https://github.com/iTwin/viewer-components-react/issues/1411