### PR TITLE
[Tree widget]: Reduce models tree visibility icon flickering

### DIFF
--- a/change/@itwin-tree-widget-react-8ce229d7-1104-48cd-a55f-300a921294c0.json
+++ b/change/@itwin-tree-widget-react-8ce229d7-1104-48cd-a55f-300a921294c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Models tree: reduce tree visibility icon flickering when changing visibility.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/VisibilityChangeEventListener.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/VisibilityChangeEventListener.test.ts
@@ -5,14 +5,14 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { createVisibilityChangeEventListener } from "../../../../tree-widget-react/components/trees/models-tree/internal/VisibilityChangeEventListener.js";
+import { VisibilityChangeEventListener } from "../../../../tree-widget-react/components/trees/models-tree/internal/VisibilityChangeEventListener.js";
 import { waitFor } from "../../../TestUtils.js";
 import { createFakeSinonViewport } from "../../Common.js";
 
 describe("VisibilityChangeEventListener", () => {
   it("raises event on `onAlwaysDrawnChanged` event", async () => {
     const vpMock = createFakeSinonViewport();
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     vpMock.onAlwaysDrawnChanged.raiseEvent(vpMock);
@@ -20,7 +20,7 @@ describe("VisibilityChangeEventListener", () => {
 
   it("raises event on `onNeverDrawnChanged` event", async () => {
     const vpMock = createFakeSinonViewport();
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     vpMock.onNeverDrawnChanged.raiseEvent(vpMock);
@@ -29,7 +29,7 @@ describe("VisibilityChangeEventListener", () => {
 
   it("raises event on `onViewedCategoriesChanged` event", async () => {
     const vpMock = createFakeSinonViewport();
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     vpMock.onViewedCategoriesChanged.raiseEvent(vpMock);
@@ -38,7 +38,7 @@ describe("VisibilityChangeEventListener", () => {
 
   it("raises event on `onViewedModelsChanged` event", async () => {
     const vpMock = createFakeSinonViewport();
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     vpMock.onViewedModelsChanged.raiseEvent(vpMock);
@@ -47,7 +47,7 @@ describe("VisibilityChangeEventListener", () => {
 
   it("raises event on `onViewedCategoriesPerModelChanged` event", async () => {
     const vpMock = createFakeSinonViewport();
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     vpMock.onViewedCategoriesPerModelChanged.raiseEvent(vpMock);
@@ -57,7 +57,7 @@ describe("VisibilityChangeEventListener", () => {
   it("raises event once when multiple affecting events are fired", async () => {
     const vpMock = createFakeSinonViewport();
     const { onViewedCategoriesPerModelChanged, onViewedCategoriesChanged, onViewedModelsChanged, onAlwaysDrawnChanged, onNeverDrawnChanged } = vpMock;
-    using handler = createVisibilityChangeEventListener(vpMock);
+    using handler = new VisibilityChangeEventListener(vpMock);
     const spy = sinon.spy();
     handler.onVisibilityChange.addListener(spy);
     onViewedCategoriesPerModelChanged.raiseEvent(vpMock);
@@ -65,6 +65,53 @@ describe("VisibilityChangeEventListener", () => {
     onViewedModelsChanged.raiseEvent(vpMock);
     onAlwaysDrawnChanged.raiseEvent(vpMock);
     onNeverDrawnChanged.raiseEvent(vpMock);
+    await waitFor(() => expect(spy).to.be.calledOnce);
+  });
+
+  it("does not raise event when suppression ends and no viewport events were raised during suppression", async () => {
+    const vpMock = createFakeSinonViewport();
+    using handler = new VisibilityChangeEventListener(vpMock);
+    const spy = sinon.spy();
+    handler.onVisibilityChange.addListener(spy);
+    handler.suppressChangeEvents();
+    handler.resumeChangeEvents();
+    expect(handler.isVisibilityChangePending).to.be.false;
+    expect(spy).to.not.be.called;
+  });
+
+  it("raises event when suppression ends and viewport events were raised during suppression", async () => {
+    const vpMock = createFakeSinonViewport();
+    const { onViewedCategoriesPerModelChanged, onViewedCategoriesChanged, onViewedModelsChanged, onAlwaysDrawnChanged, onNeverDrawnChanged } = vpMock;
+    using handler = new VisibilityChangeEventListener(vpMock);
+    const spy = sinon.spy();
+    handler.onVisibilityChange.addListener(spy);
+    handler.suppressChangeEvents();
+    onViewedCategoriesPerModelChanged.raiseEvent(vpMock);
+    onViewedCategoriesChanged.raiseEvent(vpMock);
+    onViewedModelsChanged.raiseEvent(vpMock);
+    onAlwaysDrawnChanged.raiseEvent(vpMock);
+    onNeverDrawnChanged.raiseEvent(vpMock);
+    expect(handler.isVisibilityChangePending).to.be.false;
+    expect(spy).to.not.be.called;
+    handler.resumeChangeEvents();
+    expect(handler.isVisibilityChangePending).to.be.true;
+    await waitFor(() => expect(spy).to.be.calledOnce);
+  });
+
+  it("raises event when suppression ends and viewport events were raised after suppression", async () => {
+    const vpMock = createFakeSinonViewport();
+    const { onViewedCategoriesPerModelChanged, onViewedCategoriesChanged, onViewedModelsChanged, onAlwaysDrawnChanged, onNeverDrawnChanged } = vpMock;
+    using handler = new VisibilityChangeEventListener(vpMock);
+    const spy = sinon.spy();
+    handler.onVisibilityChange.addListener(spy);
+    handler.suppressChangeEvents();
+    handler.resumeChangeEvents();
+    onViewedCategoriesPerModelChanged.raiseEvent(vpMock);
+    onViewedCategoriesChanged.raiseEvent(vpMock);
+    onViewedModelsChanged.raiseEvent(vpMock);
+    onAlwaysDrawnChanged.raiseEvent(vpMock);
+    onNeverDrawnChanged.raiseEvent(vpMock);
+    expect(handler.isVisibilityChangePending).to.be.true;
     await waitFor(() => expect(spy).to.be.calledOnce);
   });
 });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeVisibilityHandler.ts
@@ -38,18 +38,18 @@ import { releaseMainThreadOnItemsCount } from "../Utils.js";
 import { AlwaysAndNeverDrawnElementInfo } from "./AlwaysAndNeverDrawnElementInfo.js";
 import { createFilteredTree, parseCategoryKey } from "./FilteredTree.js";
 import { ModelsTreeNode } from "./ModelsTreeNode.js";
-import { createVisibilityChangeEventListener } from "./VisibilityChangeEventListener.js";
+import { VisibilityChangeEventListener } from "./VisibilityChangeEventListener.js";
 
 import type { Observable, OperatorFunction, Subscription } from "rxjs";
-import type { GroupingHierarchyNode, HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
-import type { HierarchyVisibilityHandler, HierarchyVisibilityHandlerOverridableMethod, VisibilityStatus } from "../../common/UseHierarchyVisibility.js";
-import type { ModelsTreeIdsCache } from "./ModelsTreeIdsCache.js";
 import type { Id64Arg, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
-import type { IVisibilityChangeEventListener } from "./VisibilityChangeEventListener.js";
 import type { Viewport } from "@itwin/core-frontend";
-import type { NonPartialVisibilityStatus, Visibility } from "../../common/Tooltip.js";
+import type { GroupingHierarchyNode, HierarchyFilteringPath } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
+import type { NonPartialVisibilityStatus, Visibility } from "../../common/Tooltip.js";
+import type { HierarchyVisibilityHandler, HierarchyVisibilityHandlerOverridableMethod, VisibilityStatus } from "../../common/UseHierarchyVisibility.js";
 import type { FilteredTree } from "./FilteredTree.js";
+import type { ModelsTreeIdsCache } from "./ModelsTreeIdsCache.js";
+import type { IVisibilityChangeEventListener } from "./VisibilityChangeEventListener.js";
 
 /** @beta */
 interface GetCategoryVisibilityStatusProps {
@@ -142,7 +142,7 @@ class ModelsTreeVisibilityHandlerImpl implements HierarchyVisibilityHandler {
   private _changeRequest = new Subject<{ key: HierarchyNodeKey; depth: number }>();
 
   constructor(private readonly _props: ModelsTreeVisibilityHandlerProps) {
-    this._eventListener = createVisibilityChangeEventListener(_props.viewport);
+    this._eventListener = new VisibilityChangeEventListener(_props.viewport);
     this._alwaysAndNeverDrawnElements = new AlwaysAndNeverDrawnElementInfo(_props.viewport);
     this._idsCache = this._props.idsCache;
     this._filteredTree = _props.filteredPaths ? createFilteredTree(this._props.imodelAccess, _props.filteredPaths) : undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/VisibilityChangeEventListener.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/VisibilityChangeEventListener.ts
@@ -7,7 +7,6 @@ import { BeEvent } from "@itwin/core-bentley";
 
 import type { Viewport } from "@itwin/core-frontend";
 
-/** @internal */
 export interface IVisibilityChangeEventListener extends Disposable {
   onVisibilityChange: BeEvent<() => void>;
   suppressChangeEvents(): void;
@@ -15,46 +14,75 @@ export interface IVisibilityChangeEventListener extends Disposable {
 }
 
 /** @internal */
-export function createVisibilityChangeEventListener(viewport: Viewport): IVisibilityChangeEventListener {
-  const onVisibilityChange = new BeEvent<() => void>();
-  let pendingVisibilityChange: undefined | ReturnType<typeof setTimeout>;
-  let suppressChangeEvents: number = 0;
-  const handleVisibilityChange = () => {
-    if (pendingVisibilityChange || suppressChangeEvents > 0) {
+export class VisibilityChangeEventListener implements IVisibilityChangeEventListener {
+  #onVisibilityChange: BeEvent<() => void>;
+  #pendingVisibilityChange: undefined | ReturnType<typeof setTimeout>;
+  #suppressChangeEvents = 0;
+  #hasFiredDuringSuppress = true;
+  #listeners: Array<() => void>;
+
+  constructor(viewport: Viewport) {
+    this.#onVisibilityChange = new BeEvent<() => void>();
+    this.#listeners = [
+      viewport.onViewedCategoriesPerModelChanged.addListener(() => {
+        this.#hasFiredDuringSuppress = true;
+        this.handleVisibilityChange();
+      }),
+      viewport.onViewedCategoriesChanged.addListener(() => {
+        this.#hasFiredDuringSuppress = true;
+        this.handleVisibilityChange();
+      }),
+      viewport.onViewedModelsChanged.addListener(() => {
+        this.#hasFiredDuringSuppress = true;
+        this.handleVisibilityChange();
+      }),
+      viewport.onAlwaysDrawnChanged.addListener(() => {
+        this.#hasFiredDuringSuppress = true;
+        this.handleVisibilityChange();
+      }),
+      viewport.onNeverDrawnChanged.addListener(() => {
+        this.#hasFiredDuringSuppress = true;
+        this.handleVisibilityChange();
+      }),
+    ];
+  }
+
+  public [Symbol.dispose]() {
+    if (this.#pendingVisibilityChange) {
+      clearTimeout(this.#pendingVisibilityChange);
+      this.#pendingVisibilityChange = undefined;
+    }
+    this.#listeners.forEach((listener) => listener());
+    this.#listeners.length = 0;
+  }
+
+  public get isVisibilityChangePending(): boolean {
+    return this.#pendingVisibilityChange !== undefined;
+  }
+
+  private handleVisibilityChange() {
+    if (this.#pendingVisibilityChange || this.#suppressChangeEvents > 0 || !this.#hasFiredDuringSuppress) {
       return;
     }
-    pendingVisibilityChange = setTimeout(() => {
-      onVisibilityChange.raiseEvent();
-      pendingVisibilityChange = undefined;
-    });
-  };
+    this.#pendingVisibilityChange = setTimeout(() => {
+      this.#onVisibilityChange.raiseEvent();
+      this.#pendingVisibilityChange = undefined;
+    }, 10);
+  }
 
-  const listeners = [
-    viewport.onViewedCategoriesPerModelChanged.addListener(handleVisibilityChange),
-    viewport.onViewedCategoriesChanged.addListener(handleVisibilityChange),
-    viewport.onViewedModelsChanged.addListener(handleVisibilityChange),
-    viewport.onAlwaysDrawnChanged.addListener(handleVisibilityChange),
-    viewport.onNeverDrawnChanged.addListener(handleVisibilityChange),
-  ];
+  public get onVisibilityChange() {
+    return this.#onVisibilityChange;
+  }
 
-  return {
-    onVisibilityChange,
-    [Symbol.dispose]() {
-      if (pendingVisibilityChange) {
-        clearTimeout(pendingVisibilityChange);
-        pendingVisibilityChange = undefined;
-      }
-      listeners.forEach((x) => x());
-      listeners.length = 0;
-    },
-    suppressChangeEvents: () => {
-      suppressChangeEvents++;
-    },
-    resumeChangeEvents: () => {
-      suppressChangeEvents--;
-      if (suppressChangeEvents === 0) {
-        handleVisibilityChange();
-      }
-    },
-  };
+  public suppressChangeEvents() {
+    // this.#hasFiredDuringSuppress = false;
+    ++this.#suppressChangeEvents;
+  }
+
+  public resumeChangeEvents() {
+    --this.#suppressChangeEvents;
+    if (this.#suppressChangeEvents === 0) {
+      this.handleVisibilityChange();
+    }
+  }
 }


### PR DESCRIPTION
Changed `VisibilityChangeEventListener` to fire event after suppression ends only when change event was fired during suppression.