### PR TITLE
[Map layers]: skip flaky test

### DIFF
--- a/packages/map-layers/src/test/MapLayerManagerDragDrop.test.tsx
+++ b/packages/map-layers/src/test/MapLayerManagerDragDrop.test.tsx
@@ -106,7 +106,8 @@ describe("MapLayerManager drag and drop", () => {
     } as any;
   }
 
-  it("restores the drag-start layer order when the pointer leaves all droppables", async () => {
+  // TODO re-enable with https://github.com/iTwin/viewer-components-react/issues/1796
+  it.skip("restores the drag-start layer order when the pointer leaves all droppables", async () => {
     await renderMapLayerManager(["Background"], ["Overlay"]);
 
     const draggedId = `${backgroundMapLayersId}:Background`;


### PR DESCRIPTION
One Map layers test is flaky and has failed on multiple occasions. 
Filled an issue: https://github.com/iTwin/viewer-components-react/issues/1796
Skipping the test for now.