### PR TITLE
Remove Dynamically Created Inline Styles from Map Layers

### DIFF
--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.scss
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.scss
@@ -10,3 +10,18 @@
 .map-manager-display-none {
   display: none;
 }
+
+// Hover-based visibility for settings menus
+.map-manager-source-item {
+  #MapLayerSettingsMenuWrapper,
+  #MapLayerSettingsSubLayersMenu {
+    visibility: hidden;
+  }
+
+  &:hover {
+    #MapLayerSettingsMenuWrapper,
+    #MapLayerSettingsSubLayersMenu {
+      visibility: visible;
+    }
+  }
+}

--- a/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/MapLayerDroppable.tsx
@@ -58,11 +58,6 @@ const StrictModeDroppable = ({ children, ...props }: DroppableProps) =>{
   return <Droppable {...props}>{children}</Droppable>;
 };
 
-const changeVisibilityByElementId = (element: Element | null, visible: boolean) => {
-  if (element) {
-    element.setAttribute("style", `visibility: ${visible ? "visible" : "hidden"}`);
-  }
-};
 
 /** @internal */
 export function MapLayerDroppable(props: MapLayerDroppableProps) {
@@ -116,11 +111,6 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
     [props],
   );
 
-  const changeSettingsMenuVisibility = (event: React.MouseEvent<HTMLDivElement, MouseEvent>, visible: boolean) => {
-    changeVisibilityByElementId(event.currentTarget.querySelector("#MapLayerSettingsMenuWrapper"), visible);
-    changeVisibilityByElementId(event.currentTarget.querySelector("#MapLayerSettingsSubLayersMenu"), visible);
-  };
-
   const renderItem: DraggableChildrenFn = (dragProvided, _, rubric) => {
     assert(props.layersList !== undefined);
     const activeLayer = props.layersList[rubric.source.index];
@@ -133,8 +123,6 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
         key={activeLayer.name}
         {...dragProvided.draggableProps}
         ref={dragProvided.innerRef}
-        onMouseEnter={(event) => changeSettingsMenuVisibility(event, true)}
-        onMouseLeave={(event) => changeSettingsMenuVisibility(event, false)}
       >
         {/* Checkbox */}
         <Checkbox
@@ -204,7 +192,7 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
         </span>
 
         {/* SubLayersPopupButton */}
-        <div id="MapLayerSettingsSubLayersMenu" className="map-manager-item-sub-layer-container map-manager-hidden">
+        <div id="MapLayerSettingsSubLayersMenu" className="map-manager-item-sub-layer-container">
           {activeLayer.subLayers && activeLayer.subLayers.length > 1 && (
             <SubLayersPopupButton
               checkboxStyle="eye"
@@ -252,7 +240,7 @@ export function MapLayerDroppable(props: MapLayerDroppableProps) {
             <SvgStatusWarning />
           </IconButton>
         )}
-        <div id="MapLayerSettingsMenuWrapper" className="map-manager-hidden">
+        <div id="MapLayerSettingsMenuWrapper">
           <MapLayerSettingsMenu
             activeViewport={props.activeViewport}
             mapLayerSettings={activeLayer}


### PR DESCRIPTION
Resolves https://github.com/iTwin/viewer-components-react/issues/1389.

As previously addressed in [this PR](https://github.com/iTwin/viewer-components-react/pull/1455), some apps' content security policies do not allow inline styles. That PR attempted to fix the bug described in the attached issue by converting all instances of inline styles in map-layers with corresponding css classes, however it missed the inline styles created in the `changeVisibilityByElementId()` function. This function was used to override existing styles in order to allow certain menu items to appear when hovering over an attached map layer. This PR addresses this issue by removing `changeVisibilityByElementId()` and letting css handle the hover functionality. Attached below is a clip of the hover functionality working with these changes implemented.


https://github.com/user-attachments/assets/41ce6e09-1e29-418b-ac8e-29cb8554a7dd

