### PR TITLE
[measure-tools-react] Fix measurements in profile drawings

### DIFF
--- a/packages/measure-tools/src/api/Measurement.ts
+++ b/packages/measure-tools/src/api/Measurement.ts
@@ -9,7 +9,7 @@ import type { GeometryStreamProps } from "@itwin/core-common";
 import type { DecorateContext, HitDetail } from "@itwin/core-frontend";
 import { BeButton, BeButtonEvent, IModelApp } from "@itwin/core-frontend";
 import type { TransformProps, XYProps, XYZProps , Point3d} from "@itwin/core-geometry";
-import type { Transform } from "@itwin/core-geometry";
+import { Transform } from "@itwin/core-geometry";
 import { Point2d } from "@itwin/core-geometry";
 import type { FormatterSpec } from "@itwin/core-quantity";
 import { MeasurementButtonHandledEvent, WellKnownMeasurementStyle, WellKnownViewType } from "./MeasurementEnums.js";
@@ -63,6 +63,9 @@ export namespace DrawingMetadata {
     if (origin !== undefined) {
       return {
         origin, extents, drawingId: obj.drawingId,
+        drawingType: obj.drawingType,
+        worldScale: obj.worldScale,
+        sheetToProfileTransform: obj.sheetToProfileTransform?.toJSON(),
         sheetToWorldTransformProps: obj.sheetToWorldTransformProps ? { ...obj.sheetToWorldTransformProps } : undefined
       };
     }
@@ -79,7 +82,10 @@ export namespace DrawingMetadata {
     return {
       origin: Point2d.fromJSON(json.origin),
       drawingId: json.drawingId,
+      drawingType: json.drawingType,
       extents: Point2d.fromJSON(json.extents),
+      worldScale: json.worldScale,
+      sheetToProfileTransform: json.sheetToProfileTransform ? Transform.fromJSON(json.sheetToProfileTransform) : undefined,
       sheetToWorldTransformProps,
       sheetToWorldTransformv2
     };
@@ -275,7 +281,7 @@ export interface MeasurementEqualityOptions {
   angleTolerance?: number;
 }
 
-export interface DrawingMetadataProps extends Omit<DrawingMetadata, "origin" | "extents" | "sheetToWorldTransform"> {
+export interface DrawingMetadataProps extends Omit<DrawingMetadata, "origin" | "extents" | "sheetToWorldTransform" | "sheetToProfileTransform"> {
   origin: XYProps;
   extents?: XYProps;
   /** @deprecated Will be removed, use sheetToWorldTransformProps.transformParams instead */
@@ -284,12 +290,18 @@ export interface DrawingMetadataProps extends Omit<DrawingMetadata, "origin" | "
     sheetTov8Drawing: TransformProps;
     v8DrawingToDesign: TransformProps;
   };
+  sheetToProfileTransform?: TransformProps;
   sheetToWorldTransformProps?: SheetMeasurementHelper.SheetToWorldTransformProps;
 }
 
 export interface DrawingMetadata {
   /** Id of the drawing */
   drawingId?: string;
+
+  /** Type of the drawing the metadata was resolved from. Kept alongside the transforms so callers cannot pair a
+   * drawing type with another drawing's transform.
+   */
+  drawingType?: SheetMeasurementHelper.DrawingType;
 
   /** Origin of the drawing in sheet coordinates */
   origin: Point2d;
@@ -311,9 +323,10 @@ export interface DrawingMetadata {
   */
   sheetToWorldTransform?: SheetMeasurementsHelper.SheetTransformParams;
 
-  /** Represents the transform from sheet points to distance along alignment (X) and vertical position related to alignment (Y)
-   * @deprecated
-  */
+  /** Represents the transform from sheet points to distance along alignment (X) and vertical position related to
+   * alignment (Y). Only profile/elevation drawings define one; it is undefined when the drawing has none, since these
+   * drawings are anisotropic and the isotropic sheet scale cannot stand in for it.
+   */
   sheetToProfileTransform?: Transform;
 }
 
@@ -751,7 +764,10 @@ export abstract class Measurement {
       this._drawingMetadata = {
         origin: other.drawingMetadata.origin.clone(),
         drawingId: other.drawingMetadata.drawingId,
+        drawingType: other.drawingMetadata.drawingType,
         extents: other.drawingMetadata.extents?.clone(),
+        worldScale: other.drawingMetadata.worldScale,
+        sheetToProfileTransform: other.drawingMetadata.sheetToProfileTransform?.clone(),
         sheetToWorldTransformv2: SheetMeasurementHelper.getTransform(other.drawingMetadata.origin.clone(), other.drawingMetadata.sheetToWorldTransformProps),
         sheetToWorldTransformProps: other.drawingMetadata.sheetToWorldTransformProps
     };

--- a/packages/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -5,7 +5,7 @@
 
 import { ColorDef, QueryBinder } from "@itwin/core-common";
 import type { DecorateContext, GraphicBuilder, HitDetail, ScreenViewport} from "@itwin/core-frontend";
-import { GraphicType, IModelApp, type IModelConnection } from "@itwin/core-frontend";
+import { GraphicType, IModelApp, type IModelConnection, InputSource, LocateResponse } from "@itwin/core-frontend";
 import type { TransformProps, XYProps, XYZ, XYZProps} from "@itwin/core-geometry";
 import { Point3d, Range2d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { Transform } from "@itwin/core-geometry";
@@ -45,6 +45,16 @@ export namespace SheetMeasurementHelper {
     origin: { x: number, y: number}
     bBoxLow: { x: number, y: number};
     bBoxHigh: { x: number, y: number};
+  }
+
+  /** Controls how the drawing under a point is resolved. */
+  export interface ResolveDrawingOptions {
+    /** When supplied, the drawing owning the element under the cursor is preferred over the containing rectangle.
+     * View attachment rectangles overlap, so the geometry actually picked is a stronger signal than the rectangles.
+     */
+    viewport?: ScreenViewport;
+    /** Input source used for the pick. Defaults to `InputSource.Mouse`. */
+    inputSource?: InputSource;
   }
 
   /** Information needed to use the old Civil transform but will eventually be removed @deprecated */
@@ -221,6 +231,39 @@ export namespace SheetMeasurementHelper {
   }
 
   /**
+   * Identifies the drawing from the element under the cursor.
+   * A drawing element and the model it breaks down share an id, so the hit's model id is the drawing id.
+   * @returns the picked drawing, or undefined when nothing was hit or the hit belongs to no drawing on the sheet
+   */
+  async function pickDrawing(mousePos: Point3d, drawingInfo: ReadonlyArray<DrawingTypeData>, options: ResolveDrawingOptions): Promise<DrawingTypeData | undefined> {
+    const viewport = options.viewport;
+    if (viewport === undefined)
+      return undefined;
+
+    const snappedHit = IModelApp.accuSnap.currHit;
+    const hit = snappedHit ?? await IModelApp.locateManager.doLocate(new LocateResponse(), true, mousePos, viewport, options.inputSource ?? InputSource.Mouse);
+    const hitModelId = hit?.modelId;
+    if (hitModelId === undefined)
+      return undefined;
+
+    return drawingInfo.find((info) => info.id === hitModelId);
+  }
+
+  /**
+   * Drawings whose rectangle contains the point.
+   * View attachment rectangles overlap, so more than one result means resolving from the point alone has to guess
+   * between them. Callers that cannot pick an element may want to surface that to the user.
+   */
+  export async function getDrawingsAtPoint(imodel: IModelConnection, sheetViewId: string, mousePos: Point3d): Promise<DrawingTypeData[]> {
+    if (imodel.isBlank) {
+      return [];
+    }
+
+    const drawingInfo = await DrawingDataCache.getInstance().querySheetDrawingData(imodel, sheetViewId);
+    return drawingInfo.filter((info) => getDrawingRange(info).containsXY(mousePos.x, mousePos.y));
+  }
+
+  /**
    * Gives the first drawing which contains the mouse position, undefined otherwise
    * @param mousePos
    * @param drawingInfo
@@ -359,7 +402,7 @@ export namespace SheetMeasurementHelper {
    * @param id
    * @param mousePos
    */
-  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<{
+  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d, options: ResolveDrawingOptions = {}): Promise<{
     sheetToWorldTransform : Transform,
     sheetToProfileTransform?: Transform,
     viewAttachmentOrigin: {x: number, y: number},
@@ -375,7 +418,8 @@ export namespace SheetMeasurementHelper {
 
     const drawingInfo = await DrawingDataCache.getInstance().querySheetDrawingData(imodel, id);
 
-    const correctVAData = getCorrectDrawing(mousePos, drawingInfo);
+    const pickedVAData = await pickDrawing(mousePos, drawingInfo, options);
+    const correctVAData = pickedVAData ?? getCorrectDrawing(mousePos, drawingInfo);
 
     if (correctVAData === undefined)
       return undefined;
@@ -478,9 +522,10 @@ export namespace SheetMeasurementHelper {
 
   /**
    * Resolves the drawing under the point along with everything needed to measure in it.
+   * @param options pass a viewport to resolve from the element under the cursor rather than the containing rectangle
    */
-  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<DrawingMetadata | undefined> {
-    const drawingData = await getDrawingData(imodel, id, mousePos);
+  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d, options: ResolveDrawingOptions = {}): Promise<DrawingMetadata | undefined> {
+    const drawingData = await getDrawingData(imodel, id, mousePos, options);
     if (drawingData?.drawingId === undefined || drawingData.viewAttachmentOrigin === undefined || drawingData.transformProps === undefined)
       return undefined;
 

--- a/packages/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -6,7 +6,7 @@
 import { ColorDef, QueryBinder } from "@itwin/core-common";
 import type { DecorateContext, GraphicBuilder, HitDetail, ScreenViewport} from "@itwin/core-frontend";
 import { GraphicType, IModelApp, type IModelConnection } from "@itwin/core-frontend";
-import type { XYProps, XYZ, XYZProps} from "@itwin/core-geometry";
+import type { TransformProps, XYProps, XYZ, XYZProps} from "@itwin/core-geometry";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { Transform } from "@itwin/core-geometry";
 import { Point2d } from "@itwin/core-geometry";
@@ -35,6 +35,8 @@ export namespace SheetMeasurementHelper {
     sheetScale?: number;
     DVDOrigin?: XYProps;
     transformParams?: CivilSheetTransformParams;
+    /** Raw sheet-to-profile transform as authored on the drawing, present only on profile/elevation drawings. */
+    sheetToProfileTransformProps?: TransformProps;
   }
 
   export interface DrawingTypeData {
@@ -208,16 +210,21 @@ export namespace SheetMeasurementHelper {
   }
 
   /**
-   * Gives the first drawing which constains the mouse position, undefined otherwise
+   * Gives the first drawing which contains the mouse position, undefined otherwise
    * @param mousePos
    * @param drawingInfo
+   * @param allowedDrawingTypes When provided, drawings of any other type are skipped so an overlapping drawing the
+   * caller cannot measure in does not mask the one it can.
    * @returns
    */
-  function getCorrectDrawing(mousePos: Point3d, drawingInfo: ReadonlyArray<DrawingTypeData>): DrawingTypeData | undefined {
+  function getCorrectDrawing(mousePos: Point3d, drawingInfo: ReadonlyArray<DrawingTypeData>, allowedDrawingTypes?: DrawingType[]): DrawingTypeData | undefined {
     const x = mousePos.x;
     const y = mousePos.y;
 
     for (const info of drawingInfo) {
+      if (allowedDrawingTypes !== undefined && (info.type === undefined || !allowedDrawingTypes.includes(info.type)))
+        continue;
+
       if (x >= info.origin.x && x <= info.origin.x + info.bBoxHigh.x) {
         // Within x extents
         if (y >= info.origin.y && y <= info.origin.y + info.bBoxHigh.y) {
@@ -338,7 +345,8 @@ export namespace SheetMeasurementHelper {
           const sheetToWorldTransform: CivilSheetTransformParams = { masterOrigin: Point3d.fromJSON(jsonProp.civilimodelconn.masterOrigin), sheetTov8Drawing: Transform.fromJSON(jsonProp.civilimodelconn.sheetToV8DrawingTransform), v8DrawingToDesign: Transform.fromJSON(jsonProp.civilimodelconn.v8DrawingToDesignTransform)};
           return {
             transformParams: sheetToWorldTransform,
-            sheetScale: jsonProp.scale
+            sheetScale: jsonProp.scale,
+            sheetToProfileTransformProps: jsonProp.civilimodelconn.sheetToProfileTransform ?? undefined
           };
         }
       }
@@ -352,12 +360,14 @@ export namespace SheetMeasurementHelper {
    * @param id
    * @param mousePos
    */
-  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<{
+  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d, allowedDrawingTypes?: DrawingType[]): Promise<{
     sheetToWorldTransform : Transform,
+    sheetToProfileTransform?: Transform,
     viewAttachmentOrigin: {x: number, y: number},
     viewAttachmentExtent: {x: number, y: number},
     transformProps: SheetToWorldTransformProps,
-    drawingId: string
+    drawingId: string,
+    drawingType?: number
   } | undefined> {
 
     if (imodel.isBlank) {
@@ -366,7 +376,7 @@ export namespace SheetMeasurementHelper {
 
     const drawingInfo = await DrawingDataCache.getInstance().querySheetDrawingData(imodel, id);
 
-    const correctVAData = getCorrectDrawing(mousePos, drawingInfo);
+    const correctVAData = getCorrectDrawing(mousePos, drawingInfo, allowedDrawingTypes);
 
     if (correctVAData === undefined)
       return undefined;
@@ -376,16 +386,23 @@ export namespace SheetMeasurementHelper {
     if (spatialInfo === undefined)
       return undefined;
 
+    // Transform.fromJSON silently returns identity for missing or unrecognized props, which would leave profile
+    // measurements in sheet units, so only build one when the drawing actually defines it.
+    const rawProfileTransform = spatialInfo.sheetToProfileTransformProps;
+    const sheetToProfileTransform = rawProfileTransform ? Transform.fromJSON(rawProfileTransform) : undefined;
+
     if (spatialInfo.transformParams === undefined) {
       const transform = getTransform(correctVAData.origin, spatialInfo);
-      return {sheetToWorldTransform: transform, viewAttachmentOrigin: correctVAData.origin, viewAttachmentExtent: correctVAData.bBoxHigh, drawingId: correctVAData.id, transformProps: spatialInfo};
+      return {sheetToWorldTransform: transform, sheetToProfileTransform, viewAttachmentOrigin: correctVAData.origin, viewAttachmentExtent: correctVAData.bBoxHigh, drawingId: correctVAData.id, drawingType: correctVAData.type, transformProps: spatialInfo};
     } else {
       const sheetToWorldTransform: CivilSheetTransformParams = { masterOrigin: Point3d.fromJSON(spatialInfo.transformParams.masterOrigin), sheetTov8Drawing: spatialInfo.transformParams.sheetTov8Drawing, v8DrawingToDesign: spatialInfo.transformParams.v8DrawingToDesign};
       return {
         drawingId: correctVAData.id,
+        drawingType: correctVAData.type,
         viewAttachmentOrigin: correctVAData.origin,
         viewAttachmentExtent: correctVAData.bBoxHigh,
         sheetToWorldTransform: getTransform(correctVAData.origin, {transformParams: sheetToWorldTransform}),
+        sheetToProfileTransform,
         transformProps: spatialInfo
       };
     }
@@ -455,11 +472,25 @@ export namespace SheetMeasurementHelper {
     return false;
   }
 
-  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<DrawingMetadata | undefined> {
-    const drawingData = await getDrawingData(imodel, id, mousePos);
-    if (drawingData?.drawingId !== undefined && drawingData.viewAttachmentOrigin !== undefined && drawingData.transformProps !== undefined)
-      return { origin: Point2d.fromJSON(drawingData.viewAttachmentOrigin), drawingId: drawingData.drawingId, sheetToWorldTransformProps: drawingData.transformProps, extents: Point2d.fromJSON(drawingData.viewAttachmentExtent), sheetToWorldTransformv2: drawingData.sheetToWorldTransform};
-    return undefined;
+  /**
+   * Resolves the drawing under the point along with everything needed to measure in it.
+   * @param allowedDrawingTypes When provided, drawings of any other type are skipped while resolving, so an overlapping
+   * drawing the caller cannot measure in does not mask the one it can.
+   */
+  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d, allowedDrawingTypes?: DrawingType[]): Promise<DrawingMetadata | undefined> {
+    const drawingData = await getDrawingData(imodel, id, mousePos, allowedDrawingTypes);
+    if (drawingData?.drawingId === undefined || drawingData.viewAttachmentOrigin === undefined || drawingData.transformProps === undefined)
+      return undefined;
+
+    return {
+      origin: Point2d.fromJSON(drawingData.viewAttachmentOrigin),
+      drawingId: drawingData.drawingId,
+      drawingType: drawingData.drawingType,
+      sheetToWorldTransformProps: drawingData.transformProps,
+      extents: Point2d.fromJSON(drawingData.viewAttachmentExtent),
+      sheetToWorldTransformv2: drawingData.sheetToWorldTransform,
+      sheetToProfileTransform: drawingData.sheetToProfileTransform
+    };
   }
 
 }
@@ -525,7 +556,7 @@ export namespace SheetMeasurementsHelper {
           const jsonProp = JSON.parse(row[4]);
           const scale = jsonProp.scale;
           if (jsonProp.civilimodelconn) {
-            const sheetToProfileTransform = Transform.fromJSON(jsonProp.civilimodelconn.sheetToProfileTransform);
+            const sheetToProfileTransform = jsonProp.civilimodelconn.sheetToProfileTransform ? Transform.fromJSON(jsonProp.civilimodelconn.sheetToProfileTransform) : undefined;
             const sheetToWorldTransform: SheetTransformParams = { masterOrigin: Point3d.fromJSON(jsonProp.civilimodelconn.masterOrigin), sheetTov8Drawing: Transform.fromJSON(jsonProp.civilimodelconn.sheetToV8DrawingTransform), v8DrawingToDesign: Transform.fromJSON(jsonProp.civilimodelconn.v8DrawingToDesignTransform)};
             const result: DrawingMetadata = {
               drawingId: row[0],

--- a/packages/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -41,7 +41,7 @@ export namespace SheetMeasurementHelper {
 
   export interface DrawingTypeData {
     id: string;
-    type?: number;
+    type?: DrawingType;
     origin: { x: number, y: number}
     bBoxLow: { x: number, y: number};
     bBoxHigh: { x: number, y: number};
@@ -409,7 +409,7 @@ export namespace SheetMeasurementHelper {
     viewAttachmentExtent: {x: number, y: number},
     transformProps: SheetToWorldTransformProps,
     drawingId: string,
-    drawingType?: number
+    drawingType?: DrawingType
   } | undefined> {
 
     if (imodel.isBlank) {
@@ -722,7 +722,8 @@ export namespace SheetMeasurementsHelper {
     if (!viewport)
       return false;
     for (const drawing of DrawingDataCache.getInstance().getSheetDrawingDataForViewport(viewport)) {
-      if (drawing.type && allowedDrawingTypes.includes(drawing.type)) {
+      // The cached type is the wider SheetMeasurementHelper.DrawingType, which this deprecated overload cannot express.
+      if (drawing.type && (allowedDrawingTypes as number[]).includes(drawing.type)) {
         if (SheetMeasurementsHelper.checkIfInDrawing(point, Point2d.fromJSON(drawing.origin), Point2d.fromJSON(drawing.bBoxHigh))) {
           return true;
         }

--- a/packages/measure-tools/src/api/SheetMeasurementHelper.ts
+++ b/packages/measure-tools/src/api/SheetMeasurementHelper.ts
@@ -7,7 +7,7 @@ import { ColorDef, QueryBinder } from "@itwin/core-common";
 import type { DecorateContext, GraphicBuilder, HitDetail, ScreenViewport} from "@itwin/core-frontend";
 import { GraphicType, IModelApp, type IModelConnection } from "@itwin/core-frontend";
 import type { TransformProps, XYProps, XYZ, XYZProps} from "@itwin/core-geometry";
-import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
+import { Point3d, Range2d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { Transform } from "@itwin/core-geometry";
 import { Point2d } from "@itwin/core-geometry";
 import { DrawingDataCache } from "./DrawingTypeDataCache.js";
@@ -210,28 +210,27 @@ export namespace SheetMeasurementHelper {
   }
 
   /**
+   * Sheet-space rectangle covered by a view attachment.
+   * The placement bounding box is relative to the placement origin, so bBoxLow cannot be assumed to be zero.
+   */
+  export function getDrawingRange(drawing: DrawingTypeData): Range2d {
+    const origin = Point2d.fromJSON(drawing.origin);
+    const low = Point2d.fromJSON(drawing.bBoxLow);
+    const high = Point2d.fromJSON(drawing.bBoxHigh);
+    return Range2d.createXYXY(origin.x + low.x, origin.y + low.y, origin.x + high.x, origin.y + high.y);
+  }
+
+  /**
    * Gives the first drawing which contains the mouse position, undefined otherwise
    * @param mousePos
    * @param drawingInfo
-   * @param allowedDrawingTypes When provided, drawings of any other type are skipped so an overlapping drawing the
-   * caller cannot measure in does not mask the one it can.
    * @returns
    */
-  function getCorrectDrawing(mousePos: Point3d, drawingInfo: ReadonlyArray<DrawingTypeData>, allowedDrawingTypes?: DrawingType[]): DrawingTypeData | undefined {
-    const x = mousePos.x;
-    const y = mousePos.y;
-
+  function getCorrectDrawing(mousePos: Point3d, drawingInfo: ReadonlyArray<DrawingTypeData>): DrawingTypeData | undefined {
     for (const info of drawingInfo) {
-      if (allowedDrawingTypes !== undefined && (info.type === undefined || !allowedDrawingTypes.includes(info.type)))
-        continue;
-
-      if (x >= info.origin.x && x <= info.origin.x + info.bBoxHigh.x) {
-        // Within x extents
-        if (y >= info.origin.y && y <= info.origin.y + info.bBoxHigh.y) {
-          // Within y extents
-          return info;
-        }
-      }
+      const range = getDrawingRange(info);
+      if (range.containsXY(mousePos.x, mousePos.y))
+        return info;
     }
     return undefined;
   }
@@ -360,7 +359,7 @@ export namespace SheetMeasurementHelper {
    * @param id
    * @param mousePos
    */
-  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d, allowedDrawingTypes?: DrawingType[]): Promise<{
+  export async function getDrawingData(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<{
     sheetToWorldTransform : Transform,
     sheetToProfileTransform?: Transform,
     viewAttachmentOrigin: {x: number, y: number},
@@ -376,7 +375,7 @@ export namespace SheetMeasurementHelper {
 
     const drawingInfo = await DrawingDataCache.getInstance().querySheetDrawingData(imodel, id);
 
-    const correctVAData = getCorrectDrawing(mousePos, drawingInfo, allowedDrawingTypes);
+    const correctVAData = getCorrectDrawing(mousePos, drawingInfo);
 
     if (correctVAData === undefined)
       return undefined;
@@ -391,17 +390,22 @@ export namespace SheetMeasurementHelper {
     const rawProfileTransform = spatialInfo.sheetToProfileTransformProps;
     const sheetToProfileTransform = rawProfileTransform ? Transform.fromJSON(rawProfileTransform) : undefined;
 
+    // Report the same rectangle the containment test used, so callers decorating it draw exactly that.
+    const range = getDrawingRange(correctVAData);
+    const viewAttachmentOrigin = { x: range.low.x, y: range.low.y };
+    const viewAttachmentExtent = { x: range.xLength(), y: range.yLength() };
+
     if (spatialInfo.transformParams === undefined) {
-      const transform = getTransform(correctVAData.origin, spatialInfo);
-      return {sheetToWorldTransform: transform, sheetToProfileTransform, viewAttachmentOrigin: correctVAData.origin, viewAttachmentExtent: correctVAData.bBoxHigh, drawingId: correctVAData.id, drawingType: correctVAData.type, transformProps: spatialInfo};
+      const transform = getTransform(viewAttachmentOrigin, spatialInfo);
+      return {sheetToWorldTransform: transform, sheetToProfileTransform, viewAttachmentOrigin, viewAttachmentExtent, drawingId: correctVAData.id, drawingType: correctVAData.type, transformProps: spatialInfo};
     } else {
       const sheetToWorldTransform: CivilSheetTransformParams = { masterOrigin: Point3d.fromJSON(spatialInfo.transformParams.masterOrigin), sheetTov8Drawing: spatialInfo.transformParams.sheetTov8Drawing, v8DrawingToDesign: spatialInfo.transformParams.v8DrawingToDesign};
       return {
         drawingId: correctVAData.id,
         drawingType: correctVAData.type,
-        viewAttachmentOrigin: correctVAData.origin,
-        viewAttachmentExtent: correctVAData.bBoxHigh,
-        sheetToWorldTransform: getTransform(correctVAData.origin, {transformParams: sheetToWorldTransform}),
+        viewAttachmentOrigin,
+        viewAttachmentExtent,
+        sheetToWorldTransform: getTransform(viewAttachmentOrigin, {transformParams: sheetToWorldTransform}),
         sheetToProfileTransform,
         transformProps: spatialInfo
       };
@@ -464,7 +468,7 @@ export namespace SheetMeasurementHelper {
       return false;
     for (const drawing of DrawingDataCache.getInstance().getSheetDrawingDataForViewport(viewport)) {
       if (drawing.type !== undefined && allowedDrawingTypes.includes(drawing.type)) {
-        if (SheetMeasurementHelper.checkIfInDrawing(point, Point2d.fromJSON(drawing.origin), Point2d.fromJSON(drawing.bBoxHigh))) {
+        if (getDrawingRange(drawing).containsXY(point.x, point.y)) {
           return true;
         }
       }
@@ -474,11 +478,9 @@ export namespace SheetMeasurementHelper {
 
   /**
    * Resolves the drawing under the point along with everything needed to measure in it.
-   * @param allowedDrawingTypes When provided, drawings of any other type are skipped while resolving, so an overlapping
-   * drawing the caller cannot measure in does not mask the one it can.
    */
-  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d, allowedDrawingTypes?: DrawingType[]): Promise<DrawingMetadata | undefined> {
-    const drawingData = await getDrawingData(imodel, id, mousePos, allowedDrawingTypes);
+  export async function getDrawingMetadata(imodel: IModelConnection, id: string, mousePos: Point3d): Promise<DrawingMetadata | undefined> {
+    const drawingData = await getDrawingData(imodel, id, mousePos);
     if (drawingData?.drawingId === undefined || drawingData.viewAttachmentOrigin === undefined || drawingData.transformProps === undefined)
       return undefined;
 

--- a/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
+++ b/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import type { IModelConnection } from "@itwin/core-frontend";
+import { Point2d, Point3d, Transform } from "@itwin/core-geometry";
+import { assert } from "chai";
+import { afterEach, describe, it, vi } from "vitest";
+import { DrawingDataCache } from "../../api/DrawingTypeDataCache.js";
+import { DrawingMetadata } from "../../api/Measurement.js";
+import { SheetMeasurementHelper } from "../../api/SheetMeasurementHelper.js";
+import { WellKnownViewType } from "../../api/MeasurementEnums.js";
+import { DistanceMeasurement } from "../../measurements/DistanceMeasurement.js";
+
+// Taken from a plan-and-profile sheet where the plan view attachment fully encloses the profile view attachment.
+const planDrawing: SheetMeasurementHelper.DrawingTypeData = {
+  id: "0x20000000161",
+  type: SheetMeasurementHelper.DrawingTypeEnum.Plan,
+  origin: { x: -0.010901885858856986, y: 0.0733496210801317 },
+  bBoxLow: { x: 0, y: 0 },
+  bBoxHigh: { x: 0.8713426995780083, y: 0.683576266158866 },
+};
+
+const profileDrawing: SheetMeasurementHelper.DrawingTypeData = {
+  id: "0x20000000162",
+  type: SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation,
+  origin: { x: 0.05097792785857891, y: 0.0755846793892972 },
+  bBoxLow: { x: 0, y: 0 },
+  bBoxHigh: { x: 0.7625306571302384, y: 0.2189899393616121 },
+};
+
+// Horizontal scale 1:600, vertical scale 1:120 (a 5x vertical exaggeration).
+const profileTransformProps = [[600, 0, 0, 0], [0, 120, 0, 0], [0, 0, 1, 0]];
+
+const pointInsideBothDrawings = Point3d.create(0.7278001436368169, 0.22686231342959792);
+const sheetViewId = "0x1";
+const imodel = { isBlank: false } as unknown as IModelConnection;
+const profileToolDrawingTypes = [
+  SheetMeasurementHelper.DrawingTypeEnum.Section,
+  SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation,
+];
+
+function stubDrawingCache(drawings: SheetMeasurementHelper.DrawingTypeData[], profileDrawingHasTransform = true) {
+  vi.spyOn(DrawingDataCache, "getInstance").mockReturnValue({
+    querySheetDrawingData: async () => drawings,
+    querySpatialInfo: async (_imodel: IModelConnection, drawing: SheetMeasurementHelper.DrawingTypeData) => {
+      const isProfileWithTransform = drawing.id === profileDrawing.id && profileDrawingHasTransform;
+      return {
+        sheetScale: 600,
+        sheetToProfileTransformProps: isProfileWithTransform ? profileTransformProps : undefined,
+      };
+    },
+  } as unknown as DrawingDataCache);
+}
+
+describe("SheetMeasurementHelper.getDrawingMetadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips an overlapping drawing whose type is not allowed", async () => {
+    // The plan attachment encloses the profile and defines no sheetToProfileTransform, so selecting it left profile
+    // measurements in sheet units.
+    stubDrawingCache([planDrawing, profileDrawing]);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+
+    assert.strictEqual(metadata?.drawingId, profileDrawing.id);
+    assert.strictEqual(metadata?.drawingType, SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation);
+  });
+
+  it("returns the first containing drawing when no types are given", async () => {
+    stubDrawingCache([planDrawing, profileDrawing]);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
+
+    assert.strictEqual(metadata?.drawingId, planDrawing.id);
+  });
+
+  it("returns undefined when no drawing of an allowed type contains the point", async () => {
+    stubDrawingCache([planDrawing]);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+
+    assert.isUndefined(metadata);
+  });
+
+  it("carries the profile transform of the resolved drawing", async () => {
+    stubDrawingCache([planDrawing, profileDrawing]);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+
+    // One inch of sheet at the 1:120 vertical scale is 3.048 m (10 ft), not the raw 0.0254 m of sheet space.
+    const transform = metadata?.sheetToProfileTransform;
+    assert.isDefined(transform);
+    const start = transform!.multiplyPoint3d(Point3d.create(0, 0));
+    const end = transform!.multiplyPoint3d(Point3d.create(0, 0.0254));
+    assert.closeTo(start.distance(end), 3.048, 1e-6);
+  });
+
+  it("leaves the profile transform undefined when the drawing does not define one", async () => {
+    // Transform.fromJSON yields identity for missing props, which would silently report sheet units as world units.
+    stubDrawingCache([planDrawing, profileDrawing], false);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+
+    assert.strictEqual(metadata?.drawingId, profileDrawing.id);
+    assert.isUndefined(metadata?.sheetToProfileTransform);
+  });
+});
+
+describe("DrawingMetadata profile transform round-trip", () => {
+  const metadata: DrawingMetadata = {
+    origin: Point2d.create(0.05097792785857891, 0.0755846793892972),
+    extents: Point2d.create(0.7625306571302384, 0.2189899393616121),
+    drawingId: profileDrawing.id,
+    drawingType: SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation,
+    sheetToProfileTransform: Transform.fromJSON(profileTransformProps),
+  };
+
+  it("survives toJSON and fromJSON", () => {
+    const restored = DrawingMetadata.fromJSON(DrawingMetadata.toJSON(metadata)!);
+
+    assert.strictEqual(restored.drawingType, SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation);
+    assert.isTrue(restored.sheetToProfileTransform!.isAlmostEqual(metadata.sheetToProfileTransform!));
+  });
+
+  it("survives measurement clone", () => {
+    const measurement = DistanceMeasurement.create(Point3d.create(0, 0, 0), Point3d.create(1, 1, 1), WellKnownViewType.Sheet);
+    measurement.drawingMetadata = metadata;
+
+    const cloned = measurement.clone();
+
+    assert.strictEqual(cloned.drawingMetadata?.drawingType, SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation);
+    assert.isTrue(cloned.drawingMetadata!.sheetToProfileTransform!.isAlmostEqual(metadata.sheetToProfileTransform!));
+  });
+});

--- a/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
+++ b/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
@@ -13,12 +13,13 @@ import { SheetMeasurementHelper } from "../../api/SheetMeasurementHelper.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
 import { DistanceMeasurement } from "../../measurements/DistanceMeasurement.js";
 
-// Taken from a plan-and-profile sheet where the plan view attachment fully encloses the profile view attachment.
+// From a real plan-and-profile sheet. The plan's placement bounding box starts well above its origin, so ignoring
+// bBoxLow stretched its rectangle down over the profile band.
 const planDrawing: SheetMeasurementHelper.DrawingTypeData = {
   id: "0x20000000161",
   type: SheetMeasurementHelper.DrawingTypeEnum.Plan,
   origin: { x: -0.010901885858856986, y: 0.0733496210801317 },
-  bBoxLow: { x: 0, y: 0 },
+  bBoxLow: { x: 0, y: 0.3 },
   bBoxHigh: { x: 0.8713426995780083, y: 0.683576266158866 },
 };
 
@@ -36,10 +37,6 @@ const profileTransformProps = [[600, 0, 0, 0], [0, 120, 0, 0], [0, 0, 1, 0]];
 const pointInsideBothDrawings = Point3d.create(0.7278001436368169, 0.22686231342959792);
 const sheetViewId = "0x1";
 const imodel = { isBlank: false } as unknown as IModelConnection;
-const profileToolDrawingTypes = [
-  SheetMeasurementHelper.DrawingTypeEnum.Section,
-  SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation,
-];
 
 function stubDrawingCache(drawings: SheetMeasurementHelper.DrawingTypeData[], profileDrawingHasTransform = true) {
   vi.spyOn(DrawingDataCache, "getInstance").mockReturnValue({
@@ -59,37 +56,51 @@ describe("SheetMeasurementHelper.getDrawingMetadata", () => {
     vi.restoreAllMocks();
   });
 
-  it("skips an overlapping drawing whose type is not allowed", async () => {
-    // The plan attachment encloses the profile and defines no sheetToProfileTransform, so selecting it left profile
-    // measurements in sheet units.
+  it("resolves the drawing whose rectangle contains the point", async () => {
+    // Resolving the plan here left profile measurements in sheet units.
     stubDrawingCache([planDrawing, profileDrawing]);
 
-    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
 
     assert.strictEqual(metadata?.drawingId, profileDrawing.id);
     assert.strictEqual(metadata?.drawingType, SheetMeasurementHelper.DrawingTypeEnum.ProfileOrElevation);
   });
 
-  it("returns the first containing drawing when no types are given", async () => {
-    stubDrawingCache([planDrawing, profileDrawing]);
+  it("resolves drawings that have no drawing type", async () => {
+    stubDrawingCache([planDrawing, { ...profileDrawing, type: undefined }]);
 
     const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
 
-    assert.strictEqual(metadata?.drawingId, planDrawing.id);
+    assert.strictEqual(metadata?.drawingId, profileDrawing.id);
+    assert.isUndefined(metadata?.drawingType);
   });
 
-  it("returns undefined when no drawing of an allowed type contains the point", async () => {
-    stubDrawingCache([planDrawing]);
+  it("returns undefined when no drawing contains the point", async () => {
+    stubDrawingCache([planDrawing, profileDrawing]);
 
-    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, Point3d.create(5, 5));
 
     assert.isUndefined(metadata);
+  });
+
+  it("offsets the drawing rectangle by bBoxLow", async () => {
+    // bBoxLow is relative to the placement origin; assuming it is zero displaces the whole rectangle.
+    const shifted = { ...profileDrawing, bBoxLow: { x: 0.5, y: 0.1 }, bBoxHigh: { x: 1.5, y: 0.4 } };
+    stubDrawingCache([shifted]);
+
+    const inside = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, Point3d.create(1.0, 0.3));
+    const belowLow = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, Point3d.create(0.3, 0.3));
+
+    assert.strictEqual(inside?.drawingId, shifted.id);
+    assert.isUndefined(belowLow);
+    assert.closeTo(inside!.origin.x, shifted.origin.x + 0.5, 1e-9);
+    assert.closeTo(inside!.extents!.x, 1.0, 1e-9);
   });
 
   it("carries the profile transform of the resolved drawing", async () => {
     stubDrawingCache([planDrawing, profileDrawing]);
 
-    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
 
     // One inch of sheet at the 1:120 vertical scale is 3.048 m (10 ft), not the raw 0.0254 m of sheet space.
     const transform = metadata?.sheetToProfileTransform;
@@ -103,7 +114,7 @@ describe("SheetMeasurementHelper.getDrawingMetadata", () => {
     // Transform.fromJSON yields identity for missing props, which would silently report sheet units as world units.
     stubDrawingCache([planDrawing, profileDrawing], false);
 
-    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, profileToolDrawingTypes);
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
 
     assert.strictEqual(metadata?.drawingId, profileDrawing.id);
     assert.isUndefined(metadata?.sheetToProfileTransform);

--- a/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
+++ b/packages/measure-tools/src/test/measure-tools/SheetMeasurementHelper.test.ts
@@ -3,7 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import type { IModelConnection } from "@itwin/core-frontend";
+import type { HitDetail, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import { IModelApp } from "@itwin/core-frontend";
 import { Point2d, Point3d, Transform } from "@itwin/core-geometry";
 import { assert } from "chai";
 import { afterEach, describe, it, vi } from "vitest";
@@ -13,8 +14,7 @@ import { SheetMeasurementHelper } from "../../api/SheetMeasurementHelper.js";
 import { WellKnownViewType } from "../../api/MeasurementEnums.js";
 import { DistanceMeasurement } from "../../measurements/DistanceMeasurement.js";
 
-// From a real plan-and-profile sheet. The plan's placement bounding box starts well above its origin, so ignoring
-// bBoxLow stretched its rectangle down over the profile band.
+// Plan-and-profile sheet: the plan occupies the upper band, the profile the lower one.
 const planDrawing: SheetMeasurementHelper.DrawingTypeData = {
   id: "0x20000000161",
   type: SheetMeasurementHelper.DrawingTypeEnum.Plan,
@@ -38,6 +38,11 @@ const pointInsideBothDrawings = Point3d.create(0.7278001436368169, 0.22686231342
 const sheetViewId = "0x1";
 const imodel = { isBlank: false } as unknown as IModelConnection;
 
+function stubPickedDrawingId(modelId?: string) {
+  const hit = modelId === undefined ? undefined : ({ modelId } as unknown as HitDetail);
+  vi.spyOn(IModelApp.locateManager, "doLocate").mockResolvedValue(hit);
+}
+
 function stubDrawingCache(drawings: SheetMeasurementHelper.DrawingTypeData[], profileDrawingHasTransform = true) {
   vi.spyOn(DrawingDataCache, "getInstance").mockReturnValue({
     querySheetDrawingData: async () => drawings,
@@ -57,7 +62,6 @@ describe("SheetMeasurementHelper.getDrawingMetadata", () => {
   });
 
   it("resolves the drawing whose rectangle contains the point", async () => {
-    // Resolving the plan here left profile measurements in sheet units.
     stubDrawingCache([planDrawing, profileDrawing]);
 
     const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings);
@@ -81,6 +85,40 @@ describe("SheetMeasurementHelper.getDrawingMetadata", () => {
     const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, Point3d.create(5, 5));
 
     assert.isUndefined(metadata);
+  });
+
+  it("prefers the drawing owning the picked element over the containing rectangle", async () => {
+    // Attachment rectangles can overlap heavily, so the geometry actually under the cursor decides.
+    stubDrawingCache([planDrawing, profileDrawing]);
+    stubPickedDrawingId(profileDrawing.id);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, Point3d.create(0.5, 0.5), {
+      viewport: {} as ScreenViewport,
+    });
+
+    assert.strictEqual(metadata?.drawingId, profileDrawing.id);
+  });
+
+  it("falls back to the containing rectangle when nothing is picked", async () => {
+    stubDrawingCache([profileDrawing]);
+    stubPickedDrawingId(undefined);
+
+    const metadata = await SheetMeasurementHelper.getDrawingMetadata(imodel, sheetViewId, pointInsideBothDrawings, {
+      viewport: {} as ScreenViewport,
+    });
+
+    assert.strictEqual(metadata?.drawingId, profileDrawing.id);
+  });
+
+  it("reports every drawing containing the point", async () => {
+    const overlappingPlan = { ...planDrawing, bBoxLow: { x: 0, y: 0 } };
+    stubDrawingCache([overlappingPlan, profileDrawing]);
+
+    const atPoint = await SheetMeasurementHelper.getDrawingsAtPoint(imodel, sheetViewId, pointInsideBothDrawings);
+    const outside = await SheetMeasurementHelper.getDrawingsAtPoint(imodel, sheetViewId, Point3d.create(5, 5));
+
+    assert.deepStrictEqual(atPoint.map((d) => d.id), [overlappingPlan.id, profileDrawing.id]);
+    assert.isEmpty(outside);
   });
 
   it("offsets the drawing rectangle by bBoxLow", async () => {

--- a/packages/measure-tools/src/tools/MeasureAreaTool.ts
+++ b/packages/measure-tools/src/tools/MeasureAreaTool.ts
@@ -137,7 +137,7 @@ MeasureAreaToolModel
     if (this._enableSheetMeasurements) {
       if (this.toolModel.drawingMetadata?.drawingId === undefined && ev.viewport.view.id !== undefined && isFirstPoint) {
         this.toolModel.sheetViewId = ev.viewport.view.id;
-        this.toolModel.drawingMetadata = await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point);
+        this.toolModel.drawingMetadata = await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point, { viewport: ev.viewport, inputSource: ev.inputSource });
       }
     }
   }

--- a/packages/measure-tools/src/tools/MeasureDistanceTool.ts
+++ b/packages/measure-tools/src/tools/MeasureDistanceTool.ts
@@ -127,7 +127,7 @@ MeasureDistanceToolModel
     if (this._enableSheetMeasurements) {
       if (this.toolModel.drawingMetadata?.drawingId === undefined && ev.viewport.view.id !== undefined) {
         this.toolModel.sheetViewId = ev.viewport.view.id;
-        this.toolModel.drawingMetadata = await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point);
+        this.toolModel.drawingMetadata = await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point, { viewport: ev.viewport, inputSource: ev.inputSource });
       }
     }
   }

--- a/packages/measure-tools/src/tools/MeasureLocationTool.ts
+++ b/packages/measure-tools/src/tools/MeasureLocationTool.ts
@@ -108,7 +108,7 @@ MeasureLocationToolModel
     if (this._enableSheetMeasurements) {
       if (ev.viewport.view.id !== undefined) {
         this.toolModel.sheetViewId = ev.viewport.view.id;
-        return await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point);
+        return await SheetMeasurementHelper.getDrawingMetadata(this.iModel, ev.viewport.view.id, ev.point, { viewport: ev.viewport, inputSource: ev.inputSource });
       }
     }
     return undefined;


### PR DESCRIPTION
On some profile drawings, measurements were incorrect. For example, a 10ft measurement would come out as 0.08ft.
This would happen in sheets with more than 1 drawing as, when trying to get the transform, the algorithm would output the first encountered drawing. If that drawing was not a profile drawing (and therefore did not contain the profileToWorld transform) we'd be stuck in sheet coordinates with an undefined transform.

Also, now, we give priority to element detection when starting a measurement in a drawing. This means that, when there is a element, we check the associated drawing instead of doing it by using the drawing box.

