### PR TITLE
[Tree widget]: remove `ENABLE_EXPERIMENTAL_FEATURES` usage on `next`

### DIFF
--- a/.changeset/@itwin-tree-widget-react-eight-mugs-ring.md
+++ b/.changeset/@itwin-tree-widget-react-eight-mugs-ring.md
@@ -1,0 +1,5 @@
+---
+"@itwin/tree-widget-react": patch
+---
+
+Remove the unnecessary `ENABLE_EXPERIMENTAL_FEATURES` option from ECSQL queries.

--- a/cspell.json
+++ b/cspell.json
@@ -11,7 +11,6 @@
     "Descr",
     "ecschema",
     "ecsql",
-    "ECSQLOPTIONS",
     "frontstage",
     "frontstages",
     "hilite",

--- a/packages/tree-widget/src/tree-widget-react/shared/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/shared/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -332,7 +332,6 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
                 CAST(IdToHex(Category.Id) AS TEXT) || ';' || CAST(IdToHex(ECInstanceId) AS TEXT) categoryElementPath
               FROM ${this.#elementClassName}
               JOIN IdSet(?) elementIdSet ON elementIdSet.id = ECInstanceId
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
               UNION ALL
 

--- a/packages/tree-widget/src/tree-widget-react/shared/internal/caches/ChildElementsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/shared/internal/caches/ChildElementsCache.ts
@@ -144,7 +144,7 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
             }
             if (categoryMapKeys.length > 0) {
               clauses.push({
-                whereClause: `Model.Id = ${modelId} AND Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
+                whereClause: `Model.Id = ${modelId} AND Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
                 type: "category",
                 childCategoryIds: allChildCategoryIds,
                 bindings: [{ type: "idset", value: categoryMapKeys }],
@@ -221,7 +221,6 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
               SELECT d.modelId modelId, d.reqParent reqParent, d.reqCategory reqCategory, d.ownCategory ownCategory, d.id id
               FROM Descendants d
               JOIN IdSet(?) allChildCategoryIdSet ON d.ownCategory = allChildCategoryIdSet.id
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [
               ...categoryClauses.map((c) => c.bindings ?? []).flat(),

--- a/packages/tree-widget/src/tree-widget-react/shared/internal/caches/DescendantsCountCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/shared/internal/caches/DescendantsCountCache.ts
@@ -195,7 +195,6 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
               SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
               FROM Descendants
               GROUP BY modelId, reqParent, reqCategory, ownCategory
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: bindings.length > 0 ? bindings : undefined,
           },

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -401,7 +401,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 )`,
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: elementIds }],
         },
@@ -462,7 +461,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) categoryIdSet ON categoryIdSet.id = this.ECInstanceId
             ${categoryInstanceFilterClauses.joins}
             ${createWhereClause({ conditions: [categoryInstanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: categoriesToShow }],
         },
@@ -509,7 +507,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
               "NOT this.IsPrivate",
             ],
           })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
         bindings: [{ type: "idset", value: modelIds }],
       },
@@ -558,7 +555,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
               elementInstanceFilterClauses.where,
             ],
           })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
         bindings: [...bindings, { type: "idset", value: modelIds }],
       },
@@ -646,7 +642,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
           JOIN IdSet(?) definitionContainerIdSet ON this.ECInstanceId = definitionContainerIdSet.id
           ${instanceFilterClauses.joins}
           ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
         bindings: [{ type: "idset", value: definitionContainerIds }],
       },
@@ -725,7 +720,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
           JOIN DefContainers dc ON this.ECInstanceId = dc.id
           ${instanceFilterClauses.joins}
           ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
         bindings: [],
       },
@@ -841,7 +835,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
           JOIN IdSet(?) categoryIdSet ON this.ECInstanceId = categoryIdSet.id
           ${instanceFilterClauses.joins}
           ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
         bindings: [
           ...(categoriesWithChildren.length > 0 ? [{ type: "idset" as const, value: categoriesWithChildren }] : []),
@@ -942,7 +935,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
               this.#hierarchyConfig.categories.withoutElements === "exclude" && `IFNULL((${hasElements}), 0)`,
             ],
           })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
       },
     };
@@ -995,7 +987,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) categoryIdSet ON this.Parent.Id = categoryIdSet.id
             ${instanceFilterClauses.joins}
             ${createWhereClause({ conditions: ["NOT this.IsPrivate", instanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: categoryIds }],
         },
@@ -1163,7 +1154,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 instanceFilterClauses.where,
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
           bindings: [
             ...bindings,
@@ -1219,7 +1209,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 createExcludedClassesClause({ alias: "this", excludedClassNames: this.#excludedClasses }),
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [...bindings, { type: "idset", value: elementIds }],
         },
@@ -1248,7 +1237,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   ${createWhereClause({
                     conditions: [createExcludedClassesClause({ alias: "ce", excludedClassNames: this.#excludedClasses })],
                   })}
-                  ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
                 )`,
                 categoryInstanceFilterClauses.where,
               ],
@@ -1344,7 +1332,6 @@ function createInstanceKeyPathsFromInstanceLabel(
                       createExcludedClassesClause({ alias: "this", excludedClassNames: hierarchyConfig.elements.excludedClasses }),
                     ],
                   })}
-                  ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
                 )`,
               ]
             : []),
@@ -1359,7 +1346,6 @@ function createInstanceKeyPathsFromInstanceLabel(
                   FROM ${CLASS_NAME_SubCategory} this
                   JOIN IdSet(?) subCategoryParentIdSet ON this.Parent.Id = subCategoryParentIdSet.id
                   WHERE NOT this.IsPrivate
-                  ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
                 )`,
               ]
             : []),
@@ -1373,7 +1359,6 @@ function createInstanceKeyPathsFromInstanceLabel(
                   FROM ${CLASS_NAME_DefinitionContainer} this
                   JOIN IdSet(?) definitionContainerIdSet ON this.ECInstanceId = definitionContainerIdSet.id
                   WHERE NOT this.IsPrivate
-                  ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
                 )`,
               ]
             : []),
@@ -1600,7 +1585,6 @@ export function createGeometricElementInstanceKeyPaths(props: {
           FROM ${elementClass} e
           JOIN IdSet(?) targetItemIdSet ON e.ECInstanceId = targetItemIdSet.id
           ${createWhereClause({ conditions: [createExcludedClassesClause({ alias: "e", excludedClassNames: excludedElementClassNames })] })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
           UNION ALL
 
@@ -1727,7 +1711,6 @@ export function createCategoriesSearchPaths(props: {
                 createExcludedClassesClause({ alias: "pe", excludedClassNames: excludedElementClassNames }),
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
             UNION ALL
 

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -85,7 +85,6 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
         SELECT Model.Id modelId, ECInstanceId id
         FROM ${this.#categoryElementClass}
         JOIN IdSet(?) filteredElementIdSet ON ECInstanceId = filteredElementIdSet.id
-        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
       `;
       return this.#queryExecutor.createQueryReader(
         { ecsql: query, bindings: [{ type: "idset", value: filteredElementIds }] },

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -272,7 +272,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                 JOIN IdSet(?) classificationIdSet ON this.ECInstanceId = classificationIdSet.id
                 ${instanceFilterClauses.joins}
                 ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-                ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
               `,
               bindings: [
                 ...(childClassificationsWithChildren.length > 0 ? [{ type: "idset" as const, value: childClassificationsWithChildren }] : []),
@@ -322,7 +321,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                 elementsInstanceFilterClauses.where,
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: parentClassificationIds }],
         },
@@ -359,7 +357,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                     JOIN IdSet(?) classificationIdSet ON this.ECInstanceId = classificationIdSet.id
                     ${instanceFilterClauses.joins}
                     ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-                    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
                   `,
                   bindings: [
                     ...(childClassificationsWithChildren.length > 0 ? [{ type: "idset" as const, value: childClassificationsWithChildren }] : []),
@@ -398,7 +395,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
               instanceFilterClauses.where,
             ],
           })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
           bindings: [{ type: "idset", value: parentElementIds }],
         },
@@ -543,7 +539,6 @@ function createInstanceKeyPathsFromInstanceLabelObs({
                 ${classificationLabelSelectClause}
               FROM ${CLASS_NAME_Classification} this
               JOIN IdSet(?) classificationIdSet ON this.ECInstanceId = classificationIdSet.id
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             )`,
             `${ELEMENTS_WITH_LABELS_CTE}(ClassName, ECInstanceId, DisplayLabel) AS (
               SELECT
@@ -554,7 +549,6 @@ function createInstanceKeyPathsFromInstanceLabelObs({
               JOIN ${CLASS_NAME_ElementHasClassifications} ehc ON ehc.SourceECInstanceId = this.ECInstanceId
               JOIN IdSet(?) classificationIdSet ON ehc.TargetECInstanceId = classificationIdSet.id
               ${createWhereClause({ conditions: ["this.Parent.Id IS NULL", createExcludedClassesClause({ alias: "this", excludedClassNames: props.hierarchyConfig.elements?.excludedClasses })] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
               UNION ALL
 
@@ -764,7 +758,6 @@ function createGeometricElementInstanceKeyPaths(props: {
         FROM  ${CLASS_NAME_Element} e
         JOIN IdSet(?) targetItemIdSet ON e.ECInstanceId = targetItemIdSet.id
         ${createWhereClause({ conditions: [createExcludedClassesClause({ alias: "e", excludedClassNames: excludedElementClassNames })] })}
-        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
         UNION ALL
 

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -311,7 +311,6 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
           this.ECInstanceId id
         FROM ${CLASS_NAME_GeometricElement3d} this
         JOIN IdSet(?) elementIdSet ON ECInstanceId = elementIdSet.id
-        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
       `;
       return this.#props.queryExecutor.createQueryReader(
         {

--- a/packages/tree-widget/src/tree-widget-react/trees/external-sources-tree/ExternalSourcesTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/external-sources-tree/ExternalSourcesTreeDefinition.ts
@@ -164,7 +164,6 @@ export class ExternalSourcesTreeDefinition implements HierarchyDefinition {
             LEFT JOIN BisCore.RepositoryLink rl ON rl.ECInstanceId = this.Repository.Id
             ${instanceFilterClauses.joins}
             ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: groupIds }],
         },
@@ -209,7 +208,6 @@ export class ExternalSourcesTreeDefinition implements HierarchyDefinition {
             LEFT JOIN BisCore.RepositoryLink rl ON rl.ECInstanceId = this.Repository.Id
             ${instanceFilterClauses.joins}
             ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: sourceIds }],
         },
@@ -282,7 +280,6 @@ export class ExternalSourcesTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) sourceIdSet ON sourceIdSet.id = esa.Source.Id
             ${instanceFilterClauses.joins}
             ${createWhereClause({ conditions: [instanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: sourceIds }],
         },

--- a/packages/tree-widget/src/tree-widget-react/trees/imodel-content-tree/IModelContentTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/imodel-content-tree/IModelContentTreeDefinition.ts
@@ -192,7 +192,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) childSubjectIdSet ON childSubjectIdSet.id = this.ECInstanceId
             ${subjectFilterClauses.joins}
             ${createWhereClause({ conditions: [subjectFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [
             { type: "idset", value: await this.#idsCache.getParentSubjectIds() },
@@ -235,7 +234,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               FROM ${CLASS_NAME_Model} m
               JOIN IdSet(?) childModelIdSet ON childModelIdSet.id = m.ECInstanceId
               JOIN ${CLASS_NAME_InformationPartitionElement} p ON p.ECInstanceId = m.ModeledElement.Id
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             ) model
             JOIN ${modelFilterClauses.from} this ON this.ECInstanceId = model.ECInstanceId
             JOIN ${CLASS_NAME_InformationPartitionElement} [partition] ON [partition].ECInstanceId = this.ModeledElement.Id
@@ -270,7 +268,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             FROM ${CLASS_NAME_Model} this
             JOIN IdSet(?) elementIdSet ON elementIdSet.id = this.ModeledElement.Id
             WHERE NOT this.IsPrivate
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: elementIds }],
         },
@@ -325,7 +322,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) childCategoryIdSet ON childCategoryIdSet.id = this.ECInstanceId
             ${categoryFilterClauses.joins}
             ${createWhereClause({ conditions: [categoryFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: childCategoryIds }],
         },
@@ -354,7 +350,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) modelIdSet ON modelIdSet.id = this.Model.Id
             ${informationContentElementFilterClauses.joins}
             ${createWhereClause({ conditions: [informationContentElementFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
         bindings: [{ type: "idset", value: modelIds }],
       },
@@ -407,7 +402,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
               ${instanceFilterClauses.joins}
               ${createWhereClause({ conditions: ["this.Parent.Id IS NULL", whereClause, instanceFilterClauses.where] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [
               { type: "idset", value: categoryIds },
@@ -458,7 +452,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
               ${instanceFilterClauses.joins}
               ${createWhereClause({ conditions: ["this.Parent.Id IS NULL", whereClause, instanceFilterClauses.where] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [{ type: "idset", value: modelIds }],
           },
@@ -540,7 +533,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               JOIN IdSet(?) groupIdSet ON this.Parent.Id = groupIdSet.id
               ${instanceFilterClauses.joins}
               ${createWhereClause({ conditions: [whereClause, instanceFilterClauses.where] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [{ type: "idset", value: groupIds }],
           },
@@ -588,7 +580,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               JOIN IdSet(?) groupIdSet ON egm.SourceECInstanceId = groupIdSet.id
               ${instanceFilterClauses.joins}
               ${createWhereClause({ conditions: [whereClause, instanceFilterClauses.where] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [{ type: "idset", value: groupIds }],
           },
@@ -635,7 +626,6 @@ export class IModelContentTreeDefinition implements HierarchyDefinition {
               JOIN IdSet(?) elementIdSet ON p.ECInstanceId = elementIdSet.id
               ${instanceFilterClauses.joins}
               ${createWhereClause({ conditions: [whereClause, instanceFilterClauses.where] })}
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [{ type: "idset", value: elementIds }],
           },

--- a/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
@@ -429,7 +429,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) childSubjectIdSet ON this.ECInstanceId = childSubjectIdSet.id
             ${subjectFilterClauses.joins}
             ${createWhereClause({ conditions: [subjectFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [
             {
@@ -493,7 +492,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               FROM ${CLASS_NAME_GeometricModel3d} m
               JOIN IdSet(?) childModelIdSet ON m.ECInstanceId = childModelIdSet.id
               JOIN ${CLASS_NAME_InformationPartitionElement} p ON p.ECInstanceId = m.ModeledElement.Id
-              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             ) model
             JOIN ${modelFilterClauses.from} this ON this.ECInstanceId = model.ECInstanceId
             JOIN ${CLASS_NAME_InformationPartitionElement} [partition] ON [partition].ECInstanceId = this.ModeledElement.Id
@@ -545,7 +543,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 )`,
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: elementIds }],
         },
@@ -624,7 +621,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 !categoriesToShow && modeledElementCategory !== undefined && `this.ECInstanceId <> ${modeledElementCategory}`,
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: categoriesToShow ? categoriesToShow : modelIds }],
         },
@@ -647,7 +643,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
             ${elementInstanceFilterClauses.joins}
             ${createWhereClause({ conditions: ["this.Parent.Id IS NULL", `this.Category.Id = ${modeledElementCategory}`, createExcludedClassesClause({ alias: "this", excludedClassNames: this.#hierarchyConfig.elements.excludedClasses }), elementInstanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [...bindings, { type: "idset", value: modelIds }],
         },
@@ -795,7 +790,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
             ${parentIds ? `JOIN IdSet(?) parentIdSet ON this.Parent.Id = parentIdSet.id` : ""}
             ${instanceFilterClauses.joins}
             ${createWhereClause({ conditions: [!parentIds && "this.Parent.Id IS NULL", createExcludedClassesClause({ alias: "this", excludedClassNames: this.#hierarchyConfig.elements.excludedClasses }), instanceFilterClauses.where] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [
             ...bindings,
@@ -846,7 +840,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           JOIN IdSet(?) elementIdSet ON this.Parent.Id = elementIdSet.id
           ${elementInstanceFilterClauses.joins}
           ${createWhereClause({ conditions: [`this.Category.Id = ${parentCategoryId}`, createExcludedClassesClause({ alias: "this", excludedClassNames: this.#hierarchyConfig.elements.excludedClasses }), elementInstanceFilterClauses.where] })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
           bindings: [...bindings, { type: "idset", value: elementIds }],
         },
@@ -870,7 +863,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 FROM ${this.#hierarchyConfig.elements.baseClass} ce
                 JOIN IdSet(?) parentIdSet ON ce.Parent.Id = parentIdSet.id
                 ${createWhereClause({ conditions: [createExcludedClassesClause({ alias: "ce", excludedClassNames: this.#hierarchyConfig.elements.excludedClasses })] })}
-                ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
               )`,
               categoryInstanceFilterClauses.where,
             ],
@@ -967,7 +959,6 @@ export function createGeometricElementInstanceKeyPaths(props: {
             FROM ${elementClassName} e
             JOIN IdSet(?) elementIdSet ON e.ECInstanceId = elementIdSet.id
             ${createWhereClause({ conditions: [createExcludedClassesClause({ alias: "e", excludedClassNames: excludedElementClassNames })] })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `
           : undefined;
 
@@ -984,7 +975,6 @@ export function createGeometricElementInstanceKeyPaths(props: {
               createExcludedClassesClause({ alias: "e", excludedClassNames: excludedElementClassNames }),
             ],
           })}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
       );
 
@@ -1127,7 +1117,6 @@ export function createCategoriesSearchPaths(props: {
                 createExcludedClassesClause({ alias: "pe", excludedClassNames: excludedElementClassNames }),
               ],
             })}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
             UNION ALL
 


### PR DESCRIPTION
This option is not needed. Tested by installing core 5.8.0 on the test app and executing the queries.