### PR TITLE
[Tree widget]: Fix model visibility not loading

### DIFF
--- a/change/@itwin-tree-widget-react-e9addb29-49da-4f30-abc0-dc86e9e79f21.json
+++ b/change/@itwin-tree-widget-react-e9addb29-49da-4f30-abc0-dc86e9e79f21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Models tree: Fixed adding elements to always/never drawn lists would cause model to not load its' visibility.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeVisibilityHandler.ts
@@ -931,7 +931,9 @@ class ModelsTreeVisibilityHandlerImpl implements HierarchyVisibilityHandler {
     } & GetVisibilityFromAlwaysAndNeverDrawnElementsProps & { ignoreTooltip?: boolean },
   ): VisibilityStatus {
     const { alwaysDrawn, neverDrawn, totalCount, ignoreTooltip } = props;
-
+    if (totalCount === 0) {
+      return props.defaultStatus();
+    }
     if (neverDrawn?.size === totalCount) {
       return createVisibilityStatus("hidden", getTooltipOptions(props.tooltips.allElementsInNeverDrawnList, ignoreTooltip));
     }
@@ -989,6 +991,14 @@ class ModelsTreeVisibilityHandlerImpl implements HierarchyVisibilityHandler {
           alwaysDrawn: this.getAlwaysDrawnElements({ categoryIds: categoryId, modelId }),
           neverDrawn: this.getNeverDrawnElements({ categoryIds: categoryId, modelId }),
         }).pipe(
+          // There is a known bug:
+          // Categories that don't have root elements will make visibility result incorrect
+          // E.g.:
+          // - CategoryA
+          //  - ElementA (CategoryA is visible)
+          //    - ChildElementB (CategoryB is hidden) ChildElementB is in always drawn list
+          // Result will be "partial" because CategoryB will return hidden visibility, even though all elements are visible
+          // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
           map((state) => {
             return this.getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
               ...props,


### PR DESCRIPTION
closes [#1638](https://github.com/iTwin/itwinjs-backlog/issues/1638)
This was happening when all conditions below were met:
1. Models' elements have categories and those categories don't have a single root element.
2. There are elements in always/never drawn list.
3. All categories that have root elements either return `visible` or `hidden` visibility.

We query element counts for each category (this count includes root elements of category, and elements that are their children (direct and indirect)). Query we execute would not return this count for categories that don't have root elements. This means that Promise never resolves for categories that don't have root elements. 

https://github.com/user-attachments/assets/44094592-a1b7-4e3b-a31c-a65868b0b2dd

