### PR TITLE
[Tree widget]: preload tree caches on `next`

### DIFF
--- a/.changeset/@itwin-tree-widget-react-jolly-memes-give.md
+++ b/.changeset/@itwin-tree-widget-react-jolly-memes-give.md
@@ -1,0 +1,5 @@
+---
+"@itwin/tree-widget-react": patch
+---
+
+Preload tree caches on root node expansion.

--- a/packages/tree-widget/src/tree-widget-react/shared/internal/caches/BaseIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/shared/internal/caches/BaseIdsCache.ts
@@ -104,10 +104,15 @@ export class BaseIdsCache {
 
   // Implement methods using each cache
 
-  public async preloadCachedData(): Promise<void> {
+  public async preloadModeledElements(): Promise<void> {
     try {
-      // Loading modeled elements also preloads element-model-category data.
       await toVoidPromise(this.getModeledElementsInfo());
+    } catch {}
+  }
+
+  public async preloadElementModelCategories(): Promise<void> {
+    try {
+      await toVoidPromise(this.#elementModelCategoriesCache.getCachedData());
     } catch {}
   }
 
@@ -452,8 +457,12 @@ export class BaseIdsCacheImpl {
 
   // Implement IBaseIdsCache by re-exporting BaseIdsCache methods
 
-  public async preloadCachedData(): ReturnType<BaseIdsCache["preloadCachedData"]> {
-    return this.#baseIdsCache.preloadCachedData();
+  public async preloadModeledElements(): ReturnType<BaseIdsCache["preloadModeledElements"]> {
+    return this.#baseIdsCache.preloadModeledElements();
+  }
+
+  public async preloadElementModelCategories(): ReturnType<BaseIdsCache["preloadElementModelCategories"]> {
+    return this.#baseIdsCache.preloadElementModelCategories();
   }
 
   public getChildElements(props: Props<BaseIdsCache["getChildElements"]>): ReturnType<BaseIdsCache["getChildElements"]> {

--- a/packages/tree-widget/src/tree-widget-react/shared/internal/caches/BaseIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/shared/internal/caches/BaseIdsCache.ts
@@ -5,7 +5,7 @@
 
 import { EMPTY, filter, forkJoin, from, identity, map, mergeMap, of, reduce, shareReplay, tap } from "rxjs";
 import { Guid } from "@itwin/core-bentley";
-import { fromWithRelease } from "../Rxjs.js";
+import { fromWithRelease, toVoidPromise } from "../Rxjs.js";
 import { ChildrenTree, getOrCreate } from "../Utils.js";
 import { ChildElementsCache } from "./ChildElementsCache.js";
 import { DescendantsCountCache } from "./DescendantsCountCache.js";
@@ -103,6 +103,13 @@ export class BaseIdsCache {
   }
 
   // Implement methods using each cache
+
+  public async preloadCachedData(): Promise<void> {
+    try {
+      // Loading modeled elements also preloads element-model-category data.
+      await toVoidPromise(this.getModeledElementsInfo());
+    } catch {}
+  }
 
   // ModeledElementsCache methods
   public getCategoryModeledElements({
@@ -444,6 +451,10 @@ export class BaseIdsCacheImpl {
   }
 
   // Implement IBaseIdsCache by re-exporting BaseIdsCache methods
+
+  public async preloadCachedData(): ReturnType<BaseIdsCache["preloadCachedData"]> {
+    return this.#baseIdsCache.preloadCachedData();
+  }
 
   public getChildElements(props: Props<BaseIdsCache["getChildElements"]>): ReturnType<BaseIdsCache["getChildElements"]> {
     return this.#baseIdsCache.getChildElements(props);

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -337,8 +337,9 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   {
                     parentInstancesNodePredicate: this.#categoryClass,
                     definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-                      if (requestProps.parentNodeInstanceIds.length > 0) {
-                        void this.#idsCache.preloadCachedData();
+                      void this.#idsCache.preloadDefinitionContainers();
+                      if (this.#hierarchyConfig.elements.nodes === "include") {
+                        void this.#idsCache.preloadModeledElements();
                       }
                       return this.createCategoryChildrenQuery(requestProps);
                     },
@@ -349,8 +350,9 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   {
                     parentInstancesNodePredicate: CLASS_NAME_DefinitionContainer,
                     definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-                      if (requestProps.parentNodeInstanceIds.length > 0) {
-                        void this.#idsCache.preloadCachedData();
+                      void this.#idsCache.preloadDefinitionContainers();
+                      if (this.#hierarchyConfig.elements.nodes === "include") {
+                        void this.#idsCache.preloadModeledElements();
                       }
                       return this.createDefinitionContainersAndCategoriesQuery(requestProps);
                     },

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -336,15 +336,24 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
               : [
                   {
                     parentInstancesNodePredicate: this.#categoryClass,
-                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createCategoryChildrenQuery(requestProps),
+                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+                      if (requestProps.parentNodeInstanceIds.length > 0) {
+                        void this.#idsCache.preloadCachedData();
+                      }
+                      return this.createCategoryChildrenQuery(requestProps);
+                    },
                   },
                 ]),
             ...(isDefinitionContainerSupported
               ? [
                   {
                     parentInstancesNodePredicate: CLASS_NAME_DefinitionContainer,
-                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) =>
-                      this.createDefinitionContainersAndCategoriesQuery(requestProps),
+                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+                      if (requestProps.parentNodeInstanceIds.length > 0) {
+                        void this.#idsCache.preloadCachedData();
+                      }
+                      return this.createDefinitionContainersAndCategoriesQuery(requestProps);
+                    },
                   },
                 ]
               : []),

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -86,6 +86,7 @@ interface CategoriesTreeDefinitionProps {
   viewType: "2d" | "3d";
   idsCache: CategoriesTreeIdsCache;
   hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
+  onHierarchyLevelRequested?: (parentNode?: DefineInstanceNodeChildHierarchyLevelProps["parentNode"]) => void;
 }
 
 interface CategoriesTreeInstanceKeyPathsBaseProps {
@@ -191,6 +192,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
   #categoryElementClass: EC.FullClassNameDotNotation;
   #categoryModelClass: EC.FullClassNameDotNotation;
   static #componentName = "CategoriesTreeDefinition";
+  #onHierarchyLevelRequested?: (parentNode?: DefineInstanceNodeChildHierarchyLevelProps["parentNode"]) => void;
 
   public constructor(props: CategoriesTreeDefinitionProps) {
     this.#iModelAccess = props.imodelAccess;
@@ -201,6 +203,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     this.#categoryElementClass = elementClass;
     this.#categoryModelClass = modelClass;
     this.#excludedClasses = this.#hierarchyConfig.elements.nodes === "include" ? this.#hierarchyConfig.elements.excludedClasses : undefined;
+    this.#onHierarchyLevelRequested = props.onHierarchyLevelRequested;
   }
 
   public preProcessNode: NodePreProcessor = async ({ node }) => {
@@ -312,21 +315,33 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
       return createPredicateBasedHierarchyDefinition({
         classHierarchyInspector: this.#iModelAccess,
         hierarchy: {
-          rootNodes: async (requestProps: DefineRootHierarchyLevelProps) => this.createDefinitionContainersAndCategoriesQuery(requestProps),
+          rootNodes: async (requestProps: DefineRootHierarchyLevelProps) => {
+            this.#onHierarchyLevelRequested?.();
+            return this.createDefinitionContainersAndCategoriesQuery(requestProps);
+          },
           childNodes: [
             ...(this.#hierarchyConfig.elements.nodes === "include"
               ? [
                   {
                     parentInstancesNodePredicate: this.#categoryElementClass,
-                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createElementChildrenQuery(requestProps),
+                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+                      this.#onHierarchyLevelRequested?.(requestProps.parentNode);
+                      return this.createElementChildrenQuery(requestProps);
+                    },
                   },
                   {
                     parentInstancesNodePredicate: CLASS_NAME_ISubModeledElement,
-                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createISubModeledElementChildrenQuery(requestProps),
+                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+                      this.#onHierarchyLevelRequested?.(requestProps.parentNode);
+                      return this.createISubModeledElementChildrenQuery(requestProps);
+                    },
                   },
                   {
                     parentInstancesNodePredicate: this.#categoryModelClass,
-                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createGeometricModelChildrenQuery(requestProps),
+                    definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+                      this.#onHierarchyLevelRequested?.(requestProps.parentNode);
+                      return this.createGeometricModelChildrenQuery(requestProps);
+                    },
                   },
                 ]
               : []),
@@ -337,10 +352,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   {
                     parentInstancesNodePredicate: this.#categoryClass,
                     definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-                      void this.#idsCache.preloadDefinitionContainers();
-                      if (this.#hierarchyConfig.elements.nodes === "include") {
-                        void this.#idsCache.preloadModeledElements();
-                      }
+                      this.#onHierarchyLevelRequested?.(requestProps.parentNode);
                       return this.createCategoryChildrenQuery(requestProps);
                     },
                   },
@@ -350,10 +362,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   {
                     parentInstancesNodePredicate: CLASS_NAME_DefinitionContainer,
                     definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-                      void this.#idsCache.preloadDefinitionContainers();
-                      if (this.#hierarchyConfig.elements.nodes === "include") {
-                        void this.#idsCache.preloadModeledElements();
-                      }
+                      this.#onHierarchyLevelRequested?.(requestProps.parentNode);
                       return this.createDefinitionContainersAndCategoriesQuery(requestProps);
                     },
                   },

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/UseCategoriesTree.tsx
@@ -21,6 +21,7 @@ import { createCategoriesSearchResultsTree } from "./internal/visibility/SearchR
 import type { ReactNode } from "react";
 import type { GuidString, Id64Array } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
+import type { DefineHierarchyLevelProps } from "@itwin/presentation-hierarchies";
 import type { EC } from "@itwin/presentation-shared";
 import type { VisibilityTreeProps } from "../../shared/components/VisibilityTree.js";
 import type { ExtendedVisibilityTreeRendererProps } from "../../shared/components/VisibilityTreeRenderer.js";
@@ -108,6 +109,18 @@ export function useCategoriesTree({
     hierarchyConfig: hierarchyConfiguration,
   });
 
+  const onHierarchyLevelRequested = useCallback(
+    (parentNode?: DefineHierarchyLevelProps["parentNode"]) => {
+      if (parentNode && parentNode.parentKeys.length === 0) {
+        void idsCache.preloadDefinitionContainers();
+        if (hierarchyConfiguration.elements.nodes === "include") {
+          void idsCache.preloadElementModelCategories();
+        }
+      }
+    },
+    [idsCache, hierarchyConfiguration],
+  );
+
   const getHierarchyDefinition = useCallback<VisibilityTreeProps["getHierarchyDefinition"]>(
     (props) => {
       return new CategoriesTreeDefinition({
@@ -115,9 +128,10 @@ export function useCategoriesTree({
         viewType,
         idsCache,
         hierarchyConfig: hierarchyConfiguration,
+        onHierarchyLevelRequested,
       });
     },
-    [viewType, idsCache, hierarchyConfiguration],
+    [viewType, idsCache, hierarchyConfiguration, onHierarchyLevelRequested],
   );
 
   const { getPaths, searchError } = useSearchPaths({

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -8,7 +8,7 @@ import { Guid, Id64 } from "@itwin/core-bentley";
 import { BaseIdsCacheImpl } from "../../../shared/internal/caches/BaseIdsCache.js";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_Model, CLASS_NAME_SubCategory } from "../../../shared/internal/ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../../../shared/internal/hooks/UseErrorState.js";
-import { fromWithRelease } from "../../../shared/internal/Rxjs.js";
+import { fromWithRelease, toVoidPromise } from "../../../shared/internal/Rxjs.js";
 import { createWhereClause, getClassesByView, getOrCreate } from "../../../shared/internal/Utils.js";
 
 import type { Observable } from "rxjs";
@@ -74,6 +74,12 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     this.#categoryElementClass = elementClass;
     this.#componentId = Guid.createValue();
     this.#componentName = "CategoriesTreeIdsCache";
+  }
+
+  public override async preloadCachedData(): Promise<void> {
+    try {
+      await Promise.all([super.preloadCachedData(), toVoidPromise(this.getDefinitionContainersInfo())]);
+    } catch {}
   }
 
   private queryFilteredElementsModels(filteredElementIds: Id64Array): Observable<{

--- a/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -76,9 +76,9 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     this.#componentName = "CategoriesTreeIdsCache";
   }
 
-  public override async preloadCachedData(): Promise<void> {
+  public async preloadDefinitionContainers(): Promise<void> {
     try {
-      await Promise.all([super.preloadCachedData(), toVoidPromise(this.getDefinitionContainersInfo())]);
+      await toVoidPromise(this.getDefinitionContainersInfo());
     } catch {}
   }
 

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -132,12 +132,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
         childNodes: [
           {
             parentInstancesNodePredicate: CLASS_NAME_ClassificationTable,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-              if (requestProps.parentNodeInstanceIds.length > 0) {
-                void this.#props.getIdsCache(this.#props.imodelAccess.imodelKey).preloadCachedData();
-              }
-              return this.#createClassificationTableChildrenQuery(requestProps);
-            },
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.#createClassificationTableChildrenQuery(requestProps),
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_Classification,
@@ -243,6 +238,9 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
       return [];
     }
     const cache = this.#props.getIdsCache(imodelKey);
+    if (classificationTableIds.length > 0) {
+      void cache.preloadCachedData();
+    }
     const childClassificationsDefinition = cache.isDataLoaded
       ? await this.#createCachedChildClassificationsQuery({ parentIds: classificationTableIds, cache, instanceFilter, createSelectClause, createFilterClauses })
       : await this.#createUncachedChildClassificationsQuery({

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -71,6 +71,7 @@ interface ClassificationsTreeDefinitionProps {
   imodelAccess: ECSchemaProvider & ECClassHierarchyInspector & LimitingECSqlQueryExecutor & { imodelKey: string };
   getIdsCache: (imodelKey: string) => ClassificationsTreeIdsCache;
   hierarchyConfig: ClassificationsTreeHierarchyConfiguration;
+  onHierarchyLevelRequested?: (parentNode?: DefineHierarchyLevelProps["parentNode"]) => void;
 }
 
 /** @beta */
@@ -128,19 +129,31 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
     this.#impl = createPredicateBasedHierarchyDefinition({
       classHierarchyInspector: props.imodelAccess,
       hierarchy: {
-        rootNodes: async (requestProps: DefineRootHierarchyLevelProps) => this.#createClassificationTablesQuery(requestProps),
+        rootNodes: async (requestProps: DefineRootHierarchyLevelProps) => {
+          props.onHierarchyLevelRequested?.();
+          return this.#createClassificationTablesQuery(requestProps);
+        },
         childNodes: [
           {
             parentInstancesNodePredicate: CLASS_NAME_ClassificationTable,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.#createClassificationTableChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.#createClassificationTableChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_Classification,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.#createClassificationChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.#createClassificationChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_GeometricElement,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.#createGeometricElementChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.#createGeometricElementChildrenQuery(requestProps);
+            },
           },
         ],
       },
@@ -238,9 +251,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
       return [];
     }
     const cache = this.#props.getIdsCache(imodelKey);
-    if (classificationTableIds.length > 0) {
-      void cache.preloadClassifications();
-    }
     const childClassificationsDefinition = cache.isDataLoaded
       ? await this.#createCachedChildClassificationsQuery({ parentIds: classificationTableIds, cache, instanceFilter, createSelectClause, createFilterClauses })
       : await this.#createUncachedChildClassificationsQuery({

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -239,7 +239,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
     }
     const cache = this.#props.getIdsCache(imodelKey);
     if (classificationTableIds.length > 0) {
-      void cache.preloadCachedData();
+      void cache.preloadClassifications();
     }
     const childClassificationsDefinition = cache.isDataLoaded
       ? await this.#createCachedChildClassificationsQuery({ parentIds: classificationTableIds, cache, instanceFilter, createSelectClause, createFilterClauses })

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -132,7 +132,12 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
         childNodes: [
           {
             parentInstancesNodePredicate: CLASS_NAME_ClassificationTable,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.#createClassificationTableChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              if (requestProps.parentNodeInstanceIds.length > 0) {
+                void this.#props.getIdsCache(this.#props.imodelAccess.imodelKey).preloadCachedData();
+              }
+              return this.#createClassificationTableChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_Classification,

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/UseClassificationsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/UseClassificationsTreeDefinition.ts
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+import { assert } from "@itwin/core-bentley";
 import { HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import { useSharedTreeContext } from "../../shared/contexts/SharedTreeContext.js";
 import { useTelemetryContext } from "../../shared/contexts/TelemetryContext.js";
@@ -12,7 +13,7 @@ import { ClassificationsTreeDefinition } from "./ClassificationsTreeDefinition.j
 import { getClassificationsTreeIdsCache } from "./UseClassificationsTree.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps, HierarchyDefinition } from "@itwin/presentation-hierarchies";
 import type { useTree } from "@itwin/presentation-hierarchies-react";
 import type { InstanceKey } from "@itwin/presentation-shared";
 import type { FunctionProps } from "../../shared/Utils.js";
@@ -98,13 +99,26 @@ export function useClassificationsTreeDefinitionInternal(
     });
   }, [imodels, getBaseIdsCache, getCache, hierarchyConfig, visibilityHandlerConfig]);
 
+  const onHierarchyLevelRequested = useCallback(
+    (parentNode?: DefineHierarchyLevelProps["parentNode"]) => {
+      if (parentNode && parentNode.parentKeys.length === 0) {
+        assert(parentNode.key.type === "instances");
+        const imodelKey = parentNode.key.instanceKeys[0].imodelKey;
+        const cache = imodelsWithCaches.find(({ imodelAccess }) => imodelAccess.imodelKey === imodelKey)?.cache;
+        void cache?.preloadClassifications();
+      }
+    },
+    [imodelsWithCaches],
+  );
+
   const definition = useMemo(() => {
     return new ClassificationsTreeDefinition({
       imodelAccess: imodelsWithCaches[imodelsWithCaches.length - 1].imodelAccess,
       getIdsCache: (imodelKey: string) => imodelsWithCaches.find(({ imodelAccess }) => imodelAccess.imodelKey === imodelKey)!.cache,
       hierarchyConfig,
+      onHierarchyLevelRequested,
     });
-  }, [hierarchyConfig, imodelsWithCaches]);
+  }, [hierarchyConfig, imodelsWithCaches, onHierarchyLevelRequested]);
 
   const searchTerm = search ? ("searchText" in search ? search.searchText : search.targetItems) : undefined;
   const searchLimit = search?.limit;

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -76,7 +76,7 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
     this.#componentName = "ClassificationsTreeIdsCache";
   }
 
-  public override async preloadCachedData(): Promise<void> {
+  public async preloadClassifications(): Promise<void> {
     try {
       await toVoidPromise(this.getCachedData());
     } catch {}

--- a/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -15,7 +15,7 @@ import {
   CLASS_NAME_SpatialCategory,
 } from "../../../shared/internal/ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../../../shared/internal/hooks/UseErrorState.js";
-import { fromWithRelease } from "../../../shared/internal/Rxjs.js";
+import { fromWithRelease, toVoidPromise } from "../../../shared/internal/Rxjs.js";
 import { createWhereClause, getOrCreate } from "../../../shared/internal/Utils.js";
 
 import type { Observable } from "rxjs";
@@ -74,6 +74,12 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
     this.#props = props;
     this.#componentId = Guid.createValue();
     this.#componentName = "ClassificationsTreeIdsCache";
+  }
+
+  public override async preloadCachedData(): Promise<void> {
+    try {
+      await toVoidPromise(this.getCachedData());
+    } catch {}
   }
 
   private queryClassifications(): Observable<

--- a/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
@@ -161,6 +161,7 @@ interface ModelsTreeDefinitionProps {
   idsCache: ModelsTreeIdsCache;
   hierarchyConfig: RequiredModelsTreeHierarchyConfiguration;
   componentId?: GuidString;
+  onHierarchyLevelRequested?: (parentNode?: DefineHierarchyLevelProps["parentNode"]) => void;
 }
 
 /** @beta */
@@ -220,39 +221,48 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     this.#impl = createPredicateBasedHierarchyDefinition({
       classHierarchyInspector: props.imodelAccess,
       hierarchy: {
-        rootNodes: async (requestProps) =>
-          this.createSubjectChildrenQuery({
+        rootNodes: async (requestProps) => {
+          props.onHierarchyLevelRequested?.();
+          return this.createSubjectChildrenQuery({
             ...requestProps,
             parentNodeInstanceIds: this.#hierarchyConfig.subjects.root === "exclude" ? [IModel.rootSubjectId] : [],
-          }),
+          });
+        },
         childNodes: [
           {
             parentInstancesNodePredicate: CLASS_NAME_Subject,
             definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-              void this.#idsCache.preloadElementModelCategories();
-              void this.#idsCache.preloadModeledElements();
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
               return this.createSubjectChildrenQuery(requestProps);
             },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_ISubModeledElement,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createISubModeledElementChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.createISubModeledElementChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_GeometricModel3d,
             definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-              void this.#idsCache.preloadElementModelCategories();
-              void this.#idsCache.preloadModeledElements();
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
               return this.createGeometricModel3dChildrenQuery(requestProps);
             },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_SpatialCategory,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createSpatialCategoryChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.createSpatialCategoryChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_GeometricElement3d,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createGeometricElement3dChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              props.onHierarchyLevelRequested?.(requestProps.parentNode);
+              return this.createGeometricElement3dChildrenQuery(requestProps);
+            },
           },
         ],
       },

--- a/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
@@ -229,9 +229,8 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           {
             parentInstancesNodePredicate: CLASS_NAME_Subject,
             definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-              if (requestProps.parentNodeInstanceIds.length > 0) {
-                void this.#idsCache.preloadCachedData();
-              }
+              void this.#idsCache.preloadElementModelCategories();
+              void this.#idsCache.preloadModeledElements();
               return this.createSubjectChildrenQuery(requestProps);
             },
           },
@@ -242,9 +241,8 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           {
             parentInstancesNodePredicate: CLASS_NAME_GeometricModel3d,
             definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
-              if (requestProps.parentNodeInstanceIds.length > 0) {
-                void this.#idsCache.preloadCachedData();
-              }
+              void this.#idsCache.preloadElementModelCategories();
+              void this.#idsCache.preloadModeledElements();
               return this.createGeometricModel3dChildrenQuery(requestProps);
             },
           },

--- a/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/tree-widget/src/tree-widget-react/trees/models-tree/ModelsTreeDefinition.ts
@@ -228,7 +228,12 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         childNodes: [
           {
             parentInstancesNodePredicate: CLASS_NAME_Subject,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createSubjectChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              if (requestProps.parentNodeInstanceIds.length > 0) {
+                void this.#idsCache.preloadCachedData();
+              }
+              return this.createSubjectChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_ISubModeledElement,
@@ -236,7 +241,12 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_GeometricModel3d,
-            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => this.createGeometricModel3dChildrenQuery(requestProps),
+            definitions: async (requestProps: DefineInstanceNodeChildHierarchyLevelProps) => {
+              if (requestProps.parentNodeInstanceIds.length > 0) {
+                void this.#idsCache.preloadCachedData();
+              }
+              return this.createGeometricModel3dChildrenQuery(requestProps);
+            },
           },
           {
             parentInstancesNodePredicate: CLASS_NAME_SpatialCategory,

--- a/packages/tree-widget/src/tree-widget-react/trees/models-tree/UseModelsTree.tsx
+++ b/packages/tree-widget/src/tree-widget-react/trees/models-tree/UseModelsTree.tsx
@@ -30,7 +30,7 @@ import { ModelsTreeNode } from "./ModelsTreeNode.js";
 import type { ReactNode } from "react";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import type { DefineHierarchyLevelProps, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { TreeNode } from "@itwin/presentation-hierarchies-react";
 import type { InstanceKey } from "@itwin/presentation-shared";
 import type { VisibilityTreeProps } from "../../shared/components/VisibilityTree.js";
@@ -174,9 +174,19 @@ export function useModelsTree({
     componentId,
   });
 
+  const onHierarchyLevelRequested = useCallback(
+    (parentNode?: DefineHierarchyLevelProps["parentNode"]) => {
+      if (parentNode && parentNode.parentKeys.length === 0) {
+        void idsCache.preloadElementModelCategories();
+        void idsCache.preloadModeledElements();
+      }
+    },
+    [idsCache],
+  );
+
   const getHierarchyDefinition = useCallback<VisibilityTreeProps["getHierarchyDefinition"]>(
-    ({ imodelAccess }) => new ModelsTreeDefinition({ imodelAccess, idsCache, hierarchyConfig: hierarchyConfiguration, componentId }),
-    [idsCache, hierarchyConfiguration, componentId],
+    ({ imodelAccess }) => new ModelsTreeDefinition({ imodelAccess, idsCache, hierarchyConfig: hierarchyConfiguration, componentId, onHierarchyLevelRequested }),
+    [idsCache, hierarchyConfiguration, componentId, onHierarchyLevelRequested],
   );
 
   const { getPaths, searchError, subTreeError } = useSearchPaths({


### PR DESCRIPTION
Closes #1793 
Based on https://github.com/iTwin/viewer-components-react/pull/1801#discussion_r3957155834